### PR TITLE
Selecting history frame wont affect active frame view/results and display active query on refresh

### DIFF
--- a/client/src/actions/frames.js
+++ b/client/src/actions/frames.js
@@ -11,6 +11,7 @@ export const DISCARD_FRAME = "frames/DISCARD_FRAME";
 export const DISCARD_ALL_FRAMES = "frames/DISCARD_ALL_FRAMES";
 export const PATCH_FRAME = "frames/PATCH_FRAME";
 export const UPDATE_FRAMES_TAB = "frames/UPDATE_FRAMES_TAB";
+export const SET_SELECTED_FRAME = "frames/SET_SELECTED_FRAME";
 export const SET_ACTIVE_FRAME = "frames/SET_ACTIVE_FRAME";
 
 export function receiveFrame({ id, ...frameProps }) {
@@ -26,6 +27,13 @@ export function receiveFrame({ id, ...frameProps }) {
 export function discardFrame(frameId) {
     return {
         type: DISCARD_FRAME,
+        frameId,
+    };
+}
+
+export function setSelectedFrame(frameId) {
+    return {
+        type: SET_SELECTED_FRAME,
         frameId,
     };
 }

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -7,7 +7,7 @@
 //     https://github.com/dgraph-io/ratel/blob/master/LICENSE
 
 import { makeFrame } from "../lib/helpers";
-import { receiveFrame, setActiveFrame } from "./frames";
+import { receiveFrame, setActiveFrame, setSelectedFrame } from "./frames";
 
 /**
  * runQuery runs the query and displays the appropriate result in a frame
@@ -21,5 +21,6 @@ export function runQuery(query, action = "query") {
         const frame = makeFrame({ query, action });
         dispatch(receiveFrame(frame));
         dispatch(setActiveFrame(frame.id));
+        dispatch(setSelectedFrame(frame.id));
     };
 }

--- a/client/src/components/FrameItem.js
+++ b/client/src/components/FrameItem.js
@@ -193,6 +193,8 @@ export default class FrameItem extends React.Component {
         const { debugResponse } = this.state;
 
         try {
+            this.patchThisFrame({ executed: false });
+
             const executionStart = Date.now();
             const rawResponse = await this.executeQuery(query, action, true);
             const { data, errors, extensions } = rawResponse;
@@ -248,7 +250,7 @@ export default class FrameItem extends React.Component {
 
     render() {
         const {
-            activeFrameId,
+            isSelected,
             frame,
             framesTab,
             collapsed,
@@ -301,7 +303,7 @@ export default class FrameItem extends React.Component {
 
         return (
             <FrameLayout
-                activeFrameId={activeFrameId}
+                isSelected={isSelected}
                 frame={frame}
                 collapsed={collapsed}
                 onDiscardFrame={onDiscardFrame}

--- a/client/src/components/FrameLayout.js
+++ b/client/src/components/FrameLayout.js
@@ -70,7 +70,7 @@ export default class FrameLayout extends React.Component {
 
     render() {
         const {
-            activeFrameId,
+            isSelected,
             children,
             onDiscardFrame,
             onSelectQuery,
@@ -88,7 +88,7 @@ export default class FrameLayout extends React.Component {
                 ref={this._frameRef}
             >
                 <FrameHeader
-                    activeFrameId={activeFrameId}
+                    isSelected={isSelected}
                     frame={frame}
                     isFullscreen={isFullscreen}
                     collapsed={collapsed}

--- a/client/src/components/FrameLayout/FrameHeader.js
+++ b/client/src/components/FrameLayout/FrameHeader.js
@@ -35,7 +35,7 @@ function timeToText(ns) {
 }
 
 export default function FrameHeader({
-    activeFrameId,
+    isSelected,
     editingQuery,
     frame,
     isFullscreen,
@@ -87,7 +87,7 @@ export default function FrameHeader({
     return (
         <div
             className={classnames("frame-header", {
-                active: frame.id === activeFrameId,
+                active: isSelected,
             })}
         >
             {frame.query ? (

--- a/client/src/components/FrameList.js
+++ b/client/src/components/FrameList.js
@@ -25,7 +25,7 @@ export default class FrameList extends React.Component {
 
     render() {
         const {
-            activeFrameId,
+            selectedFrameId,
             frames,
             onDiscardFrame,
             onSelectQuery,
@@ -56,7 +56,7 @@ export default class FrameList extends React.Component {
                 {finalFrames.map(frame => (
                     <FrameItem
                         key={frame.id}
-                        activeFrameId={activeFrameId}
+                        isSelected={frame.id === selectedFrameId}
                         frame={frame}
                         collapsed={true}
                         onDiscardFrame={onDiscardFrame}

--- a/client/src/components/QueryView/index.js
+++ b/client/src/components/QueryView/index.js
@@ -25,6 +25,7 @@ export default function QueryView({
     handleUpdateConnectedState,
     handleUpdateQuery,
     activeFrameId,
+    selectedFrameId,
     frames,
     framesTab,
     saveCodeMirrorInstance,
@@ -58,7 +59,7 @@ export default function QueryView({
                             />
                         </span>
                         <FrameList
-                            activeFrameId={activeFrameId}
+                            selectedFrameId={selectedFrameId}
                             frames={frames}
                             framesTab={framesTab}
                             onDiscardFrame={handleDiscardFrame}
@@ -73,7 +74,6 @@ export default function QueryView({
                 second={
                     frames.length ? (
                         <FrameItem
-                            activeFrameId={activeFrameId}
                             key={activeFrameId}
                             frame={
                                 frames.find(f => f.id === activeFrameId) ||

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -23,7 +23,7 @@ import {
     updateConnectedState,
     updateShouldPrompt,
 } from "../actions/connection";
-import { discardFrame, patchFrame, setActiveFrame } from "../actions/frames";
+import { discardFrame, patchFrame, setSelectedFrame } from "../actions/frames";
 import {
     updateQuery,
     updateAction,
@@ -46,15 +46,24 @@ class App extends React.Component {
 
     async componentDidMount() {
         const {
-            activeFrameId,
             frames,
+            activeFrameId,
             handleRefreshConnectedState,
         } = this.props;
+
         handleRefreshConnectedState(this.openChangeUrlModal);
-        if (!activeFrameId && frames.length) {
-            const { id, query, action } = frames[0];
-            this.handleSelectQuery(id, query, action);
+
+        let id = null;
+        let query = "";
+        let action = "query";
+        if (activeFrameId && frames.length) {
+            const activeFrame =
+                frames.find(frame => frame.id === activeFrameId) || {};
+            id = activeFrame.id || null;
+            query = activeFrame.query || query;
+            action = activeFrame.action || action;
         }
+        this.handleSelectQuery(id, query, action);
     }
 
     handleUpdateConnectionAndRefresh = (url, queryTimeout) => {
@@ -145,11 +154,11 @@ class App extends React.Component {
     handleSelectQuery = (frameId, query, action) => {
         const {
             _handleUpdateQueryAndAction,
-            handleSetActiveFrame,
+            handleSetSelectedFrame,
         } = this.props;
 
         _handleUpdateQueryAndAction(query, action);
-        handleSetActiveFrame(frameId);
+        handleSetSelectedFrame(frameId);
         this.focusCodemirror();
     };
 
@@ -183,6 +192,7 @@ class App extends React.Component {
         const { mainFrameUrl, overlayUrl } = this.state;
         const {
             activeFrameId,
+            selectedFrameId,
             connection,
             frames,
             framesTab,
@@ -206,6 +216,7 @@ class App extends React.Component {
                     handleUpdateConnectedState={handleUpdateConnectedState}
                     handleUpdateQuery={this.handleUpdateQuery}
                     activeFrameId={activeFrameId}
+                    selectedFrameId={selectedFrameId}
                     frames={frames}
                     framesTab={framesTab}
                     patchFrame={patchFrame}
@@ -268,6 +279,7 @@ class App extends React.Component {
 function mapStateToProps(state) {
     return {
         activeFrameId: state.frames.activeFrameId,
+        selectedFrameId: state.frames.selectedFrameId,
         frames: state.frames.items,
         framesTab: state.frames.tab,
         connection: state.connection,
@@ -284,8 +296,8 @@ function mapDispatchToProps(dispatch) {
         handleRefreshConnectedState(openChangeUrlModal) {
             dispatch(refreshConnectedState(openChangeUrlModal));
         },
-        handleSetActiveFrame(frameId) {
-            return dispatch(setActiveFrame(frameId));
+        handleSetSelectedFrame(frameId) {
+            return dispatch(setSelectedFrame(frameId));
         },
         handleDiscardFrame(frameId) {
             return dispatch(discardFrame(frameId));

--- a/client/src/reducers/frames.js
+++ b/client/src/reducers/frames.js
@@ -11,6 +11,7 @@ import {
     RECEIVE_FRAME,
     DISCARD_FRAME,
     PATCH_FRAME,
+    SET_SELECTED_FRAME,
     SET_ACTIVE_FRAME,
     UPDATE_FRAMES_TAB,
 } from "../actions/frames";
@@ -39,6 +40,10 @@ export default (state = defaultState, action) =>
                     action.frameData,
                 );
                 break;
+
+            case SET_SELECTED_FRAME:
+                draft.selectedFrameId = action.frameId;
+                return;
 
             case SET_ACTIVE_FRAME:
                 draft.activeFrameId = action.frameId;


### PR DESCRIPTION
Rather than update the active frame when it's clicked in the history, set the editor without disturbing the current active frame. The main idea is to reduce the number of background queries that can get started by clicking around in the history. The user must run the query in order for results to refresh.

And on browser refresh, if there is an active query, set the editor to that and run the query. If a query is executing, display loading indicator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/85)
<!-- Reviewable:end -->
