### PR TITLE
Change outdated command in INSTRUCTIONS.md

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -25,7 +25,7 @@ PS. This was tested in Windows 11. Using Docker and WSL.
 ### 1. Download the repository
 
 ```sh
-go get -u github.com/dgraph-io/ratel
+go install github.com/dgraph-io/ratel@latest
 ```
 
 You may see errors when you run the above command:


### PR DESCRIPTION
Hello,

Since Go 1.16 `go get` for global installs is no longer supported:

```console
$ go get -u github.com/dgraph-io/ratel                                                                                                                                                                                                                                                                                                                           
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

Nowadays, you should use `go install` for global installs.

Best regards,
Maciej Błędkowski 