### PR TITLE
Fix typo on FrameHeader

### DIFF
--- a/client/src/components/FrameLayout/FrameHeader.js
+++ b/client/src/components/FrameLayout/FrameHeader.js
@@ -57,7 +57,7 @@ export default function FrameHeader({
 
         const title = `Server Latency: ${timeToText(serverNs)} (${(
             ratio * 100
-        ).toFixed(0)}%)\nNetwok Latency: ${timeToText(networkNs)} (${(
+        ).toFixed(0)}%)\nNetwork Latency: ${timeToText(networkNs)} (${(
             (1 - ratio) *
             100
         ).toFixed(0)}%)\nTotal Latency: ${timeToText(serverNs + networkNs)}`;


### PR DESCRIPTION
Simple typo fix for "Network Latency" I noticed while using Ratel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/66)
<!-- Reviewable:end -->
