### PR TITLE
test(e2e): Remove Dgraph's lru_mb flag from docker-compose.yml.

### DIFF
--- a/client/src/e2etests/docker-compose.dev.yml
+++ b/client/src/e2etests/docker-compose.dev.yml
@@ -40,6 +40,6 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --my=server:8080 --lru_mb=2048 --zero=zero:5080 --acl_secret_file=/secrets/acl-secret.txt
+    command: dgraph alpha --my=server:8080 --zero=zero:5080 --acl_secret_file=/secrets/acl-secret.txt
 volumes:
   dgraph:

--- a/client/src/e2etests/docker-compose.prod.yml
+++ b/client/src/e2etests/docker-compose.prod.yml
@@ -39,7 +39,6 @@ services:
     restart: on-failure
     command: dgraph alpha
       --my=alpha:8080
-      --lru_mb=2048
       --zero=zero:5080
       --acl_secret_file=/secrets/acl-secret.txt
       --whitelist 1.0.0.0:255.255.255.255


### PR DESCRIPTION
The lru_mb flag was removed in Dgraph master in dgraph-io/dgraph#6629.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/236)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-03a60aa662f49ca-101614.surge.sh/?local)
<!-- Dgraph:end -->