### PR TITLE
NodeProperties: Convert facet value to string

### DIFF
--- a/client/src/components/NodeProperties.js
+++ b/client/src/components/NodeProperties.js
@@ -67,7 +67,7 @@ export default function NodeProperties({ node, onExpandNode }) {
                         {Object.keys(facets).map(k => (
                             <tr key={k}>
                                 <td>{k}</td>
-                                <td>{facets[k]}</td>
+                                <td>{String(facets[k])}</td>
                             </tr>
                         ))}
                     </tbody>


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/ratel/issues/68

With this PR
 - Boolean values for facets would be shown in the NodeProperties div. See following screenshot
![dgraph ratel dashboard](https://user-images.githubusercontent.com/12949454/53072285-bbe80180-350a-11e9-8d47-7d4d4fb14371.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/69)
<!-- Reviewable:end -->
