### PR TITLE
Fix fullscreen toggle button

### DIFF
--- a/client/src/components/FrameLayout.js
+++ b/client/src/components/FrameLayout.js
@@ -29,6 +29,9 @@ export default class FrameLayout extends React.Component {
             screenfull.raw.fullscreenchange,
             this.syncFullscreenExit,
         );
+        screenfull.onchange(() => {
+            this.setState({ isFullscreen: screenfull.isFullscreen });
+        });
     }
 
     componentWillUnmount() {
@@ -60,15 +63,9 @@ export default class FrameLayout extends React.Component {
 
         if (isFullscreen) {
             screenfull.exit();
-            this.setState({ isFullscreen: false });
         } else {
             const frameEl = ReactDOM.findDOMNode(this._frameRef.current);
             screenfull.request(frameEl);
-
-            // If fullscreen request was successful, set state.
-            if (screenfull.isFullscreen) {
-                this.setState({ isFullscreen: true });
-            }
         }
     };
 

--- a/client/src/components/FrameLayout.js
+++ b/client/src/components/FrameLayout.js
@@ -29,9 +29,6 @@ export default class FrameLayout extends React.Component {
             screenfull.raw.fullscreenchange,
             this.syncFullscreenExit,
         );
-        screenfull.onchange(() => {
-            this.setState({ isFullscreen: screenfull.isFullscreen });
-        });
     }
 
     componentWillUnmount() {
@@ -63,9 +60,11 @@ export default class FrameLayout extends React.Component {
 
         if (isFullscreen) {
             screenfull.exit();
+            this.setState({ isFullscreen: false });
         } else {
             const frameEl = ReactDOM.findDOMNode(this._frameRef.current);
             screenfull.request(frameEl);
+            this.setState({ isFullscreen: true });
         }
     };
 


### PR DESCRIPTION
This commit fixes the fullscreen toggle button bug (https://github.com/dgraph-io/ratel/issues/40)

NOTE - The `bin` icon vanishes when the frame goes into full screen mode and I guess that is the expected behaviour.  It happens because of

https://github.com/dgraph-io/ratel/blob/92e7c2d8ed00366192e19ce30d12fd5120251110/client/src/components/FrameLayout/FrameHeader.js#L119-L127
Signed-off-by: Ibrahim Jarif <jarifibrahim@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/74)
<!-- Reviewable:end -->

Fixes https://github.com/dgraph-io/ratel/issues/40