### PR TITLE
replaced the graphql and graphql+- endpoints

### DIFF
--- a/server/play-dgraph-io.nginx.conf
+++ b/server/play-dgraph-io.nginx.conf
@@ -58,7 +58,7 @@ server {
   location = /graphql/dgraph/query {
     # Adding rate limiting
     limit_req zone=play;
-    proxy_pass https://erect-effect.us-west-2.aws.cloud.dgraph.io/query;
+    proxy_pass https://erect-effect.us-west-2.aws.cloud.dgraph.io/graphql;
     proxy_set_header X-Auth-Token FT/ya7B3vBlq5yvVYf/z6T6LX2VcKSHxjerq3lqxznQ=;
   }
   location = /graphql/dgraph/health {

--- a/server/play-dgraph-io.nginx.conf
+++ b/server/play-dgraph-io.nginx.conf
@@ -19,7 +19,8 @@ server {
     set $args $args${delimeter}be=true;
 
     # Pass to the Dgraph Alpha running on this machine
-    proxy_pass http://127.0.0.1:8080;
+    proxy_pass https://crooked-advertisement.us-west-2.aws.cloud.dgraph.io;
+    proxy_set_header X-Auth-Token rFixJ0UBTQrtoyF8ZWA4ChoaGjqPthPGFtrofqvVB6g=;
 
     # Cache queries
     proxy_cache dgraphcache;
@@ -36,35 +37,41 @@ server {
     # Adding rate limiting
     limit_req zone=play burst=20;
     # Pass to the Dgraph Alpha running on this machine
-    proxy_pass http://127.0.0.1:8080;
+    proxy_pass https://crooked-advertisement.us-west-2.aws.cloud.dgraph.io;
+    proxy_set_header X-Auth-Token rFixJ0UBTQrtoyF8ZWA4ChoaGjqPthPGFtrofqvVB6g=;
   }
 
   location ~ ^/(graphql|admin) {
     # Adding rate limiting
     limit_req zone=play;
     # Pass to the Dgraph Alpha running GraphQL on this machine
-    proxy_pass http://127.0.0.1:8081;
+    proxy_pass https://erect-effect.us-west-2.aws.cloud.dgraph.io;
+    proxy_set_header X-Auth-Token FT/ya7B3vBlq5yvVYf/z6T6LX2VcKSHxjerq3lqxznQ=;
   }
 
   location = /graphql/dgraph {
     # Adding rate limiting
     limit_req zone=play;
-    proxy_pass http://127.0.0.1:8081;
+    proxy_pass https://erect-effect.us-west-2.aws.cloud.dgraph.io;
+    proxy_set_header X-Auth-Token FT/ya7B3vBlq5yvVYf/z6T6LX2VcKSHxjerq3lqxznQ=;
   }
   location = /graphql/dgraph/query {
     # Adding rate limiting
     limit_req zone=play;
-    proxy_pass http://127.0.0.1:8081/query;
+    proxy_pass https://erect-effect.us-west-2.aws.cloud.dgraph.io/query;
+    proxy_set_header X-Auth-Token FT/ya7B3vBlq5yvVYf/z6T6LX2VcKSHxjerq3lqxznQ=;
   }
   location = /graphql/dgraph/health {
     # Adding rate limiting
     limit_req zone=play;
-    proxy_pass http://127.0.0.1:8081/health;
+    proxy_pass https://erect-effect.us-west-2.aws.cloud.dgraph.io/health;
+    proxy_set_header X-Auth-Token FT/ya7B3vBlq5yvVYf/z6T6LX2VcKSHxjerq3lqxznQ=;
   }
   location = /graphql/dgraph/ui/keywords {
     # Adding rate limiting
     limit_req zone=play;
-    proxy_pass http://127.0.0.1:8081/ui/keywords;
+    proxy_pass https://erect-effect.us-west-2.aws.cloud.dgraph.io/ui/keywords;
+    proxy_set_header X-Auth-Token FT/ya7B3vBlq5yvVYf/z6T6LX2VcKSHxjerq3lqxznQ=;
   }
 
   location / {


### PR DESCRIPTION
changed the graphql and graphql+- endpoints

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/234)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-cb29087a7d17664-93671.surge.sh/?local)
<!-- Dgraph:end -->