### PR TITLE
Initial build/publish system for docker image artifact

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 build/
 client/node_modules/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,43 @@
+######
 # Build Client
+####################
 FROM node:14-alpine as client
 
 RUN apk update && apk --no-cache --virtual build-dependencies add make git bash python3 gcc g++
-ADD . /ratel
 
-WORKDIR /ratel
-RUN scripts/build.prod.sh --client
+# build package manifest layer
+RUN mkdir -p /ratel/client
+WORKDIR /ratel/client
+COPY ./client/package.json /ratel/client
+RUN npm install --legacy-peer-deps
 
+# copy all asets and build
+COPY . /ratel
+RUN npm run build:prod
+
+######
 # Build Server
-FROM golang:1.16-alpine as server
+####################
+FROM golang:1.16.4-alpine as server
 
 RUN apk update && apk add git bash
-ADD . /ratel
+COPY . /ratel
 
 WORKDIR /ratel
-COPY --from=client /ratel/server/bindata.go server/bindata.go
+COPY --from=client /ratel/client/build /ratel/client/build
+RUN go get -u github.com/go-bindata/go-bindata/...
 RUN ./scripts/build.prod.sh --server
 
-
+######
 # Final Image
-FROM alpine:latest
+####################
+FROM alpine:latest as binary
 
-RUN apk add --no-cache ca-certificates && mkdir /ratel
-COPY --from=server /ratel/build/ratel /ratel/server
+RUN apk add --no-cache ca-certificates
+RUN addgroup -g 1000 dgraph && \
+    adduser -u 1000 -G dgraph -s /bin/sh -D dgraph
+COPY --from=server /ratel/build/ratel /usr/local/bin/dgraph-ratel
 EXPOSE 8000
+USER dgraph
 
-ENTRYPOINT exec /ratel/server
+CMD ["/usr/local/bin/dgraph-ratel"]

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ BUILD_VERSION  ?= $(shell git describe --always --tags)
 
 MODIFIED = $(shell git diff-index --quiet HEAD || echo "-mod")
 
+.PHONY: version test build latest release push help
+
 version:
 	@echo Ratel ${BUILD_VERSION}
 	@echo Build: ${BUILD}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright 2020 Dgraph Labs, Inc. and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+BUILD          ?= $(shell git rev-parse --short HEAD)
+BUILD_CODENAME  = unnamed
+BUILD_DATE     ?= $(shell git log -1 --format=%ci)
+BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
+BUILD_VERSION  ?= $(shell git describe --always --tags)
+
+MODIFIED = $(shell git diff-index --quiet HEAD || echo "-mod")
+
+version:
+	@echo Ratel ${BUILD_VERSION}
+	@echo Build: ${BUILD}
+	@echo Codename: ${BUILD_CODENAME}${MODIFIED}
+	@echo Build date: ${BUILD_DATE}
+	@echo Branch: ${BUILD_BRANCH}
+	# requires GNU grep
+	@echo Go version: $(shell printf "go-%s" `grep -oP '(?<=golang:)[^-]*' Dockerfile`)
+
+test:
+	@echo Running Tests
+	@scripts/test.sh
+
+build:
+	@docker build -f Dockerfile -t dgraph/ratel:$(subst /,-,${BUILD_BRANCH}) .
+
+latest:
+	@docker tag dgraph/ratel:$(subst /,-,${BUILD_BRANCH}) dgraph/ratel:latest
+
+release: push tag_latest
+	@docker push dgraph/ratel:latest .
+
+push:
+	@docker push dgraph/ratel:$(subst /,-,${BUILD_BRANCH}) .
+
+help:
+	@echo
+	@echo Build commands:
+	@echo "  make build     - Build docker image"
+	@echo "  make test      - Runs tests"
+	@echo "  make push      - Push Docker Image with the current version tag to Docker Hub"
+	@echo "  make latest    - Tag the current Docker image as 'latest'"
+	@echo "  make release   - Push Docker image with the current version and 'latest' tags"
+	@echo "  make help      - This help"
+	@echo


### PR DESCRIPTION
The following features are added:

* makefile to build and push ratel docker image
* fixed issue with Dockerfile
* added package manifest in a separate docker image layer (best practices)
* added go-bindata install as separate docker image layer (best practices)
* run service in as unprivileged user dgraph (best practices)

None Goals:

* testing component is not updated; this needs to be updated, as it utilizes dgraph/dgraph:master image
* publishing binary artifacts not addressed in this release (currently manual process)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/269)
<!-- Reviewable:end -->
