### PR TITLE
Update link to indexing docs

### DIFF
--- a/client/src/components/schema/SchemaPredicateForm.js
+++ b/client/src/components/schema/SchemaPredicateForm.js
@@ -319,7 +319,7 @@ export default class SchemaPredicateForm extends React.Component {
             <div style={{ marginTop: "5px" }}>
                 Need help with indexing?{" "}
                 <a
-                    href="https://docs.dgraph.io/query-language/#indexing"
+                    href="https://docs.dgraph.io/query-language/schema/#indexing"
                     target="_blank"
                     rel="noopener noreferrer"
                 >


### PR DESCRIPTION
The link to [indexing](https://dgraph.io/docs/query-language/schema/#indexing) in the docs has changed, I've updated the `Need help with indexing?` link accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/235)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-2d86d6e436e9879-93898.surge.sh/?local)
<!-- Dgraph:end -->