### PR TITLE
client/public: fix spelling in loader template

### DIFF
--- a/client/public/loader.html
+++ b/client/public/loader.html
@@ -16,7 +16,7 @@
         </h6>
 
         <p class="card-text">
-          Includes latest unreleased improvements, features, experiments, sometimes bugs. Feeback is welcome in
+          Includes latest unreleased improvements, features, experiments, sometimes bugs. Feedback is welcome in
           <a href='https://discuss.dgraph.io' target=_blank>Discuss</a>
         </p>
         <a href='/?dev' class='card-link'>
@@ -47,7 +47,7 @@
           Works Offline. Never auto-updates
         </h6>
 
-        <p class='card-text'>This version of the UI was compiled into your ratel binary. It doesn't require internet connection to run, but will never get updated unless you install a new version of Ratel.</p>
+        <p class='card-text'>This version of the UI was compiled into your Ratel binary. It doesn't require internet connection to run, but will never get updated unless you install a new version of Ratel.</p>
         <a href='/?local' class='card-link'>
           <i class='icon-launch'></i> Launch Offline
         </a>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/237)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-8dd6d6e1790e7b6-109504.surge.sh/?local)
<!-- Dgraph:end -->