### PR TITLE
Add Namespace to login Modal and check for multi tenancy

### DIFF
--- a/client/src/actions/connection.js
+++ b/client/src/actions/connection.js
@@ -254,7 +254,7 @@ const loginError = (url, error) => ({
     url,
 });
 
-export const loginUser = (userid, password, refreshToken) => async (
+export const loginUser = (userid, password, namespace, refreshToken) => async (
     dispatch,
     getState,
 ) => {
@@ -267,7 +267,12 @@ export const loginUser = (userid, password, refreshToken) => async (
     await new Promise(resolve => setTimeout(resolve, 500));
     try {
         const stub = await helpers.getDgraphClientStub();
-        await stub.login(userid, password, refreshToken);
+        await stub.loginIntoNamespace(
+            userid,
+            password,
+            namespace,
+            refreshToken,
+        );
         stub.setAutoRefresh(true);
         dispatch(loginSuccess(url, stub.getAuthTokens()));
     } catch (err) {

--- a/client/src/components/ServerConnectionModal.js
+++ b/client/src/components/ServerConnectionModal.js
@@ -102,7 +102,11 @@ export default function ServerConnectionModal() {
             >
                 <Tab eventKey="acl" title="ACL Account">
                     {isAclEnabled ? (
-                        <ServerLoginWidget />
+                        <ServerLoginWidget
+                            isMultiTenancyEnabled={
+                                activeServer.isMultiTenancyEnabled
+                            }
+                        />
                     ) : (
                         <em>
                             This server has unrestricted access (Access Control

--- a/client/src/components/ServerLoginWidget.js
+++ b/client/src/components/ServerLoginWidget.js
@@ -23,7 +23,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { loginUser, logoutUser } from "actions/connection";
 import { Fetching } from "lib/constants";
 
-export default function ServerLoginWidget() {
+export default function ServerLoginWidget({ isMultiTenancyEnabled }) {
     const currentServer = useSelector(
         state => state.connection.serverHistory[0],
     );
@@ -81,21 +81,23 @@ export default function ServerLoginWidget() {
                     }}
                 />
             </Form.Group>
-            <Form.Group controlId="namespaceInput">
-                <Form.Label>Namespace:</Form.Label>
-                <Form.Control
-                    type="number"
-                    placeholder="namespace"
-                    value={namespace}
-                    onChange={e => setNamespace(e.target.value)}
-                    style={{
-                        padding: "5px 8px",
-                        marginBottom: "16px",
-                        width: "100%",
-                        color: "black",
-                    }}
-                />
-            </Form.Group>
+            {isMultiTenancyEnabled && (
+                <Form.Group controlId="namespaceInput">
+                    <Form.Label>Namespace:</Form.Label>
+                    <Form.Control
+                        type="number"
+                        placeholder="namespace"
+                        value={namespace}
+                        onChange={e => setNamespace(e.target.value)}
+                        style={{
+                            padding: "5px 8px",
+                            marginBottom: "16px",
+                            width: "100%",
+                            color: "black",
+                        }}
+                    />
+                </Form.Group>
+            )}
             <Button
                 disabled={loginPending || !userid.trim()}
                 variant="primary"

--- a/client/src/components/ServerLoginWidget.js
+++ b/client/src/components/ServerLoginWidget.js
@@ -34,12 +34,13 @@ export default function ServerLoginWidget() {
     const loggedIn = token && jwtUserid;
     const [userid, setUserid] = React.useState(jwtUserid || "groot");
     const [password, setPassword] = React.useState("");
+    const [namespace, setNamespace] = React.useState(0);
 
     const loginPending = currentServer.loginStatus === Fetching;
     const loginError = currentServer.loginError;
 
-    const onLogin = (userid, password, refreshToken) => {
-        dispatch(loginUser(userid, password, refreshToken));
+    const onLogin = (userid, password, namespace, refreshToken) => {
+        dispatch(loginUser(userid, password, Number(namespace), refreshToken));
         setPassword("");
     };
 
@@ -80,10 +81,25 @@ export default function ServerLoginWidget() {
                     }}
                 />
             </Form.Group>
+            <Form.Group controlId="namespaceInput">
+                <Form.Label>Namespace:</Form.Label>
+                <Form.Control
+                    type="number"
+                    placeholder="namespace"
+                    value={namespace}
+                    onChange={e => setNamespace(e.target.value)}
+                    style={{
+                        padding: "5px 8px",
+                        marginBottom: "16px",
+                        width: "100%",
+                        color: "black",
+                    }}
+                />
+            </Form.Group>
             <Button
                 disabled={loginPending || !userid.trim()}
                 variant="primary"
-                onClick={() => onLogin(userid, password)}
+                onClick={() => onLogin(userid, password, namespace)}
                 type="submit"
             >
                 {loginPending ? (

--- a/client/src/reducers/connection.js
+++ b/client/src/reducers/connection.js
@@ -57,6 +57,7 @@ import {
     SERVER_HISTORY_LENGTH,
     Unknown,
 } from "lib/constants";
+import { SET_MULTI_TENANCY_ENABLED } from "../actions/connection";
 
 const assert = (test, message = "No message") => {
     if (!test) {
@@ -173,6 +174,11 @@ export default (state = defaultState, action) =>
             case SET_ACL_ENABLED:
                 assert(action.url, "This action requires url " + action.type);
                 activeServer.isAclEnabled = action.isAclEnabled;
+                break;
+            case SET_MULTI_TENANCY_ENABLED:
+                assert(action.url, "This actions requires url", +action.type);
+                activeServer.isMultiTenancyEnabled =
+                    action.isMultiTenancyEnabled;
                 break;
             case SET_BACKUP_ENABLED:
                 assert(action.url, "This action requires url " + action.type);


### PR DESCRIPTION
This will not work until https://github.com/dgraph-io/dgraph-js-http makes it next release which support multi tenant

This PR is using a function (loginIntoNamespace) which was recently added in js client.

I tested this locally using `npm link` which points to master of above js client

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/250)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-a267c94e4ca5d77-127948.surge.sh/?local)
<!-- Dgraph:end -->