### PR TITLE
Fix Geo viewer bug.

### DIFF
--- a/client/src/components/ConsolePage/GeoView.js
+++ b/client/src/components/ConsolePage/GeoView.js
@@ -252,7 +252,7 @@ export default function GeoView({ results }) {
     const handleShow = () => setShowOptions(true);
 
     // Render starts here
-    const locations = parseResults(results);
+    const locations = parseResults(results).filter(e => e.location.type);
     const bounds =
         locations.length > 0 ? calculateBounds(locations) : undefined;
     const center = locations.length > 0 ? bounds.getCenter() : [0, 0];


### PR DESCRIPTION
This will filter all results that don't have the type field. This will prevent the bug from occurring again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/242)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-54d67221809a7c9-116244.surge.sh/?local)
<!-- Dgraph:end -->