### PR TITLE
uid predicates cannot have list nor @index

### DIFF
--- a/client/src/components/SchemaPredicateForm.js
+++ b/client/src/components/SchemaPredicateForm.js
@@ -350,7 +350,7 @@ export default class SchemaPredicateForm extends React.Component {
             </div>
         );
 
-        if (predicate.type !== "password") {
+        if (predicate.type !== "password" && predicate.type !== "uid") {
             listInput = (
                 <div className="checkbox">
                     <label>


### PR DESCRIPTION
@mrjn please confirm that this change makes sense:

I've noticed that server complains when I `/alter` with `somepredicate: [uid] .` or `somep: [uid] @index(uid) .`
This PR disallows this combination of settings in Ratel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/32)
<!-- Reviewable:end -->
