### PR TITLE
Add systemd service file

### DIFF
--- a/server/dgraph-ui.service
+++ b/server/dgraph-ui.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=dgraph.io Web UI
+Wants=network.target
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/bash -c 'ratel'
+Restart=on-failure
+StandardOutput=journal
+StandardError=journal
+User=dgraph
+Group=dgraph
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The service file used to control ratel with systemd was [removed from the dgraph repo](https://github.com/dgraph-io/dgraph/commit/f896081ad6cb0d6b744f8ab067d22bb231724e98#diff-1e13425f1ca305593929f3c5080e3f9ba77bf902ec334ef18a18f5de62a80b1d) but has not yet been added here. This pull request just adds the service file to this repo, with the only modification being the new binary name.