### PR TITLE
Open source Ratel under Apache 2.0 license

### DIFF
--- a/client/config/env.js
+++ b/client/config/env.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 const child_process = require('child_process');
 const fs = require("fs");

--- a/client/config/jest/cssTransform.js
+++ b/client/config/jest/cssTransform.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // This is a custom Jest transformer turning style imports into empty objects.
 // http://facebook.github.io/jest/docs/tutorial-webpack.html

--- a/client/config/jest/fileTransform.js
+++ b/client/config/jest/fileTransform.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 const path = require("path");
 

--- a/client/config/paths.js
+++ b/client/config/paths.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 const path = require("path");
 const fs = require("fs");

--- a/client/config/polyfills.js
+++ b/client/config/polyfills.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 if (typeof Promise === "undefined") {
     // Rejection tracking prevents a common issue where React gets into an

--- a/client/config/webpack.config.dev.js
+++ b/client/config/webpack.config.dev.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 const autoprefixer = require("autoprefixer");
 const path = require("path");

--- a/client/config/webpack.config.prod.js
+++ b/client/config/webpack.config.prod.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 const autoprefixer = require("autoprefixer");
 const fs = require("fs");

--- a/client/config/webpackDevServer.config.js
+++ b/client/config/webpackDevServer.config.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 const errorOverlayMiddleware = require("react-dev-utils/errorOverlayMiddleware");
 const noopServiceWorkerMiddleware = require("react-dev-utils/noopServiceWorkerMiddleware");

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,9 +1,15 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 module.exports = {};

--- a/client/scripts/build.local.js
+++ b/client/scripts/build.local.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Do this as the first thing so that any code reading it knows the right env.
 // babel-preset-react-app only accepts 3 values - "development", "test" and

--- a/client/scripts/build.prod.js
+++ b/client/scripts/build.prod.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = "production";

--- a/client/scripts/start.js
+++ b/client/scripts/start.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = "development";

--- a/client/scripts/test.js
+++ b/client/scripts/test.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = "test";

--- a/client/src/actions/connection.js
+++ b/client/src/actions/connection.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 export const UPDATE_CONNECTED_STATE = "connection/UPDATE_CONNECTED_STATE";
 export const UPDATE_SHOULD_PROMPT = "connection/UPDATE_SHOULD_PROMPT";

--- a/client/src/actions/frames.js
+++ b/client/src/actions/frames.js
@@ -1,10 +1,16 @@
 // Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { executeQuery } from "lib/helpers";
 

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import uuid from "uuid";
 

--- a/client/src/actions/query.js
+++ b/client/src/actions/query.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 export const UPDATE_QUERY = "query/UPDATE_QUERY";
 export const UPDATE_ACTION = "query/UPDATE_ACTION";

--- a/client/src/actions/ui.js
+++ b/client/src/actions/ui.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 export const SET_PANEL_SIZE = "ui/SET_PANEL_SIZE";
 export const SET_PANEL_MINIMIZED = "ui/SET_PANEL_MINIMIZED";

--- a/client/src/actions/url.js
+++ b/client/src/actions/url.js
@@ -1,10 +1,16 @@
 // Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { updateConnectedState, updateRefreshing } from "./connection";
 import * as helpers from "lib/helpers";

--- a/client/src/components/ACL/AclPage.js
+++ b/client/src/components/ACL/AclPage.js
@@ -1,10 +1,16 @@
-// Copyright 2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/ACL/EditGroupModal.js
+++ b/client/src/components/ACL/EditGroupModal.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/ACL/EditUserModal.js
+++ b/client/src/components/ACL/EditUserModal.js
@@ -1,10 +1,16 @@
-// Copyright 2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React, { useState } from "react";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/ACL/GroupDetailsPane.js
+++ b/client/src/components/ACL/GroupDetailsPane.js
@@ -1,10 +1,16 @@
-// Copyright 2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/ACL/UserDetailsPane.js
+++ b/client/src/components/ACL/UserDetailsPane.js
@@ -1,10 +1,16 @@
-// Copyright 2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/AutosizeGrid.js
+++ b/client/src/components/AutosizeGrid.js
@@ -1,10 +1,16 @@
-// Copyright 2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import ReactDataGrid from "react-data-grid";

--- a/client/src/components/D3Graph/index.js
+++ b/client/src/components/D3Graph/index.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import * as d3 from "d3";

--- a/client/src/components/DataExplorer/PathDisplay.js
+++ b/client/src/components/DataExplorer/PathDisplay.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/DataExplorer/index.js
+++ b/client/src/components/DataExplorer/index.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import ReactDataGrid from "react-data-grid";

--- a/client/src/components/EditorPanel.js
+++ b/client/src/components/EditorPanel.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import { connect } from "react-redux";

--- a/client/src/components/EntitySelector.js
+++ b/client/src/components/EntitySelector.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/FrameCodeTab.js
+++ b/client/src/components/FrameCodeTab.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Clipboard from "react-clipboard.js";

--- a/client/src/components/FrameItem.js
+++ b/client/src/components/FrameItem.js
@@ -1,10 +1,16 @@
 // Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import classnames from "classnames";

--- a/client/src/components/FrameLayout/FrameHeader.js
+++ b/client/src/components/FrameLayout/FrameHeader.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import classnames from "classnames";

--- a/client/src/components/FrameLayout/FrameSession.js
+++ b/client/src/components/FrameLayout/FrameSession.js
@@ -1,10 +1,16 @@
-// Copyright 2018-2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import memoize from "memoize-one";

--- a/client/src/components/FrameLayout/QueryPreview.js
+++ b/client/src/components/FrameLayout/QueryPreview.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/FrameLayout/SessionFooter.js
+++ b/client/src/components/FrameLayout/SessionFooter.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/FrameLayout/SessionFooterProperties.js
+++ b/client/src/components/FrameLayout/SessionFooterProperties.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import classnames from "classnames";

--- a/client/src/components/FrameLayout/SessionFooterResult.js
+++ b/client/src/components/FrameLayout/SessionFooterResult.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import pluralize from "pluralize";

--- a/client/src/components/FrameList.js
+++ b/client/src/components/FrameList.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/FrameLoading.js
+++ b/client/src/components/FrameLoading.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/FrameMessage.js
+++ b/client/src/components/FrameMessage.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Tab from "react-bootstrap/Tab";

--- a/client/src/components/GraphContainer.js
+++ b/client/src/components/GraphContainer.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/GraphIcon.js
+++ b/client/src/components/GraphIcon.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/Label.js
+++ b/client/src/components/Label.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/MovablePanel.js
+++ b/client/src/components/MovablePanel.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import classnames from "classnames";

--- a/client/src/components/NodeProperties.js
+++ b/client/src/components/NodeProperties.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/PanelLayout/HorizontalPanelLayout.js
+++ b/client/src/components/PanelLayout/HorizontalPanelLayout.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/PanelLayout/VerticalPanelLayout.js
+++ b/client/src/components/PanelLayout/VerticalPanelLayout.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Draggable from "react-draggable";

--- a/client/src/components/PanelLayout/index.js
+++ b/client/src/components/PanelLayout/index.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import classnames from "classnames";

--- a/client/src/components/PartialRenderInfo.js
+++ b/client/src/components/PartialRenderInfo.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/Progress.js
+++ b/client/src/components/Progress.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import ProgressBar from "react-bootstrap/ProgressBar";

--- a/client/src/components/Properties.js
+++ b/client/src/components/Properties.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/QueryView/index.js
+++ b/client/src/components/QueryView/index.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/SantaHat.js
+++ b/client/src/components/SantaHat.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Public domain image from https://commons.wikimedia.org/wiki/File:Santa_hat.svg
 

--- a/client/src/components/SessionList.js
+++ b/client/src/components/SessionList.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import TransitionGroup from "react-transition-group/TransitionGroup";

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import classnames from "classnames";

--- a/client/src/components/SidebarInfo.js
+++ b/client/src/components/SidebarInfo.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/SidebarLoginControl.js
+++ b/client/src/components/SidebarLoginControl.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import React from "react";
 import Button from "react-bootstrap/Button";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";

--- a/client/src/components/SidebarUpdateUrl.js
+++ b/client/src/components/SidebarUpdateUrl.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/TreeIcon.js
+++ b/client/src/components/TreeIcon.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/schema/EditTypeModal.js
+++ b/client/src/components/schema/EditTypeModal.js
@@ -1,10 +1,16 @@
-// Copyright 2018-2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React, { useState } from "react";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/schema/PredicatePropertiesPanel.js
+++ b/client/src/components/schema/PredicatePropertiesPanel.js
@@ -1,10 +1,16 @@
-// Copyright 2018-2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/schema/PredicateTabs.js
+++ b/client/src/components/schema/PredicateTabs.js
@@ -1,10 +1,16 @@
-// Copyright 2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React, { useState } from "react";
 

--- a/client/src/components/schema/PredicatesTable.js
+++ b/client/src/components/schema/PredicatesTable.js
@@ -1,10 +1,16 @@
-// Copyright 2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React, { useState } from "react";
 

--- a/client/src/components/schema/SampleDataPanel/SamplesTable.js
+++ b/client/src/components/schema/SampleDataPanel/SamplesTable.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/schema/SampleDataPanel/SamplesTable.test.js
+++ b/client/src/components/schema/SampleDataPanel/SamplesTable.test.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Enzyme from "enzyme";

--- a/client/src/components/schema/SampleDataPanel/index.js
+++ b/client/src/components/schema/SampleDataPanel/index.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/schema/Schema.js
+++ b/client/src/components/schema/Schema.js
@@ -1,10 +1,16 @@
-// Copyright 2018-2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import isEmpty from "lodash.isempty";

--- a/client/src/components/schema/SchemaDropAllModal.js
+++ b/client/src/components/schema/SchemaDropAllModal.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Button from "react-bootstrap/Button";

--- a/client/src/components/schema/SchemaPredicateForm.js
+++ b/client/src/components/schema/SchemaPredicateForm.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import cloneDeep from "lodash.clonedeep";

--- a/client/src/components/schema/SchemaPredicateModal.js
+++ b/client/src/components/schema/SchemaPredicateModal.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Modal from "react-bootstrap/Modal";

--- a/client/src/components/schema/SchemaRawModeModal.js
+++ b/client/src/components/schema/SchemaRawModeModal.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import Modal from "react-bootstrap/Modal";

--- a/client/src/components/schema/TypeProperties.js
+++ b/client/src/components/schema/TypeProperties.js
@@ -1,10 +1,16 @@
-// Copyright 2018-2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 

--- a/client/src/components/schema/TypesTable.js
+++ b/client/src/components/schema/TypesTable.js
@@ -1,10 +1,16 @@
-// Copyright 2019 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React, { useState } from "react";
 

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import classnames from "classnames";

--- a/client/src/containers/AppProvider.js
+++ b/client/src/containers/AppProvider.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import { Provider } from "react-redux";

--- a/client/src/containers/Editor.js
+++ b/client/src/containers/Editor.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from "react";
 import isEmpty from "lodash.isempty";

--- a/client/src/e2etests/acl/accessDenied.test.js
+++ b/client/src/e2etests/acl/accessDenied.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/acl/aclHelpers.js
+++ b/client/src/e2etests/acl/aclHelpers.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import { getElementText, waitForElement, waitUntil } from "../puppetHelpers";

--- a/client/src/e2etests/acl/changePermissions.test.js
+++ b/client/src/e2etests/acl/changePermissions.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/acl/createUser.test.js
+++ b/client/src/e2etests/acl/createUser.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/acl/loginLogout.test.js
+++ b/client/src/e2etests/acl/loginLogout.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/acl/passwordCheck.test.js
+++ b/client/src/e2etests/acl/passwordCheck.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/acl/showGroot.test.js
+++ b/client/src/e2etests/acl/showGroot.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/basic.test.js
+++ b/client/src/e2etests/basic.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import {
     createTestTab,
     easyUid,

--- a/client/src/e2etests/dataExplorer.test.js
+++ b/client/src/e2etests/dataExplorer.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/expandGraph.test.js
+++ b/client/src/e2etests/expandGraph.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/jsonMutation.test.js
+++ b/client/src/e2etests/jsonMutation.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/noDuplicateMutations.test.js
+++ b/client/src/e2etests/noDuplicateMutations.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/oneToOne.test.js
+++ b/client/src/e2etests/oneToOne.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/puppetHelpers.js
+++ b/client/src/e2etests/puppetHelpers.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import * as dgraph from "dgraph-js-http";
 import puppeteer from "puppeteer";
 

--- a/client/src/e2etests/queryTimeout.test.js
+++ b/client/src/e2etests/queryTimeout.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import {

--- a/client/src/e2etests/typeSystem.test.js
+++ b/client/src/e2etests/typeSystem.test.js
@@ -1,3 +1,16 @@
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import puppeteer from "puppeteer";
 
 import { loginUser } from "./acl/aclHelpers";

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import "core-js/stable";
 import "regenerator-runtime/runtime";

--- a/client/src/index.test.js
+++ b/client/src/index.test.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import jsdom from "jsdom";
 import React from "react";

--- a/client/src/lib/GraphLabeler.js
+++ b/client/src/lib/GraphLabeler.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import randomColor from "randomcolor";
 

--- a/client/src/lib/dgraph-syntax.js
+++ b/client/src/lib/dgraph-syntax.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 export function getPredicateTypeString(predicate) {
     let type = predicate.type;

--- a/client/src/lib/graph.js
+++ b/client/src/lib/graph.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import cloneDeep from "lodash.clonedeep";
 import uuid from "uuid";

--- a/client/src/lib/graph.test.js
+++ b/client/src/lib/graph.test.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { processGraph } from "./graph";
 

--- a/client/src/lib/helpers.js
+++ b/client/src/lib/helpers.js
@@ -1,10 +1,16 @@
 // Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import * as dgraph from "dgraph-js-http";
 import memoizeOne from "memoize-one";

--- a/client/src/reducers/connection.js
+++ b/client/src/reducers/connection.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import {
     UPDATE_CONNECTED_STATE,

--- a/client/src/reducers/frames.js
+++ b/client/src/reducers/frames.js
@@ -1,10 +1,16 @@
 // Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import produce from "immer";
 import {

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { persistCombineReducers } from "redux-persist";
 

--- a/client/src/reducers/query.js
+++ b/client/src/reducers/query.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import {
     UPDATE_QUERY,

--- a/client/src/reducers/ui.js
+++ b/client/src/reducers/ui.js
@@ -1,10 +1,16 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import produce from "immer";
 

--- a/client/src/reducers/url.js
+++ b/client/src/reducers/url.js
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import produce from "immer";
 

--- a/main.go
+++ b/main.go
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package main
 

--- a/scripts/licensing/header.txt
+++ b/scripts/licensing/header.txt
@@ -1,8 +1,13 @@
-// Copyright 2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
-
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/scripts/licensing/license.sh
+++ b/scripts/licensing/license.sh
@@ -7,7 +7,7 @@ files="$(find $rateldir -type f -not -path "*/client/node_modules/*" -name "*.js
 
 for f in $files
 do
-    sed -i -E '/\/\/ Copyright (201[7-8]-)?201[8-9] Dgraph Labs, Inc. and Contributors/,/\/\/     https:\/\/github.com\/dgraph-io\/ratel\/blob\/master\/LICENSE/d' $f
+    sed -i -E '/\/\/ Copyright 2017-2019 Dgraph Labs, Inc. and Contributors/,/\/\/ limitations under the License\./d' $f
     cat "$dir/header.txt" $f > $tmpfile
     cp $tmpfile $f
 

--- a/scripts/licensing/license.sh
+++ b/scripts/licensing/license.sh
@@ -3,16 +3,17 @@
 tmpfile="$(mktemp)"
 dir="$(dirname "$0")"
 rateldir="$dir/../.."
-files="$(find $rateldir -type f -name "*.js" -o -name "*.go" ! -name "bindata.go")"
+files="$(find $rateldir -type f -not -path "*/client/node_modules/*" -name "*.js" -o -name "*.go" ! -name "bindata.go")"
 
 for f in $files
 do
+    sed -i -E '/\/\/ Copyright (201[7-8]-)?201[8-9] Dgraph Labs, Inc. and Contributors/,/\/\/     https:\/\/github.com\/dgraph-io\/ratel\/blob\/master\/LICENSE/d' $f
     cat "$dir/header.txt" $f > $tmpfile
     cp $tmpfile $f
 
     year=$(git log --format=%aD $f | tail -1 | awk '{ print $4 }')
-    if [ "$year" != "2018" ]; then
-        sed -i "s/Copyright 2018 Dgraph/Copyright $year-2018 Dgraph/g" $f
+    if [ "$year" != "2019" ]; then
+        sed -i "s/Copyright 2019 Dgraph/Copyright $year-2019 Dgraph/g" $f
     fi
 
     echo $f

--- a/server/buffer.go
+++ b/server/buffer.go
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package server
 

--- a/server/content.go
+++ b/server/content.go
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package server
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package server
 

--- a/server/validate.go
+++ b/server/validate.go
@@ -1,10 +1,16 @@
-// Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+// Copyright 2017-2019 Dgraph Labs, Inc. and Contributors
 //
-// Licensed under the Dgraph Community License (the "License"); you
-// may not use this file except in compliance with the License. You
-// may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/dgraph-io/ratel/blob/master/LICENSE
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package server
 


### PR DESCRIPTION
Relicensing the Dgraph Ratel repository as Apache 2.0! :tada:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/126)
<!-- Reviewable:end -->
