### PR TITLE
Use URL encoding with /moveTablet

### DIFF
--- a/client/src/components/Cluster/MoveTabletModal.js
+++ b/client/src/components/Cluster/MoveTabletModal.js
@@ -48,7 +48,7 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
     const getUrl = () =>
         `${sanitizeUrl(
             zeroUrlInput,
-        )}/moveTablet?tablet=${tablet}&group=${targetGroup}`;
+        )}/moveTablet?tablet=${encodeURIComponent(tablet)}&group=${targetGroup}`;
 
     const humanizeGroupSize = group => {
         const space = Object.values(group.tablets || {}).reduce(


### PR DESCRIPTION
Fixes https://discuss.dgraph.io/t/ratel-does-not-url-encode-predicate-in-move-tablet-url/9067.

The `tablet` variable in the URL is a string, and it has been inserted into the URL without proper encoding, causing issues. I've fixed that by passing the string through `encodeURIComponent`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/226)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-eabac6e3ea7f3e8-83243.surge.sh/?local)
<!-- Dgraph:end -->