### PR TITLE
Fix e2e tests by removing flag for enterprise features.

### DIFF
--- a/client/src/e2etests/docker-compose.dev.yml
+++ b/client/src/e2etests/docker-compose.dev.yml
@@ -40,7 +40,6 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --my=server:8080 --lru_mb=2048 --zero=zero:5080 --enterprise_features --acl_secret_file=/secrets/acl-secret.txt
-
+    command: dgraph alpha --my=server:8080 --lru_mb=2048 --zero=zero:5080 --acl_secret_file=/secrets/acl-secret.txt
 volumes:
   dgraph:

--- a/client/src/e2etests/docker-compose.prod.yml
+++ b/client/src/e2etests/docker-compose.prod.yml
@@ -35,7 +35,7 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --my=server:8080 --lru_mb=2048 --zero=zero:5080 --enterprise_features --acl_secret_file=/secrets/acl-secret.txt
+    command: dgraph alpha --my=server:8080 --lru_mb=2048 --zero=zero:5080 --acl_secret_file=/secrets/acl-secret.txt
 
 volumes:
   dgraph:


### PR DESCRIPTION
dgraph-io/dgraph#3824 removed the `--enterprise_features` flag. This change removes the flag from the cluster configuration for e2e tests so that the Dgraph cluster can run properly for the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/109)
<!-- Reviewable:end -->
