### PR TITLE
fix: Remove link to slack

### DIFF
--- a/client/src/components/SidebarInfo.js
+++ b/client/src/components/SidebarInfo.js
@@ -75,16 +75,6 @@ export default function SidebarInfo() {
                     </li>
                     <li>
                         <a
-                            href="https://slack.dgraph.io"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            <i className="fab fa-slack link-icon" />
-                            Slack group
-                        </a>
-                    </li>
-                    <li>
-                        <a
                             href="https://tour.dgraph.io"
                             target="_blank"
                             rel="noopener noreferrer"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/232)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-79385b034c63297-87227.surge.sh/?local)
<!-- Dgraph:end -->