### PR TITLE
Add ability to delete node from graph view

### DIFF
--- a/client/src/components/FrameItem.js
+++ b/client/src/components/FrameItem.js
@@ -252,6 +252,7 @@ export default class FrameItem extends React.Component {
             frame,
             framesTab,
             collapsed,
+            onDeleteNode,
             onDiscardFrame,
             onSelectQuery,
         } = this.props;
@@ -278,6 +279,7 @@ export default class FrameItem extends React.Component {
                     hoveredNode={hoveredNode}
                     jsonResponse={rawResponse || jsonResponse || debugResponse}
                     onShowMoreNodes={this.handleShowMoreNodes}
+                    onDeleteNode={onDeleteNode}
                     onExpandNode={this.handleExpandNode}
                     onNodeHovered={this.handleNodeHovered}
                     onNodeSelected={this.handleNodeSelected}

--- a/client/src/components/FrameLayout/FrameSession.js
+++ b/client/src/components/FrameLayout/FrameSession.js
@@ -63,6 +63,7 @@ class FrameSession extends React.Component {
             handleSetPanelMinimized,
             highlightPredicate,
             hoveredNode,
+            onDeleteNode,
             onExpandNode,
             onShowMoreNodes,
             onNodeHovered,
@@ -85,6 +86,7 @@ class FrameSession extends React.Component {
                         hoveredNode={hoveredNode}
                         onShowMoreNodes={onShowMoreNodes}
                         nodesDataset={parsedResponse.nodes}
+                        onDeleteNode={onDeleteNode}
                         onExpandNode={onExpandNode}
                         onNodeHovered={onNodeHovered}
                         onNodeSelected={onNodeSelected}

--- a/client/src/components/GraphContainer.js
+++ b/client/src/components/GraphContainer.js
@@ -21,6 +21,7 @@ export default ({
     highlightPredicate,
     hoveredNode,
     nodesDataset,
+    onDeleteNode,
     onExpandNode,
     onSetPanelMinimized,
     onShowMoreNodes,
@@ -71,6 +72,7 @@ export default ({
             {selectedNode ? (
                 <NodeProperties
                     node={hoveredNode || selectedNode}
+                    onDeleteNode={onDeleteNode}
                     onExpandNode={onExpandNode}
                 />
             ) : null}

--- a/client/src/components/NodeProperties.js
+++ b/client/src/components/NodeProperties.js
@@ -12,7 +12,7 @@ import Table from "react-bootstrap/Table";
 
 import "../assets/css/NodeProperties.scss";
 
-export default function NodeProperties({ node, onExpandNode }) {
+export default function NodeProperties({ node, onDeleteNode, onExpandNode }) {
     if (!node) {
         return null;
     }
@@ -28,11 +28,19 @@ export default function NodeProperties({ node, onExpandNode }) {
                 aria-label="Node options"
             >
                 <Button
+                    className="mr-2"
                     variant="info"
                     size="sm"
                     onClick={() => onExpandNode(node.uid)}
                 >
                     Expand
+                </Button>
+                <Button
+                    variant="danger"
+                    size="sm"
+                    onClick={() => onDeleteNode(node)}
+                >
+                    Delete
                 </Button>
             </div>
 

--- a/client/src/components/QueryView/index.js
+++ b/client/src/components/QueryView/index.js
@@ -20,6 +20,7 @@ export default function QueryView({
     handleDiscardFrame,
     handleRunQuery,
     onSelectQuery,
+    onSetQuery,
     handleUpdateAction,
     handleUpdateConnectedState,
     handleUpdateQuery,
@@ -81,6 +82,11 @@ export default function QueryView({
                             framesTab={framesTab}
                             collapsed={false}
                             onDiscardFrame={handleDiscardFrame}
+                            onDeleteNode={({ uid }) => {
+                                // TODO: this is a simple hack for formatting -- could also use beautify or something like that
+                                const query = `{\n\tdelete {\n\t\t<${uid}> * * .\n\t}\n}`;
+                                onSetQuery(query, "mutate");
+                            }}
                             onSelectQuery={onSelectQuery}
                             onUpdateConnectedState={handleUpdateConnectedState}
                             patchFrame={patchFrame}

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -153,6 +153,13 @@ class App extends React.Component {
         this.focusCodemirror();
     };
 
+    handleSetQuery = (query, action) => {
+        const { _handleUpdateQueryAndAction } = this.props;
+
+        _handleUpdateQueryAndAction(query, action);
+        this.focusCodemirror();
+    };
+
     handleClearQuery = () => {
         this.handleUpdateQuery("", this.focusCodemirror);
     };
@@ -194,6 +201,7 @@ class App extends React.Component {
                     handleDiscardFrame={handleDiscardFrame}
                     handleRunQuery={this.handleRunQuery}
                     onSelectQuery={this.handleSelectQuery}
+                    onSetQuery={this.handleSetQuery}
                     handleUpdateAction={this.handleUpdateAction}
                     handleUpdateConnectedState={handleUpdateConnectedState}
                     handleUpdateQuery={this.handleUpdateQuery}


### PR DESCRIPTION
Sets the query in the editor to delete the selected node. User is required to run the query for the node to actually be deleted (a form of confirmation).

Should help with #76

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/82)
<!-- Reviewable:end -->
