### PR TITLE
Fix: removes url from being truncated

### DIFF
--- a/client/src/components/Cluster/ClusterPage.scss
+++ b/client/src/components/Cluster/ClusterPage.scss
@@ -109,8 +109,8 @@
             border: 1px solid #ccc;
             display: flex;
             flex-direction: row;
+            flex-wrap: wrap;
             margin: 8px 8px 0;
-            max-width: 180px;
             padding: 8px;
             position: relative;
             white-space: nowrap;

--- a/client/src/components/Cluster/ClusterPage.scss
+++ b/client/src/components/Cluster/ClusterPage.scss
@@ -51,6 +51,10 @@
         flex-direction: row;
         flex-wrap: wrap;
 
+        @media (max-width: 1300px) {
+            display: block;
+        }
+
         .group {
             flex: 1;
             min-height: calc(max(22vw, 200px));


### PR DESCRIPTION
<img width="1788" alt="Screenshot 2021-02-09 at 12 15 19 AM" src="https://user-images.githubusercontent.com/9936881/107268058-abb9eb80-6a6d-11eb-84d3-b67f8a71d55a.png">
<img width="1618" alt="Screenshot 2021-02-09 at 12 15 42 AM" src="https://user-images.githubusercontent.com/9936881/107268082-b1afcc80-6a6d-11eb-9451-785baa8fd364.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/246)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-9f5eaf4ce03c620-121532.surge.sh/?local)
<!-- Dgraph:end -->