### PR TITLE
fix: remove dgraph.group from create group

### DIFF
--- a/client/src/components/ACL/JsonDataAdapter.js
+++ b/client/src/components/ACL/JsonDataAdapter.js
@@ -150,7 +150,6 @@ export default function JsonDataAdapter(
         await executeMutation(`{
           set {
             <_:group> <dgraph.xid> ${JSON.stringify(groupName)} .
-            <_:group> <dgraph.group> "[]" .
             <_:group> <dgraph.type> "Group" .
           }
         }`);


### PR DESCRIPTION

dgraph.group was removed post 20.03 backends, I was not able to create group on cloud backend, with this fix, groups can be created.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/273)
<!-- Reviewable:end -->
