### PR TITLE
Fix error after deleting frame

### DIFF
--- a/client/src/components/FrameItem.js
+++ b/client/src/components/FrameItem.js
@@ -54,7 +54,6 @@ export default class FrameItem extends React.Component {
 
         const { hoveredAxis, hoveredNode, selectedNode } = this.state;
         const { response, error } = tabResult || {};
-
         const renderContent = () => {
             if (!frame.completed) {
                 return <FrameLoading />;
@@ -74,10 +73,11 @@ export default class FrameItem extends React.Component {
                     selectedNode={selectedNode}
                 />
             ) : (
+                // TODO: what's a good response for this case?
                 <FrameMessage
                     error={error}
                     query={frame.query}
-                    response={tabResult.response}
+                    response={response}
                 />
             );
         };

--- a/client/src/components/QueryView/index.js
+++ b/client/src/components/QueryView/index.js
@@ -33,9 +33,9 @@ export default function QueryView({
 }) {
     const frame = frames.find(f => f.id === activeFrameId) || frames[0] || {};
     const tabName = frame.action === "mutate" ? "mutate" : activeTab;
-    const frameResult = frame && frameResults[frame.id];
+    const frameResult = (frame && frameResults[frame.id]) || {};
     const tabResult =
-        frameResult[tabName] || frameResult[Object.keys(frameResult)[0]] || {};
+        frameResult[tabName] || frameResult[Object.keys(frameResult)[0]];
 
     return (
         <div className="query-view">

--- a/client/src/components/QueryView/index.js
+++ b/client/src/components/QueryView/index.js
@@ -33,8 +33,9 @@ export default function QueryView({
 }) {
     const frame = frames.find(f => f.id === activeFrameId) || frames[0] || {};
     const tabName = frame.action === "mutate" ? "mutate" : activeTab;
+    const frameResult = frame && frameResults[frame.id];
     const tabResult =
-        frame && frameResults[frame.id] && frameResults[frame.id][tabName];
+        frameResult[tabName] || frameResult[Object.keys(frameResult)[0]] || {};
 
     return (
         <div className="query-view">


### PR DESCRIPTION
This should resolve #95

The issue came from the current frame not having the state's active tab as a result.

Here's how I was able to reproduce:
run a query(1) on graph tab
run the same query(1) on the json tab
run a new query(2) still on the json tab
run another new query(3) on the json tab
switch to graph tab and run the same query(3)
then try and delete

My fix just takes the first tab of the frame if the active tab isn't present. I don't update the state, but I can if that makes sense to do. But you run the risk of the same tab not being present in other results.

I also added a TODO on line 76 of FrameItem.js because it's passing response from tabResult which was already determined to be falsey and I'm not sure what a good response for that case would be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/101)
<!-- Reviewable:end -->
