### PR TITLE
Adding support for X-Dgraph-AuthToken header

### DIFF
--- a/client/src/actions/connection.js
+++ b/client/src/actions/connection.js
@@ -31,6 +31,7 @@ export const SET_ACL_ENABLED = "connection/SET_ACL_ENABLED";
 export const SET_BACKUP_ENABLED = "connection/SET_BACKUP_ENABLED";
 export const SET_QUERY_TIMEOUT = "connection/SET_QUERY_TIMEOUT";
 export const SET_SLASH_API_KEY = "connection/SET_SLASH_API_KEY";
+export const SET_AUTH_TOKEN = "connection/SET_AUTH_TOKEN";
 export const REMOVE_URL = "connection/REMOVE_URL";
 export const UPDATE_URL = "connection/UPDATE_URL";
 export const UPDATE_ACL_STATE = "connection/UPDATE_ACL_STATE";
@@ -67,6 +68,14 @@ export function setSlashApiKey(url, slashApiKey) {
         type: SET_SLASH_API_KEY,
         url,
         slashApiKey,
+    };
+}
+
+export function setAuthToken(url, authToken) {
+    return {
+        type: SET_AUTH_TOKEN,
+        url,
+        authToken,
     };
 }
 

--- a/client/src/components/ServerConnectionModal.js
+++ b/client/src/components/ServerConnectionModal.js
@@ -153,6 +153,22 @@ export default function ServerConnectionModal() {
                             }
                         />
                     </Form.Group>
+                    <Form.Group controlId="authToken">
+                        <Form.Label>Auth Token:</Form.Label>
+                        <Form.Control
+                            type="text"
+                            placeholder="Auth Token"
+                            value={activeServer.authToken || ""}
+                            onChange={e =>
+                                dispatch(
+                                    actions.setAuthToken(
+                                        activeServer.url,
+                                        e.target.value,
+                                    ),
+                                )
+                            }
+                        />
+                    </Form.Group>
                 </Tab>
             </Tabs>
         );

--- a/client/src/containers/AppProvider.js
+++ b/client/src/containers/AppProvider.js
@@ -22,7 +22,12 @@ import ReduxThunk from "redux-thunk";
 
 import { getAddrParam, getHashParams } from "lib/helpers";
 import { runQuery, setResultsTab } from "actions/frames";
-import { loginUser, setSlashApiKey, updateUrl } from "actions/connection";
+import {
+    loginUser,
+    setSlashApiKey,
+    setAuthToken,
+    updateUrl
+} from "actions/connection";
 import {
     migrateToServerConnection,
     migrateToHaveZeroUrl,
@@ -116,6 +121,14 @@ export default class AppProvider extends React.Component {
                 setSlashApiKey(
                     hashParams.addr || addrParam,
                     hashParams.slashApiKey,
+                ),
+            );
+        }
+        if (hashParams.authToken) {
+            store.dispatch(
+                setAuthToken(
+                    hashParams.addr || addrParam,
+                    hashParams.authToken,
                 ),
             );
         }

--- a/client/src/lib/helpers.js
+++ b/client/src/lib/helpers.js
@@ -111,6 +111,10 @@ export function setCurrentServerSlashApiKey(slashApiKey) {
     clientStubOptions.headers["X-Auth-Token"] = slashApiKey;
 }
 
+export function setCurrentServerAuthToken(authToken) {
+    clientStubOptions.headers["X-Dgraph-AuthToken"] = authToken;
+}
+
 export const getDgraphClient = async () =>
     (await createDgraphClient(dgraphServerUrl)).client;
 

--- a/client/src/reducers/connection.js
+++ b/client/src/reducers/connection.js
@@ -25,6 +25,7 @@ import {
     SET_BACKUP_ENABLED,
     SET_QUERY_TIMEOUT,
     SET_SLASH_API_KEY,
+    SET_AUTH_TOKEN,
     REMOVE_URL,
     UPDATE_URL,
     UPDATE_ACL_STATE,
@@ -41,6 +42,7 @@ import {
     getDefaultUrl,
     setCurrentServerQueryTimeout,
     setCurrentServerSlashApiKey,
+    setCurrentServerAuthToken,
     setCurrentServerUrl,
     sanitizeUrl,
 } from "lib/helpers";
@@ -71,6 +73,7 @@ const makeServerRecord = url => ({
     aclState: Unknown,
     queryTimeout: QUERY_TIMEOUT_DEFAULT,
     slashApiKey: null,
+    accessToken: null,
     isAclEnabled: true,
     isBackupEnabled: true,
 
@@ -187,6 +190,13 @@ export default (state = defaultState, action) =>
                 activeServer.slashApiKey = action.slashApiKey;
                 if (action.url === currentServer.url) {
                     setCurrentServerSlashApiKey(activeServer.slashApiKey);
+                }
+                break;
+            case SET_AUTH_TOKEN:
+                assert(action.url, "This action requires url " + action.type);
+                activeServer.authToken = action.authToken;
+                if (action.url === currentServer.url) {
+                    setCurrentServerAuthToken(activeServer.authToken);
                 }
                 break;
 


### PR DESCRIPTION
This PR addresses the issue raised [here](https://discuss.dgraph.io/t/add-poor-man-s-auth-to-ratel-ui/8065) (and originally in #224) by adding a new "Auth Token" setting to the "Extra Settings" tab in the server connection modal. The inputted value will then be sent as the `X-Dgraph-AuthToken` HTTP header on requests to the server.

I'm not familar with the Ratel codebase, so it's possible that I've missed something! I've followed the same pattern used for the Slash API Key for consistency.

When I ran `./scripts/build.prod.sh` it made updates to `yarn.lock` and `package-lock.json`, however I presumed these changes should not be commited as this PR does not introduce any new depedencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/248)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-3de89d570403282-123792.surge.sh/?local)
<!-- Dgraph:end -->