### PR TITLE
Predicate counts are now loaded on demand in Data Explorer.

### DIFF
--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -241,7 +241,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(App);
+export default connect(mapStateToProps, mapDispatchToProps)(App);


### PR DESCRIPTION
If you have a better idea for the button text, let me know. 'Fetch counts' sounds kind of clunky. 


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/148)
<!-- Reviewable:end -->
