### PR TITLE
Refactor D3Graph: remove NodesDataset, simplify data structures

### DIFF
--- a/client/src/components/FrameItem.js
+++ b/client/src/components/FrameItem.js
@@ -37,7 +37,6 @@ export default class FrameItem extends React.Component {
     };
 
     handleNodeHovered = hoveredNode => this.setState({ hoveredNode });
-
     handleAxisHovered = hoveredAxis => this.setState({ hoveredAxis });
 
     render() {
@@ -77,7 +76,7 @@ export default class FrameItem extends React.Component {
                 <FrameMessage
                     error={error}
                     query={frame.query}
-                    response={tabResult ? tabResult.response : {}}
+                    response={response}
                 />
             );
         };

--- a/client/src/components/GraphContainer.js
+++ b/client/src/components/GraphContainer.js
@@ -59,11 +59,11 @@ export default ({
                 selectedNode
                     ? null
                     : remainingNodes > 0
-                    ? `Showing ${nodesDataset.length +
+                    ? `Showing ${nodesDataset.size +
                           remainingNodes} nodes (${remainingNodes} hidden) and ${
-                          edgesDataset.length
+                          edgesDataset.size
                       } edges`
-                    : `Showing ${nodesDataset.length} nodes and ${edgesDataset.length} edges`
+                    : `Showing ${nodesDataset.size} nodes and ${edgesDataset.size} edges`
             }
             height={panelHeight}
             width={panelWidth}


### PR DESCRIPTION
Cleaner data flow between parser and d3 simulation/forces.

This will help with collapsing nodes, showing trees in the Data Explorer, and facets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/102)
<!-- Reviewable:end -->
