### PR TITLE
play: Enable TLS SNI for Dgraph Play queries

### DIFF
--- a/server/play-dgraph-io.nginx.conf
+++ b/server/play-dgraph-io.nginx.conf
@@ -4,6 +4,7 @@ limit_req_zone $binary_remote_addr zone=play:10m rate=1000r/s;
 server {
   listen      80;
   server_name play.dgraph.io www.play.dgraph.io play-master.dgraph.io www.play-master.dgraph.io;
+  proxy_ssl_server_name on;
 
   location /query {
     # Adding rate limiting
@@ -19,7 +20,6 @@ server {
     set $args $args${delimeter}be=true;
 
     # Pass to the Dgraph Alpha running on this machine
-    proxy_ssl_server_name on;
     proxy_pass https://crooked-advertisement.us-west-2.aws.cloud.dgraph.io;
     proxy_set_header X-Auth-Token rFixJ0UBTQrtoyF8ZWA4ChoaGjqPthPGFtrofqvVB6g=;
 
@@ -38,7 +38,6 @@ server {
     # Adding rate limiting
     limit_req zone=play burst=20;
     # Pass to the Dgraph Alpha running on this machine
-    proxy_ssl_server_name on;
     proxy_pass https://crooked-advertisement.us-west-2.aws.cloud.dgraph.io;
     proxy_set_header X-Auth-Token rFixJ0UBTQrtoyF8ZWA4ChoaGjqPthPGFtrofqvVB6g=;
   }

--- a/server/play-dgraph-io.nginx.conf
+++ b/server/play-dgraph-io.nginx.conf
@@ -1,5 +1,5 @@
 proxy_cache_path /var/nginx levels=1:2 keys_zone=dgraphcache:20m max_size=1g inactive=60m use_temp_path=off;
-limit_req_zone $binary_remote_addr zone=play:10m rate=100r/s;
+limit_req_zone $binary_remote_addr zone=play:10m rate=1000r/s;
 
 server {
   listen      80;
@@ -19,6 +19,7 @@ server {
     set $args $args${delimeter}be=true;
 
     # Pass to the Dgraph Alpha running on this machine
+    proxy_ssl_server_name on;
     proxy_pass https://crooked-advertisement.us-west-2.aws.cloud.dgraph.io;
     proxy_set_header X-Auth-Token rFixJ0UBTQrtoyF8ZWA4ChoaGjqPthPGFtrofqvVB6g=;
 
@@ -37,6 +38,7 @@ server {
     # Adding rate limiting
     limit_req zone=play burst=20;
     # Pass to the Dgraph Alpha running on this machine
+    proxy_ssl_server_name on;
     proxy_pass https://crooked-advertisement.us-west-2.aws.cloud.dgraph.io;
     proxy_set_header X-Auth-Token rFixJ0UBTQrtoyF8ZWA4ChoaGjqPthPGFtrofqvVB6g=;
   }


### PR DESCRIPTION
This sets `proxy_ssl_server_name` so that the SNI is used in the TLS proxy connection.

Without this, nginx won't be able to connect to the upstream backends. These logs show up in error.log:
```
2021/05/04 15:48:55 [error] 22269#22269: *42 no live upstreams while connecting to upstream, client: 172.69.79.178, server: play.dgraph.io, request: "GET /health HTTP/1.1", upstream: "https://crooked-advertisement.us-west-2.aws.cloud.dgraph.io/health", host: "play.dgraph.io", referrer: "https://play.dgraph.io/?latest"

<...nginx reload...>

2021/05/04 15:51:10 [error] 23517#23517: *120 SSL_do_handshake() failed (SSL: error:14094438:SSL routines:ssl3_read_bytes:tlsv1 alert internal error:SSL alert number 80) while SSL handshaking to upstream, client: $IP, server: play.dgraph.io, request: "POST /query?timeout=20s HTTP/1.1", upstream: "https://$IP:443/query?timeout=20s&be=true", host: "play.dgraph.io", referrer: "https://play.dgraph.io/?latest"
```

This fixes connection issues for queries running in:
* the Dgraph docs (e.g., https://dgraph.io/docs/query-language/functions), and
* the GraphQL Tour (e.g., https://dgraph.io/tour/graphqlmoredata/2/).

This PR also bumps up the limit requests on Play so that more traffic can get through.

References:
* https://stackoverflow.com/a/38401715
* http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/266)
<!-- Reviewable:end -->
