### PR TITLE
update build scripts to support metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,12 @@ COPY . /ratel
 
 WORKDIR /ratel
 ENV CGO_ENABLED=0
+ARG version
+ARG commitID
+ARG commitINFO
+
 COPY --from=client /ratel/client/build /ratel/client/build
-# instal go-bindata
+# install go-bindata
 RUN go get -u github.com/go-bindata/go-bindata/...
 RUN ./scripts/build.prod.sh --server
 

--- a/Makefile
+++ b/Makefile
@@ -14,23 +14,17 @@
 # limitations under the License.
 #
 
-BUILD          ?= $(shell git rev-parse --short HEAD)
-BUILD_CODENAME  = unnamed
-BUILD_DATE     ?= $(shell git log -1 --format=%ci)
-BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILD_VERSION  ?= $(shell git describe --always --tags)
-
-MODIFIED = $(shell git diff-index --quiet HEAD || echo "-mod")
+BUILD_COMMMIT_ID ?= $(shell git rev-parse --short HEAD)
+BUILD_COMMMIT_INFO ?= $(shell git show --pretty=format:"%h  %ad  %d" | head -n1)
 
 .PHONY: version test build latest release push help
 
 version:
 	@echo Ratel ${BUILD_VERSION}
-	@echo Build: ${BUILD}
-	@echo Codename: ${BUILD_CODENAME}${MODIFIED}
-	@echo Build date: ${BUILD_DATE}
-	@echo Branch: ${BUILD_BRANCH}
-	# requires GNU grep
+	@echo Commit ID: ${BUILD_COMMMIT_ID}
+	@echo Commit Info: "${BUILD_COMMMIT_INFO}"
+# requires GNU grep (BSD Grep will not work)
 	@echo Go version: $(shell printf "go-%s" `grep -oP '(?<=golang:)[^-]*' Dockerfile`)
 
 test:
@@ -38,7 +32,11 @@ test:
 	@scripts/test.sh
 
 build:
-	@docker build -f Dockerfile -t dgraph/ratel:${BUILD_VERSION} .
+	@docker build --file Dockerfile  \
+		--build-arg commitID=${BUILD_COMMMIT_ID} \
+		--build-arg commitINFO="${BUILD_COMMMIT_INFO}" \
+		--build-arg version=${BUILD_VERSION} \
+		--tag dgraph/ratel:${BUILD_VERSION} .
 
 latest: build
 	@docker tag dgraph/ratel:${BUILD_VERSION} dgraph/ratel:latest

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-client",
-  "version": "21.03.0",
+  "version": "v21.03.0",
   "description": "The user interface for interacting with Dgraph server",
   "license": "Apache-2.0",
   "repository": {

--- a/scripts/build.prod.sh
+++ b/scripts/build.prod.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 dir="$( cd "$( printf '%s' "${BASH_SOURCE[0]%/*}" )" && pwd )"
@@ -8,12 +7,12 @@ rootDir=$(git rev-parse --show-toplevel)
 # cd to the scripts directory
 pushd "$dir" > /dev/null
     # setting metadata and flags
-    version="$(grep -i '"version"' < "$rootDir/client/package.json" | awk -F '"' '{print $4}')"
+    version=${version:-"$(grep version.: $rootDir/client/package.json | cut -d'"' -f4)"}
     flagUploadToS3=false
     buildClientFiles=false
     buildServerBinary=false
-    commitID="$(git rev-parse --short HEAD)"
-    commitINFO="$(git show --pretty=format:"%h  %ad  %d" | head -n1)"
+    commitID=${commitID:-"$(git rev-parse --short HEAD)"}
+    commitINFO=${commitINFO:-"$(git show --pretty=format:"%h  %ad  %d" | head -n1)"}
 
     while [ "$1" != "" ]; do
         case $1 in

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -51,8 +51,8 @@ function buildServer {
 
     # Declaring variables used which are assigned in build script
     declare go_bindata
-    declare commitID
-    declare commitINFO
+    # declare commitID
+    # declare commitINFO
 
     # Run bindata for all files in in client/build/ (recursive).
     go-bindata -fs -o ./server/bindata.go -pkg server -prefix "./client/build" -ignore=DS_Store ./client/build/...


### PR DESCRIPTION
Currently `dgraph-ratel -version` binary does not report any metadata despite code support for metadata.  This PR will do the following:

* fix `commitID` and `commitINFO` that were set to empty strings
* support passing in `commitID`, `commitINFO`, and `version` externally
* support building building metadata version with docker and make.

### Not Goals

The designated key names and value content have not been changed, using it as is.  The metadata for commitINFO is bizarre, and I don't understand the original intention for this:

```
Ratel Version: v21.03.0-16-g5ec15c3
Commit ID: 9debcc4
Commit Info: 9debcc4¨•¨¨•¨Fri¨•¨May¨•¨28¨•¨14:57:46¨•¨2021¨•¨-0700¨•¨¨•¨¨•¨(HEAD¨•¨->¨•¨joaquin/build-meta-update,¨•¨origin/master,¨•¨origin/HEAD,¨•¨master)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ratel/275)
<!-- Reviewable:end -->
