### PR TITLE
Pass flag to squash consecutive queries in FrameList

### DIFF
--- a/client/src/reducers/frames.js
+++ b/client/src/reducers/frames.js
@@ -24,10 +24,12 @@ export default (state = defaultState, action) =>
     produce(state, draft => {
         switch (action.type) {
             case RECEIVE_FRAME:
-                draft.items = draft.items.filter(
-                    item => item.query !== action.frame.query,
-                );
-                draft.items.unshift(action.frame);
+                const previousQuery = draft.items[0] && draft.items[0].query;
+                if (previousQuery === action.frame.query) {
+                    draft.items[0] = action.frame;
+                } else {
+                    draft.items.unshift(action.frame);
+                }
                 break;
 
             case DISCARD_FRAME:

--- a/client/src/reducers/frames.js
+++ b/client/src/reducers/frames.js
@@ -24,6 +24,9 @@ export default (state = defaultState, action) =>
     produce(state, draft => {
         switch (action.type) {
             case RECEIVE_FRAME:
+                draft.items = draft.items.filter(
+                    item => item.query !== action.frame.query,
+                );
                 draft.items.unshift(action.frame);
                 break;
 
@@ -35,7 +38,7 @@ export default (state = defaultState, action) =>
 
             case PATCH_FRAME:
                 Object.assign(
-                    draft.items.find(frame => frame.id === action.id),
+                    draft.items.find(frame => frame.id === action.id) || {},
                     action.frameData,
                 );
                 break;


### PR DESCRIPTION
In FrameList, add a flag that will squash neighboring FrameItems together so only the most recent is shown. It will only squash if the previously ran query is the same.

This should help with #77

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/80)
<!-- Reviewable:end -->
