### PR TITLE
test: Fix Docker set up.

### DIFF
--- a/client/src/e2etests/docker-compose.prod.yml
+++ b/client/src/e2etests/docker-compose.prod.yml
@@ -12,12 +12,6 @@ services:
 
   zero:
     image: dgraph/dgraph:master
-    volumes:
-      - type: volume
-        source: dgraph
-        target: /dgraph
-        volume:
-          nocopy: true
     ports:
       - 5080:5080
       - 6080:6080
@@ -27,11 +21,6 @@ services:
   alpha:
     image: dgraph/dgraph:master
     volumes:
-      - type: volume
-        source: dgraph
-        target: /dgraph
-        volume:
-          nocopy: true
       - ./acl-secret.txt:/secrets/acl-secret.txt
     ports:
       - 8080:8080
@@ -42,6 +31,3 @@ services:
       --zero=zero:5080
       --acl='secret-file=/secrets/acl-secret.txt;'
       --security='whitelist=1.0.0.0:255.255.255.255;'
-
-volumes:
-  dgraph:

--- a/client/src/e2etests/docker-compose.prod.yml
+++ b/client/src/e2etests/docker-compose.prod.yml
@@ -40,8 +40,8 @@ services:
     command: dgraph alpha
       --my=alpha:8080
       --zero=zero:5080
-      --acl_secret_file=/secrets/acl-secret.txt
-      --whitelist 1.0.0.0:255.255.255.255
+      --acl='secret-file=/secrets/acl-secret.txt;'
+      --security='whitelist=1.0.0.0:255.255.255.255;'
 
 volumes:
   dgraph:

--- a/client/src/e2etests/docker-compose.prod.yml
+++ b/client/src/e2etests/docker-compose.prod.yml
@@ -2,7 +2,7 @@
 # /scripts/build.prod.sh
 version: "3.7"
 services:
-  ratel-prod:
+  ratel:
     image: dgraph/dgraph:master
     ports:
       - 8000

--- a/client/src/e2etests/docker-compose.prod.yml
+++ b/client/src/e2etests/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
       - 9080
     restart: on-failure
     command: dgraph alpha
-      --my=alpha:8080
+      --my=alpha:7080
       --zero=zero:5080
       --acl='secret-file=/secrets/acl-secret.txt;'
       --security='whitelist=1.0.0.0:255.255.255.255;'

--- a/client/src/e2etests/docker-compose.prod.yml
+++ b/client/src/e2etests/docker-compose.prod.yml
@@ -5,7 +5,7 @@ services:
   ratel-prod:
     image: dgraph/dgraph:master
     ports:
-      - 8000:8000
+      - 8000
     volumes:
       - ../../../build/ratel:/ratel
     command: /ratel
@@ -13,8 +13,8 @@ services:
   zero:
     image: dgraph/dgraph:master
     ports:
-      - 5080:5080
-      - 6080:6080
+      - 5080
+      - 6080
     restart: on-failure
     command: dgraph zero --my=zero:5080
 
@@ -23,8 +23,8 @@ services:
     volumes:
       - ./acl-secret.txt:/secrets/acl-secret.txt
     ports:
-      - 8080:8080
-      - 9080:9080
+      - 8080
+      - 9080
     restart: on-failure
     command: dgraph alpha
       --my=alpha:8080

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -65,9 +65,9 @@ pushd "$dir" > /dev/null
   popd > /dev/null
 
   # Cleanup
-  # pushd "$composedir" > /dev/null
-  #   docker-compose down && docker-compose rm -f
-  # popd > /dev/null
+  pushd "$composedir" > /dev/null
+    docker-compose down && docker-compose rm -f
+  popd > /dev/null
 popd > /dev/null
 
 exit $testresults

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,18 +8,18 @@
 # "yarn test" runs on the local machine.
 
 function wait-for-healthy() {
-    printf "wait-for-healthy($1): Waiting for %s to return 200 OK\n" "$2"
+    echo "wait-for-healthy($1): Waiting for $2 to return 200 OK"
     tries=0
     until curl -sL -w "%{http_code}\\n" "$2" -o /dev/null | grep -q 200; do
         tries=$tries+1
         if [[ $tries -gt 300 ]]; then
-            printf "wait-for-healthy($1): Took longer than 1 minute to be healthy.\n"
-            printf "wait-for-healthy($1): Waiting stopped.\n"
+            echo "wait-for-healthy($1): Took longer than 1 minute to be healthy."
+            echo "wait-for-healthy($1): Waiting stopped."
             return 1
         fi
         sleep 0.2
     done
-    printf "wait-for-healthy($1): Done.\n"
+    echo "wait-for-healthy($1): Done."
 }
 
 dir="$( cd "$( printf '%s' "${BASH_SOURCE[0]%/*}" )" && pwd )"
@@ -53,8 +53,8 @@ pushd "$dir" > /dev/null
   ratelport="$(docker container port e2etests_ratel_1 8000 | awk -F':' '{print $2}')"
   alphaport="$(docker container port e2etests_alpha_1 8080 | awk -F':' '{print $2}')"
 
-  wait-for-healthy "Alpha" localhost:$alphaport/health
-  wait-for-healthy "Ratel" localhost:$ratelport
+  wait-for-healthy "Alpha" "localhost:$alphaport/health"
+  wait-for-healthy "Ratel" "localhost:$ratelport"
 
   # Run tests
   pushd "$clientdir" > /dev/null

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -64,12 +64,11 @@ pushd "$dir" > /dev/null
     testresults="$?"
   popd > /dev/null
 
-  if [ $testresults != 0 ]; then
-      docker-compose logs
-  fi
-
   # Cleanup
   pushd "$composedir" > /dev/null
+    if [ $testresults != 0 ]; then
+      docker-compose logs
+    fi
     docker-compose down && docker-compose rm -f
   popd > /dev/null
 popd > /dev/null

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,7 +8,7 @@
 # "yarn test" runs on the local machine.
 
 function wait-for-healthy() {
-    printf 'wait-for-healthy($1): Waiting for %s to return 200 OK\n' "$2"
+    printf "wait-for-healthy($1): Waiting for %s to return 200 OK\n" "$2"
     tries=0
     until curl -sL -w "%{http_code}\\n" "$2" -o /dev/null | grep -q 200; do
         tries=$tries+1
@@ -50,7 +50,7 @@ pushd "$dir" > /dev/null
 
   # Verifying that the docker containers are up and running
   docker ps
-  ratelport="$(docker container port e2etests_ratel-prod_1 8080 | awk -F':' '{print $2}')"
+  ratelport="$(docker container port e2etests_ratel_1 8000 | awk -F':' '{print $2}')"
   alphaport="$(docker container port e2etests_alpha_1 8080 | awk -F':' '{print $2}')"
 
   wait-for-healthy "Alpha" localhost:$alphaport/health
@@ -65,9 +65,9 @@ pushd "$dir" > /dev/null
   popd > /dev/null
 
   # Cleanup
-  pushd "$composedir" > /dev/null
-    docker-compose down && docker-compose rm -f
-  popd > /dev/null
+  # pushd "$composedir" > /dev/null
+  #   docker-compose down && docker-compose rm -f
+  # popd > /dev/null
 popd > /dev/null
 
 exit $testresults

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -64,7 +64,7 @@ pushd "$dir" > /dev/null
     testresults="$?"
   popd > /dev/null
 
-  if ! [ $testresults != 0 ]; then
+  if [ $testresults != 0 ]; then
       docker-compose logs
   fi
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -64,6 +64,10 @@ pushd "$dir" > /dev/null
     testresults="$?"
   popd > /dev/null
 
+  if ! [ $testresults != 0 ]; then
+      docker-compose logs
+  fi
+
   # Cleanup
   pushd "$composedir" > /dev/null
     docker-compose down && docker-compose rm -f

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,18 +8,18 @@
 # "yarn test" runs on the local machine.
 
 function wait-for-healthy() {
-    printf 'wait-for-healthy: Waiting for %s to return 200 OK\n' "$1"
+    printf 'wait-for-healthy($1): Waiting for %s to return 200 OK\n' "$2"
     tries=0
-    until curl -sL -w "%{http_code}\\n" "$1" -o /dev/null | grep -q 200; do
+    until curl -sL -w "%{http_code}\\n" "$2" -o /dev/null | grep -q 200; do
         tries=$tries+1
         if [[ $tries -gt 300 ]]; then
-            printf "wait-for-healthy: Took longer than 1 minute to be healthy.\n"
-            printf "wait-for-healthy: Waiting stopped.\n"
+            printf "wait-for-healthy($1): Took longer than 1 minute to be healthy.\n"
+            printf "wait-for-healthy($1): Waiting stopped.\n"
             return 1
         fi
         sleep 0.2
     done
-    printf "wait-for-healthy: Done.\n"
+    printf "wait-for-healthy($1): Done.\n"
 }
 
 dir="$( cd "$( printf '%s' "${BASH_SOURCE[0]%/*}" )" && pwd )"
@@ -50,11 +50,11 @@ pushd "$dir" > /dev/null
 
   # Verifying that the docker containers are up and running
   docker ps
-  ratelport="$(docker container port e2etests_ratel_1 8080 | awk -F':' '{print $2}')"
+  ratelport="$(docker container port e2etests_ratel-prod_1 8080 | awk -F':' '{print $2}')"
   alphaport="$(docker container port e2etests_alpha_1 8080 | awk -F':' '{print $2}')"
 
-  wait-for-healthy localhost:$alphaport/health
-  wait-for-healthy localhost:$ratelport
+  wait-for-healthy "Alpha" localhost:$alphaport/health
+  wait-for-healthy "Ratel" localhost:$ratelport
 
   # Run tests
   pushd "$clientdir" > /dev/null

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -50,13 +50,16 @@ pushd "$dir" > /dev/null
 
   # Verifying that the docker containers are up and running
   docker ps
-  wait-for-healthy localhost:8080/health
-  wait-for-healthy localhost:8000
+  ratelport="$(docker container port e2etests_ratel_1 8080 | awk -F':' '{print $2}')"
+  alphaport="$(docker container port e2etests_alpha_1 8080 | awk -F':' '{print $2}')"
+
+  wait-for-healthy localhost:$alphaport/health
+  wait-for-healthy localhost:$ratelport
 
   # Run tests
   pushd "$clientdir" > /dev/null
     # Workaround: Use ?local to run production Ratel builds for e2e tests
-    TEST_DGRAPH_SERVER="http://localhost:8080" TEST_RATEL_URL="http://localhost:8000?local" \
+    TEST_DGRAPH_SERVER="http://localhost:$alphaport" TEST_RATEL_URL="http://localhost:$ratelport?local" \
       npm test -- --runInBand --testTimeout 40000 --watchAll=false
     testresults="$?"
   popd > /dev/null


### PR DESCRIPTION
The static port test setup makes it harder to run tests and causes test failures in CI. This PR addresses fixes the test with the folllowing:

* Not using fixed ports. Expose random ports for Dgraph and Dgraph Ratel and test against those.
* Not persisting data in volumes. They're not needed for tests that are temporary.

CI agent setup: Installed dependencies for Puppeteer via `apt-get`:
https://github.com/puppeteer/puppeteer/blob/4607d5a2d3e37715e277a9d634a533f658c70bcc/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/260)
<!-- Reviewable:end -->
 
 
 
 
 
 
<!-- Dgraph:start -->
Ratel Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/36b847cb0bc328b98e11d84c1b3e4cd0a93484f8/ratel.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ratel-60b523c813afd6e-131318.surge.sh/?local)
<!-- Dgraph:end -->