### PR TITLE
bugfix: fix bug on userpane

### DIFF
--- a/client/src/components/ACL/UserDetailsPane.js
+++ b/client/src/components/ACL/UserDetailsPane.js
@@ -57,7 +57,7 @@ export default class UserDetailsPane extends React.Component {
         const groupColumns = [
             {
                 key: "membership",
-                name: " ",
+                name: "",
                 width: 32,
                 resizable: true,
                 formatter: cell => (
@@ -74,11 +74,12 @@ export default class UserDetailsPane extends React.Component {
                 resizable: true,
             },
             {
-                key: "acl",
-                name: "Predicates",
+                key: "groups",
+                name: "Predicate Count",
                 resizable: true,
-                formatter: ({ value: acl }) =>
-                    acl.filter(acl => acl.perm).length,
+                formatter: ({ row }) => {
+                    return row?.acl?.filter(a => a.perm).length;
+                },
             },
         ];
 


### PR DESCRIPTION
This bug has been there for long, some of the users has reported them on discuss.

Issue - Inside ACLs, on User list, When you click on any of the user, Page goes blank

Fix - There is no such key as `acl`, instead of acls, we have group and inside groups we have acls, we are showing predicate count in column.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/268)
<!-- Reviewable:end -->
