### PR TITLE
Update Dockerfile build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apk update && apk add git bash
 COPY . /ratel
 
 WORKDIR /ratel
+ENV CGO_ENABLED=0
 COPY --from=client /ratel/client/build /ratel/client/build
 RUN go get -u github.com/go-bindata/go-bindata/...
 RUN ./scripts/build.prod.sh --server


### PR DESCRIPTION
This is a fix to allow binaries compiled in on Alpine Linux to work in other distros like Debian/Ubuntu by adding `CGO_ENABLED=0 `.  Without this, there will be a dependency to `/lib/libc.musl-x86_64.so.1`, which won't exist on Ubuntu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/274)
<!-- Reviewable:end -->
