### PR TITLE
Add Cobra, make version info persistent

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,5 +17,5 @@ package main
 import "github.com/dgraph-io/ratel/server"
 
 func main() {
-	server.Run()
+	server.Execute()
 }

--- a/scripts/build.prod.sh
+++ b/scripts/build.prod.sh
@@ -4,8 +4,9 @@ set -e
 
 version="$(cat ../client/package.json | grep -i "version*" | awk -F '"' '{print $4}')" 
 flagUploadToS3=false
-commitID="$(git rev-parse --short HEAD)"
-commitINFO="$(git show --pretty=format:"%h  %ad  %d" | head -n1)"
+lastCommitSHA1=$(git rev-parse --short HEAD)
+gitBranch=$(git rev-parse --abbrev-ref HEAD)
+lastCommitTime=$(git log -1 --format=%ci)
 
 while [ "$1" != "" ]; do
     case $1 in

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -26,29 +26,21 @@ function buildClient {
     cd ..
 }
 
-function doChecks {
-    if ! hash go 2>/dev/null; then
-		echo "Could not find golang. Please install Go env and try again.";
-		exit 1;
-	fi
-
-    if hash go-bindata 2>/dev/null; then
-        go_bindata="$(which go-bindata)"
-       else
-        echo "Could not find go-bindata. Please install go-bindata and try again. Read the INSTRUCTIONS.md";
-        exit 1;
-    fi
-}
-
 # Build server files.
 function buildServer {
-    doChecks
     echo
     echo "=> Building server files..."
 
     # Run bindata for all files in in client/build/ (recursive).
     go get github.com/jteeuwen/go-bindata/go-bindata
-    $go_bindata -o ./server/bindata.go -pkg server -prefix "./client/build" -ignore=DS_Store ./client/build/...
+    $GOPATH/bin/go-bindata -o ./server/bindata.go -pkg server -prefix "./client/build" -ignore=DS_Store ./client/build/...
+
+    # Check if production build.
+    if [ $1 = true ]; then
+        ldflagsVal="-X github.com/dgraph-io/ratel/server.mode=prod"
+    else
+        ldflagsVal="-X github.com/dgraph-io/ratel/server.mode=local"
+    fi
 
     # Check if production build.
     if [ $1 = true ]; then

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -26,14 +26,29 @@ function buildClient {
     cd ..
 }
 
+function doChecks {
+    if ! hash go 2>/dev/null; then
+		echo "Could not find golang. Please install Go env and try again.";
+		exit 1;
+	fi
+
+    if hash go-bindata 2>/dev/null; then
+        go_bindata="$(which go-bindata)"
+       else
+        echo "Could not find go-bindata. Please install go-bindata and try again. Read the INSTRUCTIONS.md";
+        exit 1;
+    fi
+}
+
 # Build server files.
 function buildServer {
+    doChecks
     echo
     echo "=> Building server files..."
 
     # Run bindata for all files in in client/build/ (recursive).
     go get github.com/jteeuwen/go-bindata/go-bindata
-    $GOPATH/bin/go-bindata -o ./server/bindata.go -pkg server -prefix "./client/build" -ignore=DS_Store ./client/build/...
+    $go_bindata -o ./server/bindata.go -pkg server -prefix "./client/build" -ignore=DS_Store ./client/build/...
 
     # Check if production build.
     if [ $1 = true ]; then
@@ -47,11 +62,9 @@ function buildServer {
         ldflagsVal="$ldflagsVal -X github.com/dgraph-io/ratel/server.version=$2"
     fi
 
-    # This is necessary, as the go build flag "-ldflags" won't work with spaces.
-    escape=$(echo $commitINFO | sed -e "s/ /¨•¨/g")
-    
-    ldflagsVal="$ldflagsVal -X github.com/dgraph-io/ratel/server.commitINFO=$escape"
-    ldflagsVal="$ldflagsVal -X github.com/dgraph-io/ratel/server.commitID=$commitID"
+    ldflagsVal="$ldflagsVal -X 'github.com/dgraph-io/ratel/server.branch=$gitBranch'"
+    ldflagsVal="$ldflagsVal -X github.com/dgraph-io/ratel/server.lastCommitSHA1=$lastCommitSHA1"
+    ldflagsVal="$ldflagsVal -X 'github.com/dgraph-io/ratel/server.lastCommitTime=$lastCommitTime'"
 
     # Build the Go binary with linker flags.
     go build -ldflags="$ldflagsVal" -o build/ratel

--- a/server/server.go
+++ b/server/server.go
@@ -50,8 +50,7 @@ var (
 
 	listenAddr string
 
-	cfgFile     string
-	userLicense string
+	cfgFile string
 
 	rootCmd = &cobra.Command{
 		Use:   "ratel",

--- a/server/server.go
+++ b/server/server.go
@@ -16,18 +16,24 @@ package server
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"html/template"
 	"log"
 	"net/http"
 	"os"
 	"strings"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 const (
-	defaultPort = 8000
-	defaultAddr = ""
+	defaultPort   = 8000
+	defaultAddr   = "localhost"
+	defaultAlpha  = ""
+	defaultTLSCrt = ""
+	defaultTLSKey = ""
 
 	indexPath = "index.html"
 )
@@ -43,11 +49,48 @@ var (
 	tlsKey string
 
 	listenAddr string
+
+	cfgFile     string
+	userLicense string
+
+	rootCmd = &cobra.Command{
+		Use:   "ratel",
+		Short: "Ratel is a Dgraph UI.",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Starting Ratel UI\n", printversion())
+			Run()
+		},
+	}
 )
+
+func printversion() string {
+	return fmt.Sprintf(`
+Ratel version   : %v
+Commit ID       : %v
+Commit Info     : %v
+
+For Dgraph official documentation, visit https://docs.dgraph.io.
+For discussions about Dgraph     , visit https://discuss.dgraph.io.
+To say hi to the community       , visit https://dgraph.slack.com.
+
+Licensed variously under the Apache Public License 2.0 and Dgraph Community License.
+Copyright 2015-2020 Dgraph Labs, Inc.
+	`,
+		version, commitID, commitINFO)
+
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
 
 // Run starts the server.
 func Run() {
-	parseFlags()
 	indexContent := prepareIndexContent()
 
 	http.HandleFunc("/", makeMainHandler(indexContent))
@@ -62,37 +105,52 @@ func Run() {
 		log.Fatalln(http.ListenAndServe(addrStr, nil))
 	}
 }
+func init() {
+	cobra.OnInitialize(initConfig)
 
-func parseFlags() {
-	portPtr := flag.Int("port", defaultPort, "Port on which the ratel server will run.")
-	addrPtr := flag.String("addr", defaultAddr, "Address of the Dgraph server.")
-	versionFlagPtr := flag.Bool("version", false, "Prints the version of ratel.")
-	tlsCrtPtr := flag.String("tls_crt", "", "TLS cert for serving HTTPS requests.")
-	tlsKeyPtr := flag.String("tls_key", "", "TLS key for serving HTTPS requests.")
-	listenAddrPtr := flag.String("listen-addr", defaultAddr, "Address Ratel server should listen on.")
+	rootCmd.PersistentFlags().IntVarP(&port, "port", "p", defaultPort,
+		"Port on which the ratel server will run.")
+	rootCmd.PersistentFlags().StringVarP(&addr, "addr", "d", defaultAlpha,
+		"Address of the Dgraph Alpha.")
+	rootCmd.PersistentFlags().StringVarP(&tlsCrt, "tls_crt", "c", defaultTLSCrt,
+		"TLS cert for serving HTTPS requests.")
+	rootCmd.PersistentFlags().StringVarP(&tlsKey, "tls_key", "k", defaultTLSKey,
+		"TLS key for serving HTTPS requests.")
+	rootCmd.PersistentFlags().StringVarP(&listenAddr, "listen-addr", "l", defaultAddr,
+		"Address Ratel UI server should listen on.")
 
-	flag.Parse()
+	viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port"))
 
-	if *versionFlagPtr {
-		fmt.Printf("Ratel Version: %s\n", version)
-		fmt.Printf("Commit ID: %s\n", commitID)
-		fmt.Printf("Commit Info: %s\n", commitINFO)
-		os.Exit(0)
+	viper.BindPFlag("addr", rootCmd.PersistentFlags().Lookup("addr"))
+	viper.BindPFlag("tlsCrt", rootCmd.PersistentFlags().Lookup("tls_crt"))
+	viper.BindPFlag("tlsKey", rootCmd.PersistentFlags().Lookup("tls_key"))
+	viper.BindPFlag("listenAddr", rootCmd.PersistentFlags().Lookup("listen-addr"))
+}
+func er(msg interface{}) {
+	fmt.Println("Error:", msg)
+	os.Exit(1)
+}
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			er(err)
+		}
+
+		// Search config in home directory with name ".cobra" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigName(".cobra")
 	}
 
-	var err error
-	addr, err = validateAddr(*addrPtr)
-	if err != nil && err != errAddrNil {
-		fmt.Printf("Error parsing Dgraph server address: %s\n", err.Error())
-		os.Exit(1)
+	viper.AutomaticEnv()
+
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
-
-	port = *portPtr
-
-	tlsCrt = *tlsCrtPtr
-	tlsKey = *tlsKeyPtr
-
-	listenAddr = *listenAddrPtr
 }
 
 func getAsset(path string) string {

--- a/server/server.go
+++ b/server/server.go
@@ -39,11 +39,12 @@ const (
 )
 
 var (
-	port       int
-	addr       string
-	version    string
-	commitINFO string
-	commitID   string
+	port           int
+	addr           string
+	version        string
+	branch         string
+	lastCommitSHA1 string
+	lastCommitTime string
 
 	tlsCrt string
 	tlsKey string
@@ -64,9 +65,10 @@ var (
 
 func printversion() string {
 	return fmt.Sprintf(`
-Ratel version   : %v
-Commit ID       : %v
-Commit Info     : %v
+Ratel version    : %v
+Commit SHA-1     : %v
+Commit timestamp : %v
+Branch           : %v
 
 For Dgraph official documentation, visit https://docs.dgraph.io.
 For discussions about Dgraph     , visit https://discuss.dgraph.io.
@@ -75,7 +77,7 @@ To say hi to the community       , visit https://dgraph.slack.com.
 Licensed variously under the Apache Public License 2.0 and Dgraph Community License.
 Copyright 2015-2020 Dgraph Labs, Inc.
 	`,
-		version, commitID, commitINFO)
+		version, lastCommitSHA1, lastCommitTime, branch)
 
 }
 


### PR DESCRIPTION
Add Cobra for better handling of flags.
Edit Version print format to a similar one used in other binaries.
Make version info persistent (it will always print version and info on logs).

Closes #30

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/182)
<!-- Reviewable:end -->
 
 
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-1c6fcc0eca51588-55488.surge.sh/?local)
<!-- Dgraph:end -->