### PR TITLE
feat: overhaul graph visualization (Neo4j/ArangoDB-inspired)

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -98,6 +98,30 @@ export USE_DOCKER=1
 make test
 ```
 
+## Code style and formatting
+
+Formatting is enforced by [Trunk](https://docs.trunk.io), configured in
+[`.trunk/trunk.yaml`](.trunk/trunk.yaml). Trunk routes each file type to a formatter:
+
+- **JS / JSX / JSON** → Biome, configured in
+  [`.trunk/configs/biome.json`](.trunk/configs/biome.json)
+- **SCSS / CSS / Markdown / YAML** → Prettier, configured in
+  [`.trunk/configs/.prettierrc`](.trunk/configs/.prettierrc)
+
+For JS this repo's Biome config is **2-space indent, single quotes, and no semicolons** — which
+differs from Biome's out-of-the-box defaults (tabs, double quotes, semicolons). So format through
+the repo config rather than an editor's bundled formatter, or you'll churn every file you touch and
+fail CI:
+
+```bash
+cd client/
+npm run lint   # runs `trunk fmt` against the repo config
+```
+
+If your editor formats on save, point its Biome/Prettier integration at the configs under
+`.trunk/configs/` (the Trunk VSCode extension does this automatically), or turn format-on-save off
+and rely on `npm run lint`.
+
 ## Production build
 
 ```sh

--- a/client/package.json
+++ b/client/package.json
@@ -62,10 +62,19 @@
       "@babel/preset-react"
     ]
   },
-  "browserslist": [">2%", "last 3 versions", "Firefox ESR", "not ie < 9"],
+  "browserslist": [
+    ">2%",
+    "last 3 versions",
+    "Firefox ESR",
+    "not ie < 9"
+  ],
   "jest": {
-    "collectCoverageFrom": ["src/**/*.{js,jsx,mjs}"],
-    "setupFiles": ["<rootDir>/config/polyfills.js"],
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx,mjs}"
+    ],
+    "setupFiles": [
+      "<rootDir>/config/polyfills.js"
+    ],
     "testEnvironment": "jsdom",
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}",
@@ -77,8 +86,12 @@
       "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|mjs|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
-    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"],
-    "modulePaths": ["./src/"],
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"
+    ],
+    "modulePaths": [
+      "./src/"
+    ],
     "moduleNameMapper": {
       "^react-native$": "react-native-web"
     },

--- a/client/package.json
+++ b/client/package.json
@@ -62,19 +62,10 @@
       "@babel/preset-react"
     ]
   },
-  "browserslist": [
-    ">2%",
-    "last 3 versions",
-    "Firefox ESR",
-    "not ie < 9"
-  ],
+  "browserslist": [">2%", "last 3 versions", "Firefox ESR", "not ie < 9"],
   "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx,mjs}"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/polyfills.js"
-    ],
+    "collectCoverageFrom": ["src/**/*.{js,jsx,mjs}"],
+    "setupFiles": ["<rootDir>/config/polyfills.js"],
     "testEnvironment": "jsdom",
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}",
@@ -86,12 +77,8 @@
       "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|mjs|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"
-    ],
-    "modulePaths": [
-      "./src/"
-    ],
+    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"],
+    "modulePaths": ["./src/"],
     "moduleNameMapper": {
       "^react-native$": "react-native-web"
     },

--- a/client/src/assets/css/EntitySelector.scss
+++ b/client/src/assets/css/EntitySelector.scss
@@ -1,7 +1,7 @@
 .entity-selector {
-  background: white;
-  border-top: 1px solid #d2d2d2;
-  padding: 10px;
+  background: #fff;
+  border-top: 1px solid #e8e8e8;
+  padding: 10px 12px;
   position: relative;
 
   transition: all 200ms;
@@ -9,7 +9,7 @@
 
   max-height: 85px;
   &.expanded {
-    max-height: 205px;
+    max-height: 250px;
 
     .toggle {
       transform-origin: center;
@@ -18,7 +18,7 @@
   }
 
   .toggle {
-    $size: 16px;
+    $size: 18px;
     $color: #848f99;
     background-color: #fff;
     border-color: $color;
@@ -29,24 +29,41 @@
     height: $size;
     padding: 0;
     position: absolute;
-    right: 6px;
+    right: 8px;
     transition: transform 400ms;
-    top: 6px;
+    top: 8px;
     width: $size;
   }
 }
 
 .label-container {
-  display: inline-block;
-  padding: 1px 7px 1.5px;
-  border-radius: 5px;
-  margin-right: 7px;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 12px;
+  margin-right: 6px;
   margin-bottom: 5px;
   font-size: 12px;
   font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border: 2px solid transparent;
+
+  &:hover {
+    transform: scale(1.05);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  }
+
+  .color-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 6px;
+    flex-shrink: 0;
+  }
 
   .label-value {
-    margin-right: 4px;
+    margin-right: 0;
   }
 
   .shorthand {

--- a/client/src/assets/css/Graph.scss
+++ b/client/src/assets/css/Graph.scss
@@ -17,10 +17,14 @@
   display: flex;
   flex: 1;
   position: relative;
+  background-color: #f8f9fa;
+  background-image:
+    radial-gradient(circle, #ddd 1px, transparent 1px);
+  background-size: 24px 24px;
 }
 
 .graph {
-  background-color: #fdfdfd;
+  background-color: #f8f9fa;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -40,9 +44,98 @@
 
 .partial-render-info {
   position: absolute;
-  padding: 2px 5px;
-  background: color.adjust(#fff, $alpha: -0.7);
-  box-shadow: #fff 0 0 18px 0;
+  padding: 6px 12px;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   z-index: 1;
   color: #5d5d5d;
+  font-size: 13px;
+  top: 52px;
+  left: 12px;
+}
+
+.graph-toolbar {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 10;
+}
+
+.graph-search {
+  display: flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 0 8px;
+  height: 36px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  transition: all 0.2s ease;
+
+  &.focused {
+    border-color: #4C8EDA;
+    box-shadow: 0 1px 6px rgba(76, 142, 218, 0.2);
+  }
+
+  .search-icon {
+    color: #999;
+    flex-shrink: 0;
+    margin-right: 6px;
+  }
+
+  input {
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: 13px;
+    width: 160px;
+    color: #333;
+
+    &::placeholder {
+      color: #aaa;
+    }
+  }
+}
+
+.graph-control-btn {
+  width: 36px;
+  height: 36px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.95);
+  color: #555;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+
+  &:hover {
+    background: #fff;
+    color: #333;
+    border-color: #bbb;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+.graph-stats {
+  position: absolute;
+  bottom: 8px;
+  left: 200px;
+  font-size: 12px;
+  color: #888;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 4px 10px;
+  border-radius: 4px;
+  z-index: 10;
+  pointer-events: none;
 }

--- a/client/src/assets/css/Graph.scss
+++ b/client/src/assets/css/Graph.scss
@@ -18,8 +18,7 @@
   flex: 1;
   position: relative;
   background-color: #f8f9fa;
-  background-image:
-    radial-gradient(circle, #ddd 1px, transparent 1px);
+  background-image: radial-gradient(circle, #ddd 1px, transparent 1px);
   background-size: 24px 24px;
 }
 
@@ -77,7 +76,7 @@
   transition: all 0.2s ease;
 
   &.focused {
-    border-color: #4C8EDA;
+    border-color: #4c8eda;
     box-shadow: 0 1px 6px rgba(76, 142, 218, 0.2);
   }
 

--- a/client/src/components/D3Graph/D3Graph.scss
+++ b/client/src/components/D3Graph/D3Graph.scss
@@ -12,4 +12,23 @@
     width: 100%;
     height: 100%;
   }
+
+  .graph-minimap {
+    position: absolute;
+    bottom: 32px;
+    left: 12px;
+    width: 180px;
+    height: 120px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 8px;
+    cursor: crosshair;
+    z-index: 5;
+    pointer-events: auto;
+    opacity: 0.9;
+    transition: opacity 0.2s;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
 }

--- a/client/src/components/D3Graph/index.js
+++ b/client/src/components/D3Graph/index.js
@@ -724,10 +724,10 @@ export default class D3Graph extends React.Component {
 
   createForces = () => {
     this.d3simulation
-      .alphaTarget(0.05)
-      .alphaMin(0.05005)
-      .alphaDecay(0.02)
-      .velocityDecay(0.3)
+      .alphaTarget(0)
+      .alphaMin(0.005)
+      .alphaDecay(0.05)
+      .velocityDecay(0.5)
       .force('link', d3.forceLink()
         .distance((d) => {
           const srcDeg = this.nodeDegrees.get(typeof d.source === 'object' ? d.source.id : d.source) || 1
@@ -998,7 +998,7 @@ export default class D3Graph extends React.Component {
         .force('cluster', forceCluster(0.35))
 
       this.edgesForce = this.d3simulation.force('link')
-      this.d3simulation.alpha(1).restart()
+      this.d3simulation.alpha(0.5).restart()
     }
 
     this.d3simulation.nodes(Array.from(nodes.values()))

--- a/client/src/components/D3Graph/index.js
+++ b/client/src/components/D3Graph/index.js
@@ -4,50 +4,150 @@
  */
 
 import * as d3 from 'd3'
-import { event as currentEvent } from 'd3-selection' // Because https://stackoverflow.com/questions/36887428/d3-event-is-null-in-a-reactjs-d3js-component
+import { event as currentEvent } from 'd3-selection'
 import debounce from 'lodash.debounce'
 import React from 'react'
 
 import './D3Graph.scss'
 
-const ARROW_LENGTH = 5
-const ARROW_WIDTH = 2
+const ARROW_LENGTH = 8
+const ARROW_WIDTH = 4
 
-const LABEL_RADIUS = 4
-const NODE_RADIUS = 9
+const MIN_NODE_RADIUS = 8
+const MAX_NODE_RADIUS = 40
+const DEFAULT_NODE_RADIUS = 12
 const DOUBLE_CLICK_MS = 250
 
-const fixedPosForce = () => {
-  const self = {
-    nodes: [],
-  }
+// Performance thresholds
+const PERF = {
+  LARGE_GRAPH: 300,       // nodes: disable expensive effects
+  HUGE_GRAPH: 800,        // nodes: aggressive LOD
+  MAX_VISIBLE_EDGES: 2000, // max edges to render at once
+  MINIMAP_INTERVAL: 8,     // only redraw minimap every N frames
+  HULL_INTERVAL: 5,        // only recompute hulls every N frames
+}
 
-  const res = function tick(alpha) {
-    self.nodes.forEach((n) => {
-      if (!n._posFixed) {
-        return
-      }
+const THEME = {
+  nodeBorderActive: 3,
+  nodeBorderDefault: 1.5,
+  edgeWidthActive: 3.0,
+  edgeWidthHighlight: 2.0,
+  edgeWidthDefault: 1.2,
+  edgeAlphaDefault: 0.35,
+  edgeAlphaHighlight: 0.9,
+  edgeAlphaDimmed: 0.06,
+  nodeDimmedAlpha: 0.12,
+  labelFont: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  hullAlpha: 0.07,
+  hullStrokeAlpha: 0.25,
+  hullPadding: 30,
+}
+
+function parseHexColor(hex) {
+  if (!hex || hex[0] !== '#' || hex.length < 7) return { r: 128, g: 128, b: 128 }
+  return {
+    r: parseInt(hex.slice(1, 3), 16),
+    g: parseInt(hex.slice(3, 5), 16),
+    b: parseInt(hex.slice(5, 7), 16),
+  }
+}
+
+function darkenColor(hex, factor = 0.3) {
+  const { r, g, b } = parseHexColor(hex)
+  return `rgb(${Math.round(r * (1 - factor))},${Math.round(g * (1 - factor))},${Math.round(b * (1 - factor))})`
+}
+
+function lightenColor(hex, factor = 0.3) {
+  const { r, g, b } = parseHexColor(hex)
+  return `rgb(${Math.min(255, Math.round(r + (255 - r) * factor))},${Math.min(255, Math.round(g + (255 - g) * factor))},${Math.min(255, Math.round(b + (255 - b) * factor))})`
+}
+
+function hexToRgba(hex, alpha) {
+  const { r, g, b } = parseHexColor(hex)
+  return `rgba(${r},${g},${b},${alpha})`
+}
+
+function roundRect(ctx, x, y, w, h, r) {
+  const rr = Math.min(r, w / 2, h / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + rr, y)
+  ctx.arcTo(x + w, y, x + w, y + h, rr)
+  ctx.arcTo(x + w, y + h, x, y + h, rr)
+  ctx.arcTo(x, y + h, x, y, rr)
+  ctx.arcTo(x, y, x + w, y, rr)
+  ctx.closePath()
+}
+
+const fixedPosForce = () => {
+  const self = { nodes: [] }
+  const res = function tick() {
+    for (let i = 0; i < self.nodes.length; i++) {
+      const n = self.nodes[i]
+      if (!n._posFixed) continue
       n.x = n._posFixed.x
       n.y = n._posFixed.y
-    })
+    }
   }
-
   res.initialize = (nodes) => (self.nodes = nodes)
-
   res.setNodeCoords = (node, x, y) => {
     node._posFixed = { x, y }
     node.x = x
     node.y = y
   }
-
   return res
+}
+
+// ArangoDB-style cluster force — reuses allocations
+const forceCluster = (strength = 0.35) => {
+  let nodes = []
+  // Reuse these maps across ticks to avoid GC
+  const centerX = new Map()
+  const centerY = new Map()
+  const counts = new Map()
+
+  function force(alpha) {
+    // Reset accumulators
+    centerX.forEach((_, k) => { centerX.set(k, 0); centerY.set(k, 0); counts.set(k, 0) })
+
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i]
+      const g = n.group
+      if (!g) continue
+      if (!counts.has(g)) { centerX.set(g, 0); centerY.set(g, 0); counts.set(g, 0) }
+      centerX.set(g, centerX.get(g) + n.x)
+      centerY.set(g, centerY.get(g) + n.y)
+      counts.set(g, counts.get(g) + 1)
+    }
+
+    // Normalize to centroids
+    counts.forEach((c, g) => {
+      if (c > 0) {
+        centerX.set(g, centerX.get(g) / c)
+        centerY.set(g, centerY.get(g) / c)
+      }
+    })
+
+    const s = alpha * strength
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i]
+      if (!n.group || n._posFixed) continue
+      const cx = centerX.get(n.group)
+      const cy = centerY.get(n.group)
+      if (cx === undefined) continue
+      n.vx += (cx - n.x) * s
+      n.vy += (cy - n.y) * s
+    }
+  }
+
+  force.initialize = (_) => (nodes = _)
+  force.strength = (s) => { strength = s; return force }
+  return force
 }
 
 export default class D3Graph extends React.Component {
   width = 100
   height = 100
   outer = React.createRef()
-
   devicePixelRatio = window.devicePixelRatio || 1
 
   state = {
@@ -59,104 +159,360 @@ export default class D3Graph extends React.Component {
     edges: new Map(),
   }
 
+  nodeDegrees = new Map()
+  adjacencyMap = new Map()
+  groupColors = new Map()
+  animationFrameId = null
+  lastFrameTime = 0
+  frameCount = 0
+
+  // Pre-cached per-node render data (avoids per-frame allocation)
+  nodeRenderCache = new Map()
+
+  // Cached hull paths (recomputed every HULL_INTERVAL frames)
+  cachedHulls = null
+
+  // Pulse animation state
+  pulsingNodes = new Map()
+
+  computeNodeDegrees = () => {
+    this.nodeDegrees.clear()
+    this.adjacencyMap.clear()
+
+    this.document.nodes.forEach((n) => {
+      this.nodeDegrees.set(n.id, 0)
+      this.adjacencyMap.set(n.id, new Set())
+    })
+
+    this.document.edges.forEach((edge) => {
+      const srcId = typeof edge.source === 'object' ? edge.source.id : edge.source
+      const tgtId = typeof edge.target === 'object' ? edge.target.id : edge.target
+      this.nodeDegrees.set(srcId, (this.nodeDegrees.get(srcId) || 0) + 1)
+      this.nodeDegrees.set(tgtId, (this.nodeDegrees.get(tgtId) || 0) + 1)
+      if (this.adjacencyMap.has(srcId)) this.adjacencyMap.get(srcId).add(tgtId)
+      if (this.adjacencyMap.has(tgtId)) this.adjacencyMap.get(tgtId).add(srcId)
+    })
+
+    this.maxDegree = 1
+    this.nodeDegrees.forEach((deg) => {
+      if (deg > this.maxDegree) this.maxDegree = deg
+    })
+
+    this.groupColors.clear()
+    this.document.nodes.forEach((n) => {
+      if (n.group && n.color && !this.groupColors.has(n.group)) {
+        this.groupColors.set(n.group, n.color)
+      }
+    })
+
+    // Pre-cache radius and colors per node (avoids recalc every frame)
+    this.nodeRenderCache.clear()
+    this.document.nodes.forEach((n) => {
+      const degree = this.nodeDegrees.get(n.id) || 0
+      let radius = DEFAULT_NODE_RADIUS
+      if (this.maxDegree > 1) {
+        const t = Math.sqrt(degree / this.maxDegree)
+        radius = MIN_NODE_RADIUS + t * (MAX_NODE_RADIUS - MIN_NODE_RADIUS)
+      }
+      const color = n.color || '#848484'
+      this.nodeRenderCache.set(n.id, {
+        radius,
+        degree,
+        color,
+        colorDark: darkenColor(color, 0.25),
+      })
+    })
+
+    this.cachedHulls = null // invalidate hull cache
+  }
+
+  getNodeRadius = (node) => {
+    const cached = this.nodeRenderCache.get(node.id)
+    return cached ? cached.radius : DEFAULT_NODE_RADIUS
+  }
+
+  isInNeighborhood = (nodeId) => {
+    const hoveredNode = this.props.activeNode
+    if (!hoveredNode || !this._isHovering) return true
+    if (nodeId === hoveredNode.id) return true
+    const neighbors = this.adjacencyMap.get(hoveredNode.id)
+    return neighbors && neighbors.has(nodeId)
+  }
+
+  isEdgeInNeighborhood = (edge) => {
+    const hoveredNode = this.props.activeNode
+    if (!hoveredNode || !this._isHovering) return true
+    const srcId = typeof edge.source === 'object' ? edge.source.id : edge.source
+    const tgtId = typeof edge.target === 'object' ? edge.target.id : edge.target
+    return srcId === hoveredNode.id || tgtId === hoveredNode.id
+  }
+
+  getWorldViewport = () => {
+    const k = this.state.transform.k
+    const tx = this.state.transform.x
+    const ty = this.state.transform.y
+    return {
+      x0: -tx / k, y0: -ty / k,
+      x1: (this.width - tx) / k, y1: (this.height - ty) / k,
+    }
+  }
+
+  isInViewport = (x, y, pad = 60) => {
+    const vp = this._viewport
+    if (!vp) return true
+    return x >= vp.x0 - pad && x <= vp.x1 + pad && y >= vp.y0 - pad && y <= vp.y1 + pad
+  }
+
+  // Hull computation — cached and throttled
+  computeHulls = () => {
+    const nodeCount = this.document.nodes.size
+    if (nodeCount > PERF.HUGE_GRAPH || nodeCount < 4) {
+      this.cachedHulls = []
+      return
+    }
+
+    const byGroup = new Map()
+    this.document.nodes.forEach((n) => {
+      if (!n.group) return
+      if (!byGroup.has(n.group)) byGroup.set(n.group, [])
+      byGroup.get(n.group).push([n.x, n.y])
+    })
+
+    const hulls = []
+    byGroup.forEach((points, group) => {
+      if (points.length < 3) return
+      const hull = d3.polygonHull(points)
+      if (!hull) return
+      hulls.push({ hull, color: this.groupColors.get(group) || '#888888' })
+    })
+    this.cachedHulls = hulls
+  }
+
+  drawHulls = (context) => {
+    if (!this.cachedHulls || !this.cachedHulls.length) return
+
+    context.save()
+    context.lineJoin = 'round'
+    context.lineWidth = 1.5
+
+    for (let h = 0; h < this.cachedHulls.length; h++) {
+      const { hull, color } = this.cachedHulls[h]
+      context.fillStyle = hexToRgba(color, THEME.hullAlpha)
+      context.strokeStyle = hexToRgba(color, THEME.hullStrokeAlpha)
+
+      const pad = THEME.hullPadding
+      context.beginPath()
+      for (let i = 0; i < hull.length; i++) {
+        const p0 = hull[(i - 1 + hull.length) % hull.length]
+        const p1 = hull[i]
+        const p2 = hull[(i + 1) % hull.length]
+        const v1x = p1[0] - p0[0], v1y = p1[1] - p0[1]
+        const v2x = p2[0] - p1[0], v2y = p2[1] - p1[1]
+        const len1 = Math.hypot(v1x, v1y) || 1
+        const len2 = Math.hypot(v2x, v2y) || 1
+        const pInX = p1[0] - (v1x / len1) * pad, pInY = p1[1] - (v1y / len1) * pad
+        const pOutX = p1[0] + (v2x / len2) * pad, pOutY = p1[1] + (v2y / len2) * pad
+        if (i === 0) context.moveTo(pInX, pInY)
+        else context.lineTo(pInX, pInY)
+        context.quadraticCurveTo(p1[0], p1[1], pOutX, pOutY)
+      }
+      context.closePath()
+      context.fill()
+      context.stroke()
+    }
+    context.restore()
+  }
+
+  // Minimap — throttled, simple rendering
+  drawMinimap = () => {
+    if (!this.minimapCanvas || !this.document.nodes.size) return
+    // Only redraw minimap every N frames
+    if (this.frameCount % PERF.MINIMAP_INTERVAL !== 0) return
+
+    const mmw = this.minimapCanvas.width
+    const mmh = this.minimapCanvas.height
+    const mmctx = this.minimapContext
+
+    mmctx.clearRect(0, 0, mmw, mmh)
+
+    mmctx.fillStyle = 'rgba(20, 22, 30, 0.85)'
+    roundRect(mmctx, 0, 0, mmw, mmh, 6)
+    mmctx.fill()
+
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    this.document.nodes.forEach((n) => {
+      if (n.x < minX) minX = n.x
+      if (n.y < minY) minY = n.y
+      if (n.x > maxX) maxX = n.x
+      if (n.y > maxY) maxY = n.y
+    })
+
+    const pad = 10
+    const gw = (maxX - minX) || 1
+    const gh = (maxY - minY) || 1
+    const sx = (mmw - pad * 2) / gw
+    const sy = (mmh - pad * 2) / gh
+    const s = Math.min(sx, sy)
+    const ox = (mmw - s * gw) / 2
+    const oy = (mmh - s * gh) / 2
+
+    mmctx.save()
+    mmctx.translate(ox - minX * s, oy - minY * s)
+    mmctx.scale(s, s)
+
+    // Skip edges in minimap for large graphs
+    if (this.document.edges.size < 500) {
+      mmctx.strokeStyle = 'rgba(255,255,255,0.1)'
+      mmctx.lineWidth = 1 / s
+      mmctx.beginPath()
+      this.document.edges.forEach((edge) => {
+        if (!edge.source.x) return
+        mmctx.moveTo(edge.source.x, edge.source.y)
+        mmctx.lineTo(edge.target.x, edge.target.y)
+      })
+      mmctx.stroke()
+    }
+
+    // Batch node drawing by color for fewer state changes
+    const dotSize = Math.max(1.5, 2 / s)
+    mmctx.globalAlpha = 0.8
+    // Simple single-pass: just draw all nodes as one color for speed
+    mmctx.fillStyle = 'rgba(180,190,200,0.9)'
+    mmctx.beginPath()
+    this.document.nodes.forEach((n) => {
+      mmctx.moveTo(n.x + dotSize, n.y)
+      mmctx.arc(n.x, n.y, dotSize, 0, Math.PI * 2)
+    })
+    mmctx.fill()
+    mmctx.globalAlpha = 1
+
+    // Viewport rectangle
+    const vp = this.getWorldViewport()
+    mmctx.strokeStyle = 'rgba(80,166,255,0.9)'
+    mmctx.lineWidth = 2 / s
+    mmctx.fillStyle = 'rgba(80,166,255,0.08)'
+    mmctx.strokeRect(vp.x0, vp.y0, vp.x1 - vp.x0, vp.y1 - vp.y0)
+    mmctx.fillRect(vp.x0, vp.y0, vp.x1 - vp.x0, vp.y1 - vp.y0)
+
+    mmctx.restore()
+  }
+
   labelEdge = (context, edge) => {
-    if (
-      (this.document.edges.length > 40 &&
-        this.state.transform.k * this.devicePixelRatio < 1.25) ||
-      this.document.edges.length > 200
-    ) {
-      return
-    }
+    const zoom = this.state.transform.k * this.devicePixelRatio
+    if (this.document.edges.size > 200 && zoom < 1.5) return
+    if (this.document.edges.size > 40 && zoom < 1.0) return
+    if (zoom < 0.6) return
 
-    if (edge.arc.distance < 2 * NODE_RADIUS + 50) {
-      return
-    }
+    const srcR = this.getNodeRadius(edge.source)
+    const tgtR = this.getNodeRadius(edge.target)
+    if (edge.arc.distance < srcR + tgtR + 40) return
 
-    context.font = `12px sans-serif`
+    const fontSize = 11
+    context.font = `500 ${fontSize}px ${THEME.labelFont}`
     context.textAlign = 'center'
     context.textBaseline = 'middle'
 
-    const maxWidth = 100,
-      bgPadding = 2
+    const maxWidth = 120
+    const bgPadding = 4
     let { width } = context.measureText(edge.label)
     width = Math.min(width, maxWidth)
 
-    context.globalAlpha = 0.5
-    context.fillStyle = '#fff'
-
     const { centerX: cx, centerY: cy } = edge.arc
+    const rw = width + 2 * bgPadding
+    const rh = fontSize + bgPadding
 
-    context.fillRect(
-      cx - width / 2 - bgPadding,
-      cy - 6,
-      width + 2 * bgPadding,
-      12,
-    )
+    context.globalAlpha = 0.88
+    context.fillStyle = '#ffffff'
+    roundRect(context, cx - rw / 2, cy - rh / 2, rw, rh, 3)
+    context.fill()
     context.globalAlpha = 1
 
-    if (this.props.activeEdge === edge) {
-      context.shadowColor = edge.color
-      context.shadowBlur = 3
-    }
-    context.fillStyle = edge.color
+    context.fillStyle = '#333333'
     context.fillText(edge.label, cx, cy, maxWidth)
-
-    context.shadowColor = null
-    context.shadowBlur = 0
   }
 
   labelNode = (context, node) => {
-    if (
-      (this.document.nodes.size > 50 &&
-        this.state.transform.k * this.devicePixelRatio < 1.2) ||
-      this.document.nodes.size > 500
-    ) {
-      return
-    }
+    const zoom = this.state.transform.k * this.devicePixelRatio
+    const nodeCount = this.document.nodes.size
+    const cached = this.nodeRenderCache.get(node.id)
+    const degree = cached ? cached.degree : 0
+    const radius = cached ? cached.radius : DEFAULT_NODE_RADIUS
 
-    const fontSize = 14
-    context.font = `${fontSize}px sans-serif`
+    if (nodeCount > 500 && zoom < 2.0 && degree < 3) return
+    if (nodeCount > 200 && zoom < 1.2 && degree < 2) return
+    if (nodeCount > 50 && zoom < 0.8) return
+    if (zoom < 0.4) return
+    if (nodeCount > 100 && degree < 2 && zoom < 1.5) return
+
+    const label = node.label || ''
+    if (!label) return
+
+    const fontSize = Math.max(10, Math.min(14, radius * 0.9))
+    context.font = `600 ${fontSize}px ${THEME.labelFont}`
     context.textAlign = 'center'
-    context.fillText(node.label, node.x, node.y + NODE_RADIUS + fontSize - 2)
+    context.textBaseline = 'middle'
+
+    const maxWidth = radius * 4
+    let { width: textWidth } = context.measureText(label)
+    textWidth = Math.min(textWidth, maxWidth)
+
+    const bgPadding = 3
+    const textY = node.y + radius + fontSize / 2 + 4
+    const rw = textWidth + 2 * bgPadding
+    const rh = fontSize + bgPadding
+
+    context.globalAlpha = 0.88
+    context.fillStyle = '#2A2C34'
+    roundRect(context, node.x - rw / 2, textY - rh / 2, rw, rh, rh / 2)
+    context.fill()
+    context.globalAlpha = 1
+
+    context.fillStyle = '#FFFFFF'
+    context.fillText(label, node.x, textY, maxWidth)
   }
 
   _drawAll = () => {
     const context = this.canvasContext
-    if (!context) {
-      return
-    }
+    if (!context) return
 
     const { highlightPredicate } = this.props
+    this._isHovering = !!this.props.hoveredNode
+    this.frameCount++
 
     context.save()
     const { devicePixelRatio: dpr } = this
     context.clearRect(0, 0, this.width * dpr, this.height * dpr)
-
-    context.translate(
-      this.state.transform.x * dpr,
-      this.state.transform.y * dpr,
-    )
+    context.translate(this.state.transform.x * dpr, this.state.transform.y * dpr)
     context.scale(this.state.transform.k * dpr, this.state.transform.k * dpr)
 
-    const addArrow = (arc, target, { x: vx, y: vy }) => {
-      const baseOffset = NODE_RADIUS + ARROW_LENGTH
-      arc.arrowBase = [target.x - vx * baseOffset, target.y - vy * baseOffset]
-      arc.arrowEnd = [target.x - NODE_RADIUS * vx, target.y - NODE_RADIUS * vy]
-      arc.arrowPt1 = [
-        arc.arrowBase[0] + ARROW_WIDTH * vy,
-        arc.arrowBase[1] - ARROW_WIDTH * vx,
-      ]
-      arc.arrowPt2 = [
-        arc.arrowBase[0] - ARROW_WIDTH * vy,
-        arc.arrowBase[1] + ARROW_WIDTH * vx,
-      ]
+    this._viewport = this.getWorldViewport()
+
+    const zoom = this.state.transform.k * dpr
+    const isZoomedOut = zoom < 0.3
+    const nodeCount = this.document.nodes.size
+    const isLargeGraph = nodeCount > PERF.LARGE_GRAPH
+    const isHugeGraph = nodeCount > PERF.HUGE_GRAPH
+
+    // --- Hulls (throttled) ---
+    if (!isZoomedOut && !isHugeGraph) {
+      if (this.frameCount % PERF.HULL_INTERVAL === 0 || !this.cachedHulls) {
+        this.computeHulls()
+      }
+      this.drawHulls(context)
     }
 
-    const rotate = (vx, vy, alpha) => {
-      return [
-        vx * Math.cos(alpha) - vy * Math.sin(alpha),
-        vx * Math.sin(alpha) + vy * Math.cos(alpha),
-      ]
+    // --- Arc helpers (defined once, not per-edge) ---
+    const addArrow = (arc, target, vx, vy, nodeRadius) => {
+      const baseOffset = nodeRadius + ARROW_LENGTH
+      arc.arrowBase0 = target.x - vx * baseOffset
+      arc.arrowBase1 = target.y - vy * baseOffset
+      arc.arrowEnd0 = target.x - nodeRadius * vx
+      arc.arrowEnd1 = target.y - nodeRadius * vy
+      arc.arrowPt10 = arc.arrowBase0 + ARROW_WIDTH * vy
+      arc.arrowPt11 = arc.arrowBase1 - ARROW_WIDTH * vx
+      arc.arrowPt20 = arc.arrowBase0 - ARROW_WIDTH * vy
+      arc.arrowPt21 = arc.arrowBase1 + ARROW_WIDTH * vx
+      arc.hasArrow = true
     }
 
     const getArc = (edge) => {
@@ -164,125 +520,204 @@ export default class D3Graph extends React.Component {
       const dy = edge.target.y - edge.source.y
       const l = Math.sqrt(dx * dx + dy * dy)
 
-      const arc = {
-        radius: -1,
-        distance: l,
-        centerX: edge.source.x + dx / 2,
-        centerY: edge.source.y + dy / 2,
-      }
+      const srcR = this.getNodeRadius(edge.source)
+      const tgtR = this.getNodeRadius(edge.target)
 
-      if (
-        !edge.siblingCount ||
-        edge.siblingCount < 2 ||
-        (edge.siblingCount % 2 && edge.siblingIndex === 0) ||
-        l < NODE_RADIUS * 2
-      ) {
-        // Edge is a straight line
-        // (no siblings or sibling #0 with odd number of edges)
-        if (l > 2 * NODE_RADIUS + 2 * ARROW_LENGTH) {
-          const vec = { x: dx / l, y: dy / l }
-          addArrow(arc, edge.target, vec)
+      const arc = { radius: -1, distance: l, centerX: edge.source.x + dx / 2, centerY: edge.source.y + dy / 2, hasArrow: false }
+
+      if (!edge.siblingCount || edge.siblingCount < 2 ||
+          (edge.siblingCount % 2 && edge.siblingIndex === 0) ||
+          l < srcR + tgtR) {
+        if (l > srcR + tgtR + 2 * ARROW_LENGTH) {
+          addArrow(arc, edge.target, dx / l, dy / l, tgtR)
         }
         return arc
       }
 
+      const LR = 4
       let offset
       if (edge.siblingCount % 2) {
-        offset = LABEL_RADIUS * (1 + Math.ceil(edge.siblingIndex / 2) * 2)
+        offset = LR * (1 + Math.ceil(edge.siblingIndex / 2) * 2)
       } else {
-        offset = LABEL_RADIUS * (1 + Math.floor(edge.siblingIndex / 2) * 2)
+        offset = LR * (1 + Math.floor(edge.siblingIndex / 2) * 2)
       }
-      if (edge.siblingCount * LABEL_RADIUS > (0.9 * l) / 2) {
-        // If there are too many edges - scale everything down.
-        // It won't look nice, but will at least work.
-        offset = (offset * 0.9 * l) / 2 / edge.siblingCount / LABEL_RADIUS
+      if (edge.siblingCount * LR > (0.9 * l) / 2) {
+        offset = (offset * 0.9 * l) / 2 / edge.siblingCount / LR
       }
 
-      const norm = edge.siblingIndex % 2 ? [dy / l, -dx / l] : [-dy / l, dx / l]
-
+      const norm0 = edge.siblingIndex % 2 ? dy / l : -dy / l
+      const norm1 = edge.siblingIndex % 2 ? -dx / l : dx / l
       const R = (offset * offset + (l * l) / 4) / 2 / offset
       const h2 = (R * offset) / (R - offset)
 
-      const arcBent = {
-        radius: R,
-        distance: l,
-        centerX: edge.source.x + dx / 2 + norm[0] * offset,
-        centerY: edge.source.y + dy / 2 + norm[1] * offset,
+      arc.radius = R
+      arc.centerX = edge.source.x + dx / 2 + norm0 * offset
+      arc.centerY = edge.source.y + dy / 2 + norm1 * offset
+      arc.controlX = edge.source.x + dx / 2 + norm0 * (offset + h2)
+      arc.controlY = edge.source.y + dy / 2 + norm1 * (offset + h2)
 
-        controlX: edge.source.x + dx / 2 + norm[0] * (offset + h2),
-        controlY: edge.source.y + dy / 2 + norm[1] * (offset + h2),
-      }
-
-      if (l > 2 * NODE_RADIUS + 2 * ARROW_LENGTH) {
+      if (l > srcR + tgtR + 2 * ARROW_LENGTH) {
         const rotateDir = edge.siblingIndex % 2 ? +1 : -1
-        const alpha = Math.asin(l / 2 / R)
-        const theta = Math.asin(NODE_RADIUS / 2 / R)
-        const [vx, vy] = rotate(dx / l, dy / l, rotateDir * (alpha - theta))
-        addArrow(arcBent, edge.target, { x: vx, y: vy })
+        const alpha = Math.asin(Math.min(1, l / 2 / R))
+        const theta = Math.asin(Math.min(1, tgtR / 2 / R))
+        const ra = rotateDir * (alpha - theta)
+        const cosA = Math.cos(ra), sinA = Math.sin(ra)
+        const ndx = dx / l, ndy = dy / l
+        addArrow(arc, edge.target, ndx * cosA - ndy * sinA, ndx * sinA + ndy * cosA, tgtR)
       }
 
-      return arcBent
+      return arc
     }
 
+    // --- Edges ---
+    context.lineCap = 'round'
+    let edgesDrawn = 0
     this.document.edges.forEach((edge) => {
-      context.beginPath()
+      // Hard cap on visible edges for huge graphs
+      if (isHugeGraph && edgesDrawn >= PERF.MAX_VISIBLE_EDGES) return
+
+      // Viewport culling
+      if (!this.isInViewport(edge.source.x, edge.source.y, 100) &&
+          !this.isInViewport(edge.target.x, edge.target.y, 100)) return
+
+      edgesDrawn++
       const arc = (edge.arc = getArc(edge))
 
-      context.moveTo(edge.source.x, edge.source.y)
-      context.strokeStyle = edge.color
-      context.lineWidth = edge.predicate === highlightPredicate ? 1.5 : 0.5
+      const isHighlighted = edge.predicate === highlightPredicate
+      const isActive = edge === this.props.activeEdge
+      const inNeighborhood = this.isEdgeInNeighborhood(edge)
 
-      if (edge === this.props.activeEdge) {
-        context.lineWidth = 2.0
+      context.strokeStyle = edge.color
+      if (this._isHovering && !inNeighborhood) {
+        context.globalAlpha = THEME.edgeAlphaDimmed
+        context.lineWidth = 0.5
+      } else if (isActive) {
+        context.globalAlpha = THEME.edgeAlphaHighlight
+        context.lineWidth = THEME.edgeWidthActive
+      } else if (isHighlighted || (this._isHovering && inNeighborhood)) {
+        context.globalAlpha = THEME.edgeAlphaHighlight
+        context.lineWidth = THEME.edgeWidthHighlight
+      } else {
+        context.globalAlpha = THEME.edgeAlphaDefault
+        context.lineWidth = THEME.edgeWidthDefault
       }
 
+      context.beginPath()
+      context.moveTo(edge.source.x, edge.source.y)
       if (arc.radius <= 0) {
         context.lineTo(edge.target.x, edge.target.y)
       } else {
-        context.arcTo(
-          arc.controlX,
-          arc.controlY,
-          edge.target.x,
-          edge.target.y,
-          arc.radius,
-        )
+        context.arcTo(arc.controlX, arc.controlY, edge.target.x, edge.target.y, arc.radius)
       }
-
-      if (arc.arrowEnd) {
-        context.moveTo(...arc.arrowEnd)
-        context.lineTo(...arc.arrowPt1)
-        context.moveTo(...arc.arrowEnd)
-        context.lineTo(...arc.arrowPt2)
-      }
-
       context.stroke()
 
-      this.labelEdge(context, edge, arc.centerX, arc.centerY)
-      context.lineWidth = 0.5
+      // Arrowhead — skip for huge graphs when zoomed out
+      if (arc.hasArrow && !(isHugeGraph && isZoomedOut)) {
+        context.fillStyle = edge.color
+        context.beginPath()
+        context.moveTo(arc.arrowEnd0, arc.arrowEnd1)
+        context.lineTo(arc.arrowPt10, arc.arrowPt11)
+        context.lineTo(arc.arrowPt20, arc.arrowPt21)
+        context.closePath()
+        context.fill()
+      }
+
+      context.globalAlpha = 1
+      if (!isLargeGraph && (!this._isHovering || inNeighborhood)) {
+        this.labelEdge(context, edge)
+      }
     })
 
-    // Draw the nodes
+    // --- Nodes ---
     this.document.nodes.forEach((d) => {
-      context.fillStyle = d.color || '#ccc'
-      context.strokeStyle = '#c63'
+      if (!this.isInViewport(d.x, d.y, 50)) return
 
-      context.beginPath()
-      context.arc(d.x, d.y, NODE_RADIUS, 0, 2 * Math.PI, true)
-      context.fill()
-      context.stroke()
+      const cached = this.nodeRenderCache.get(d.id)
+      const radius = cached ? cached.radius : DEFAULT_NODE_RADIUS
+      const color = cached ? cached.color : '#848484'
+      const isActive = d === this.props.activeNode
+      const inNeighborhood = this.isInNeighborhood(d.id)
+      const dimmed = this._isHovering && !inNeighborhood
 
-      if (d === this.props.activeNode) {
-        context.lineWidth = 1.5
+      if (dimmed) context.globalAlpha = THEME.nodeDimmedAlpha
+
+      // LOD: dots at very low zoom
+      if (isZoomedOut) {
+        context.fillStyle = color
         context.beginPath()
-        context.arc(d.x, d.y, NODE_RADIUS, 0, 2 * Math.PI, true)
-        context.stroke()
-        context.lineWidth = 0.5
+        context.arc(d.x, d.y, Math.max(2, radius * 0.3), 0, 2 * Math.PI)
+        context.fill()
+        context.globalAlpha = 1
+        return
       }
 
-      this.labelNode(context, d)
+      // Solid fill
+      context.fillStyle = color
+      context.beginPath()
+      context.arc(d.x, d.y, radius, 0, 2 * Math.PI, true)
+      context.fill()
+
+      // Border
+      context.strokeStyle = cached ? cached.colorDark : darkenColor(color, 0.25)
+      context.lineWidth = isActive ? THEME.nodeBorderActive : THEME.nodeBorderDefault
+      context.stroke()
+
+      // Active glow
+      if (isActive && !dimmed) {
+        context.strokeStyle = color
+        context.globalAlpha = 0.4
+        context.lineWidth = 4
+        context.beginPath()
+        context.arc(d.x, d.y, radius + 4, 0, 2 * Math.PI, true)
+        context.stroke()
+        context.globalAlpha = dimmed ? THEME.nodeDimmedAlpha : 1
+      }
+
+      // Search pulse
+      const pulse = this.pulsingNodes.get(d.id)
+      if (pulse && pulse > 0) {
+        context.strokeStyle = '#50A6FF'
+        context.globalAlpha = 0.6 * pulse
+        context.lineWidth = 8 * pulse
+        context.beginPath()
+        context.arc(d.x, d.y, radius + 10 * (1 - pulse), 0, 2 * Math.PI)
+        context.stroke()
+        context.globalAlpha = 1
+      }
+
+      // Expanded dot
+      if (d.expanded) {
+        context.fillStyle = '#ffffff'
+        context.beginPath()
+        context.arc(d.x + radius * 0.55, d.y - radius * 0.55, 3, 0, 2 * Math.PI)
+        context.fill()
+      }
+
+      context.globalAlpha = 1
+      if (!dimmed) this.labelNode(context, d)
     })
 
     context.restore()
+    this.drawMinimap()
+  }
+
+  startAnimationLoop = () => {
+    const animate = (timestamp) => {
+      const delta = timestamp - (this.lastFrameTime || timestamp)
+      this.lastFrameTime = timestamp
+
+      let hasPulse = false
+      this.pulsingNodes.forEach((val, key) => {
+        const newVal = val - delta * 0.002
+        if (newVal <= 0) this.pulsingNodes.delete(key)
+        else { this.pulsingNodes.set(key, newVal); hasPulse = true }
+      })
+
+      if (hasPulse) this._drawAll()
+
+      this.animationFrameId = requestAnimationFrame(animate)
+    }
+    this.animationFrameId = requestAnimationFrame(animate)
   }
 
   drawGraph = debounce(this._drawAll, 5, { leading: true, trailing: true })
@@ -292,16 +727,36 @@ export default class D3Graph extends React.Component {
       .alphaTarget(0.05)
       .alphaMin(0.05005)
       .alphaDecay(0.02)
-      .velocityDecay(0.09)
-      .force(
-        'link',
-        d3
-          .forceLink()
-          .distance(60)
-          .strength(0.05)
-          .id((d) => d.id),
+      .velocityDecay(0.3)
+      .force('link', d3.forceLink()
+        .distance((d) => {
+          const srcDeg = this.nodeDegrees.get(typeof d.source === 'object' ? d.source.id : d.source) || 1
+          const tgtDeg = this.nodeDegrees.get(typeof d.target === 'object' ? d.target.id : d.target) || 1
+          const srcG = typeof d.source === 'object' ? d.source.group : null
+          const tgtG = typeof d.target === 'object' ? d.target.group : null
+          const cross = srcG && tgtG && srcG !== tgtG
+          return (cross ? 100 : 60) + Math.sqrt(srcDeg + tgtDeg) * 15
+        })
+        .strength((d) => {
+          const srcG = typeof d.source === 'object' ? d.source.group : null
+          const tgtG = typeof d.target === 'object' ? d.target.group : null
+          return srcG === tgtG ? 0.4 : 0.15
+        })
+        .id((d) => d.id),
       )
-      .force('charge', d3.forceManyBody().strength(-10))
+      .force('charge', d3.forceManyBody()
+        .strength((d) => {
+          const degree = this.nodeDegrees.get(d.id) || 0
+          return -200 - degree * 30
+        })
+        .distanceMax(500)
+        .theta(0.9),
+      )
+      .force('collision', d3.forceCollide()
+        .radius((d) => this.getNodeRadius(d) + 8)
+        .strength(0.8),
+      )
+      .force('cluster', forceCluster(0.35))
       .force('fixedPosForce', fixedPosForce())
 
     this.fixedPosForce = this.d3simulation.force('fixedPosForce')
@@ -319,205 +774,233 @@ export default class D3Graph extends React.Component {
       .attr('height', this.height)
       .node()
 
+    this.minimapCanvas = document.createElement('canvas')
+    this.minimapCanvas.className = 'graph-minimap'
+    this.minimapCanvas.width = 180
+    this.minimapCanvas.height = 120
+    this.outer.current.appendChild(this.minimapCanvas)
+    this.minimapContext = this.minimapCanvas.getContext('2d')
+    this.minimapCanvas.addEventListener('click', this.onMinimapClick)
+
     this.zoomBehavior = d3
       .zoom()
-      .scaleExtent([(1 / 4) * this.devicePixelRatio, 4 * this.devicePixelRatio])
+      .scaleExtent([(1 / 8) * this.devicePixelRatio, 6 * this.devicePixelRatio])
       .on('zoom', this.onZoom)
 
     d3.select(this.graphCanvas)
       .on('click', this.onClick)
       .on('dblclick', this.onDoubleClick)
       .on('mousemove', this.onMouseMove)
-      .call(
-        d3
-          .drag()
-          .subject(this.dragsubject)
-          .on('start', this.dragstarted)
-          .on('drag', this.dragged),
-      )
+      .call(d3.drag().subject(this.dragsubject).on('start', this.dragstarted).on('drag', this.dragged))
       .call(this.zoomBehavior)
 
     this.onResize()
     this.updateDocument(this.props.nodes, this.props.edges)
-
+    this.startAnimationLoop()
     this.resizeObserver = window.setInterval(this.onResize, 1000)
   }
 
   componentWillUnmount() {
     clearInterval(this.resizeObserver)
+    if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId)
+    if (this.minimapCanvas) this.minimapCanvas.removeEventListener('click', this.onMinimapClick)
   }
 
-  getD3EventCoords = (event) => {
-    // TODO: event object probably already has inverted coords,
-    // so this whole method is redundant.
-    return this.state.transform.invert([event.x, event.y])
-  }
+  onMinimapClick = (e) => {
+    if (!this.document.nodes.size) return
+    const rect = this.minimapCanvas.getBoundingClientRect()
+    const px = e.clientX - rect.left, py = e.clientY - rect.top
+    const mmw = this.minimapCanvas.width, mmh = this.minimapCanvas.height
 
-  findNodeAtPos = (x, y) => {
-    let minNode = undefined
-    let minD = 1e10
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
     this.document.nodes.forEach((n) => {
-      const d = (n.x - x) * (n.x - x) + (n.y - y) * (n.y - y)
-      if (d < minD) {
-        minNode = n
-        minD = d
-      }
+      if (n.x < minX) minX = n.x; if (n.y < minY) minY = n.y
+      if (n.x > maxX) maxX = n.x; if (n.y > maxY) maxY = n.y
     })
 
-    if (minD > NODE_RADIUS * NODE_RADIUS) {
-      return undefined
-    }
+    const pad = 10, gw = (maxX - minX) || 1, gh = (maxY - minY) || 1
+    const s = Math.min((mmw - pad * 2) / gw, (mmh - pad * 2) / gh)
+    const ox = (mmw - s * gw) / 2, oy = (mmh - s * gh) / 2
+    const wx = (px - ox + minX * s) / s, wy = (py - oy + minY * s) / s
+
+    const k = this.state.transform.k
+    d3.select(this.graphCanvas).transition().duration(300)
+      .call(this.zoomBehavior.transform, d3.zoomIdentity.translate(this.width / 2 - wx * k, this.height / 2 - wy * k).scale(k))
+  }
+
+  getD3EventCoords = (event) => this.state.transform.invert([event.x, event.y])
+
+  findNodeAtPos = (x, y) => {
+    let minNode, minD = 1e10
+    this.document.nodes.forEach((n) => {
+      const r = this.getNodeRadius(n)
+      const d = (n.x - x) * (n.x - x) + (n.y - y) * (n.y - y)
+      if (d < r * r && d < minD) { minNode = n; minD = d }
+    })
     return minNode
   }
 
   findEdgeAtPos = (x, y) => {
-    let minEdge = undefined
-    let minD = 1e10
+    let minEdge, minD = 1e10
     this.document.edges.forEach((edge) => {
+      if (!edge.arc) return
       const { centerX: cx, centerY: cy } = edge.arc
       const d = (cx - x) * (cx - x) + (cy - y) * (cy - y)
-      if (d < minD) {
-        minEdge = edge
-        minD = d
-      }
+      if (d < minD) { minEdge = edge; minD = d }
     })
-
-    if (minD > 10 * 10) {
-      return undefined
-    }
-    return minEdge
+    return minD > 225 ? undefined : minEdge
   }
 
   onMouseMove = () => {
     const { offsetX: x, offsetY: y } = currentEvent
     const pt = this.getD3EventCoords({ x, y })
-
     const node = this.findNodeAtPos(...pt)
     this.props.onNodeHovered(node)
-
-    if (!node) {
-      this.props.onEdgeHovered(this.findEdgeAtPos(...pt))
-    }
+    if (this.graphCanvas) this.graphCanvas.style.cursor = node ? 'pointer' : 'default'
+    if (!node) this.props.onEdgeHovered(this.findEdgeAtPos(...pt))
+    this.drawGraph()
   }
 
   onClick = () => {
     const { offsetX: x, offsetY: y } = currentEvent
     const pt = this.getD3EventCoords({ x, y })
-
     const node = this.findNodeAtPos(...pt)
-    if (node) {
-      currentEvent.stopImmediatePropagation()
-      return this.props.onNodeSelected(node)
-    } else {
-      const edge = this.findEdgeAtPos(...pt)
-      if (edge) {
-        currentEvent.stopImmediatePropagation()
-        return this.props.onEdgeSelected(edge)
-      }
-    }
+    if (node) { currentEvent.stopImmediatePropagation(); return this.props.onNodeSelected(node) }
+    const edge = this.findEdgeAtPos(...pt)
+    if (edge) { currentEvent.stopImmediatePropagation(); return this.props.onEdgeSelected(edge) }
   }
 
   onDoubleClick = () => {
     const { offsetX: x, offsetY: y } = currentEvent
     const pt = this.getD3EventCoords({ x, y })
-
     const node = this.findNodeAtPos(...pt)
-    if (node) {
-      currentEvent.stopImmediatePropagation()
-      return this.props.onNodeDoubleClicked(node)
-    }
+    if (node) { currentEvent.stopImmediatePropagation(); return this.props.onNodeDoubleClicked(node) }
   }
 
   dragsubject = () => {
     const { offsetX: x, offsetY: y } = currentEvent.sourceEvent
     const pt = this.getD3EventCoords({ x, y })
-
     const node = this.findNodeAtPos(...pt)
     this.props.onNodeSelected(node)
-
     return node
   }
 
   dragstarted = () => {
-    if (!currentEvent.active) {
-      setTimeout(() => this.d3simulation.alpha(0.5).restart(), DOUBLE_CLICK_MS)
-    }
+    if (!currentEvent.active) setTimeout(() => this.d3simulation.alpha(0.5).restart(), DOUBLE_CLICK_MS)
   }
 
   dragged = () => {
     const { offsetX: x, offsetY: y } = currentEvent.sourceEvent
     const pt = this.getD3EventCoords({ x, y })
-
     this.fixedPosForce.setNodeCoords(currentEvent.subject, ...pt)
     this.drawGraph()
-
     this.d3simulation.alpha(Math.max(0.12, this.d3simulation.alpha()))
   }
 
   _updateZoom = (transform) => {
-    if (this.state.transform.toString() !== transform.toString()) {
-      this.setState({ transform })
-    }
+    if (this.state.transform.toString() !== transform.toString()) this.setState({ transform })
   }
-  updateZoom = debounce(this._updateZoom, 2, {
-    leading: true,
-    trailing: true,
-  })
-
+  updateZoom = debounce(this._updateZoom, 2, { leading: true, trailing: true })
   onZoom = () => this.updateZoom(currentEvent.transform)
+
+  zoomToFit = () => {
+    if (!this.graphCanvas || !this.document.nodes.size) return
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    this.document.nodes.forEach((n) => {
+      const r = this.getNodeRadius(n) + 20
+      if (n.x - r < minX) minX = n.x - r; if (n.y - r < minY) minY = n.y - r
+      if (n.x + r > maxX) maxX = n.x + r; if (n.y + r > maxY) maxY = n.y + r
+    })
+    const p = 40, gw = maxX - minX + p * 2, gh = maxY - minY + p * 2
+    const scale = Math.min(this.width / gw, this.height / gh, 2) * 0.9
+    const transform = d3.zoomIdentity.translate(this.width / 2, this.height / 2).scale(scale).translate(-(minX + maxX) / 2, -(minY + maxY) / 2)
+    d3.select(this.graphCanvas).transition().duration(500).call(this.zoomBehavior.transform, transform)
+  }
+
+  focusNode = (node) => {
+    if (!this.graphCanvas || !node) return
+    const k = 2.2
+    d3.select(this.graphCanvas).transition().duration(500).ease(d3.easeCubicOut)
+      .call(this.zoomBehavior.transform, d3.zoomIdentity.translate(this.width / 2 - node.x * k, this.height / 2 - node.y * k).scale(k))
+    this.pulsingNodes.set(node.id, 1.0)
+  }
+
+  searchNode = (query) => {
+    if (!query) return null
+    const q = query.toLowerCase().trim()
+    let found = null
+    this.document.nodes.forEach((n) => {
+      if (found) return
+      const name = (n.name || n.label || '').toLowerCase()
+      const uid = (n.uid || n.id || '').toLowerCase()
+      if (name.includes(q) || uid === q) found = n
+    })
+    return found
+  }
 
   onResize = () => {
     let resized = false
     if (this.outer.current) {
       const el = this.outer.current
-
       resized |= this.width !== el.offsetWidth
       resized |= this.height !== el.offsetHeight
-
       this.width = el.offsetWidth
       this.height = el.offsetHeight
     }
-
-    if (!resized) {
-      return
-    }
+    if (!resized) return
 
     this.zoomBehavior.scaleTo(d3.select(this.graphCanvas), 1)
     this.zoomBehavior.translateTo(d3.select(this.graphCanvas), 0, 0)
 
     const { width, height } = this
     this.d3simulation
-      .force('x', d3.forceX(0).strength((0.01 * height) / width))
-      .force('y', d3.forceY(0).strength((0.01 * width) / height))
+      .force('x', d3.forceX(0).strength((0.02 * height) / width))
+      .force('y', d3.forceY(0).strength((0.02 * width) / height))
 
     d3.select(this.graphCanvas)
       .attr('width', this.width * this.devicePixelRatio)
       .attr('height', this.height * this.devicePixelRatio)
 
     this.canvasContext = this.graphCanvas.getContext('2d')
-
     this._drawAll()
   }
 
   updateDocument = (nodes, edges) => {
-    if (!this.d3simulation || !nodes || !edges) {
-      return
-    }
+    if (!this.d3simulation || !nodes || !edges) return
 
-    const newNodesReceived =
-      this.document.nodesLength !== nodes.size ||
-      this.document.edgesLength !== edges.size
+    const newNodesReceived = this.document.nodesLength !== nodes.size || this.document.edgesLength !== edges.size
+
+    this.document = { edges, edgesLength: edges.size, nodes, nodesLength: nodes.size }
+    this.computeNodeDegrees()
 
     if (newNodesReceived) {
+      this.d3simulation
+        .force('link', d3.forceLink()
+          .distance((d) => {
+            const srcDeg = this.nodeDegrees.get(typeof d.source === 'object' ? d.source.id : d.source) || 1
+            const tgtDeg = this.nodeDegrees.get(typeof d.target === 'object' ? d.target.id : d.target) || 1
+            const srcG = typeof d.source === 'object' ? d.source.group : null
+            const tgtG = typeof d.target === 'object' ? d.target.group : null
+            return ((srcG && tgtG && srcG !== tgtG) ? 100 : 60) + Math.sqrt(srcDeg + tgtDeg) * 15
+          })
+          .strength((d) => {
+            const srcG = typeof d.source === 'object' ? d.source.group : null
+            const tgtG = typeof d.target === 'object' ? d.target.group : null
+            return srcG === tgtG ? 0.4 : 0.15
+          })
+          .id((d) => d.id),
+        )
+        .force('charge', d3.forceManyBody()
+          .strength((d) => -200 - (this.nodeDegrees.get(d.id) || 0) * 30)
+          .distanceMax(500).theta(0.9),
+        )
+        .force('collision', d3.forceCollide().radius((d) => this.getNodeRadius(d) + 8).strength(0.8))
+        .force('cluster', forceCluster(0.35))
+
+      this.edgesForce = this.d3simulation.force('link')
       this.d3simulation.alpha(1).restart()
     }
 
-    this.document = {
-      edges,
-      edgesLength: edges.size,
-      nodes,
-      nodesLength: nodes.size,
-    }
     this.d3simulation.nodes(Array.from(nodes.values()))
     this.edgesForce.links(Array.from(edges.values()))
   }
@@ -526,7 +1009,6 @@ export default class D3Graph extends React.Component {
     this.updateDocument(this.props.nodes, this.props.edges)
     this.onResize()
     this.drawGraph()
-
     return <div ref={this.outer} className='graph-outer' />
   }
 }

--- a/client/src/components/D3Graph/index.js
+++ b/client/src/components/D3Graph/index.js
@@ -3,1012 +3,1189 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as d3 from 'd3'
-import { event as currentEvent } from 'd3-selection'
-import debounce from 'lodash.debounce'
-import React from 'react'
+import * as d3 from "d3";
+import { event as currentEvent } from "d3-selection";
+import debounce from "lodash.debounce";
+import React from "react";
 
-import './D3Graph.scss'
+import "./D3Graph.scss";
 
-const ARROW_LENGTH = 8
-const ARROW_WIDTH = 4
+const ARROW_LENGTH = 8;
+const ARROW_WIDTH = 4;
 
-const MIN_NODE_RADIUS = 8
-const MAX_NODE_RADIUS = 40
-const DEFAULT_NODE_RADIUS = 12
-const DOUBLE_CLICK_MS = 250
+const MIN_NODE_RADIUS = 8;
+const MAX_NODE_RADIUS = 40;
+const DEFAULT_NODE_RADIUS = 12;
+const DOUBLE_CLICK_MS = 250;
 
 // Performance thresholds
 const PERF = {
-  LARGE_GRAPH: 300,       // nodes: disable expensive effects
-  HUGE_GRAPH: 800,        // nodes: aggressive LOD
-  MAX_VISIBLE_EDGES: 2000, // max edges to render at once
-  MINIMAP_INTERVAL: 8,     // only redraw minimap every N frames
-  HULL_INTERVAL: 5,        // only recompute hulls every N frames
-}
+	LARGE_GRAPH: 300, // nodes: disable expensive effects
+	HUGE_GRAPH: 800, // nodes: aggressive LOD
+	MAX_VISIBLE_EDGES: 2000, // max edges to render at once
+	MINIMAP_INTERVAL: 8, // only redraw minimap every N frames
+	HULL_INTERVAL: 5, // only recompute hulls every N frames
+};
 
 const THEME = {
-  nodeBorderActive: 3,
-  nodeBorderDefault: 1.5,
-  edgeWidthActive: 3.0,
-  edgeWidthHighlight: 2.0,
-  edgeWidthDefault: 1.2,
-  edgeAlphaDefault: 0.35,
-  edgeAlphaHighlight: 0.9,
-  edgeAlphaDimmed: 0.06,
-  nodeDimmedAlpha: 0.12,
-  labelFont: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-  hullAlpha: 0.07,
-  hullStrokeAlpha: 0.25,
-  hullPadding: 30,
-}
+	nodeBorderActive: 3,
+	nodeBorderDefault: 1.5,
+	edgeWidthActive: 3.0,
+	edgeWidthHighlight: 2.0,
+	edgeWidthDefault: 1.2,
+	edgeAlphaDefault: 0.35,
+	edgeAlphaHighlight: 0.9,
+	edgeAlphaDimmed: 0.06,
+	nodeDimmedAlpha: 0.12,
+	labelFont: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+	hullAlpha: 0.07,
+	hullStrokeAlpha: 0.25,
+	hullPadding: 30,
+};
 
 function parseHexColor(hex) {
-  if (!hex || hex[0] !== '#' || hex.length < 7) return { r: 128, g: 128, b: 128 }
-  return {
-    r: parseInt(hex.slice(1, 3), 16),
-    g: parseInt(hex.slice(3, 5), 16),
-    b: parseInt(hex.slice(5, 7), 16),
-  }
+	if (!hex || hex[0] !== "#" || hex.length < 7)
+		return { r: 128, g: 128, b: 128 };
+	return {
+		r: parseInt(hex.slice(1, 3), 16),
+		g: parseInt(hex.slice(3, 5), 16),
+		b: parseInt(hex.slice(5, 7), 16),
+	};
 }
 
 function darkenColor(hex, factor = 0.3) {
-  const { r, g, b } = parseHexColor(hex)
-  return `rgb(${Math.round(r * (1 - factor))},${Math.round(g * (1 - factor))},${Math.round(b * (1 - factor))})`
-}
-
-function lightenColor(hex, factor = 0.3) {
-  const { r, g, b } = parseHexColor(hex)
-  return `rgb(${Math.min(255, Math.round(r + (255 - r) * factor))},${Math.min(255, Math.round(g + (255 - g) * factor))},${Math.min(255, Math.round(b + (255 - b) * factor))})`
+	const { r, g, b } = parseHexColor(hex);
+	return `rgb(${Math.round(r * (1 - factor))},${Math.round(g * (1 - factor))},${Math.round(b * (1 - factor))})`;
 }
 
 function hexToRgba(hex, alpha) {
-  const { r, g, b } = parseHexColor(hex)
-  return `rgba(${r},${g},${b},${alpha})`
+	const { r, g, b } = parseHexColor(hex);
+	return `rgba(${r},${g},${b},${alpha})`;
 }
 
 function roundRect(ctx, x, y, w, h, r) {
-  const rr = Math.min(r, w / 2, h / 2)
-  ctx.beginPath()
-  ctx.moveTo(x + rr, y)
-  ctx.arcTo(x + w, y, x + w, y + h, rr)
-  ctx.arcTo(x + w, y + h, x, y + h, rr)
-  ctx.arcTo(x, y + h, x, y, rr)
-  ctx.arcTo(x, y, x + w, y, rr)
-  ctx.closePath()
+	const rr = Math.min(r, w / 2, h / 2);
+	ctx.beginPath();
+	ctx.moveTo(x + rr, y);
+	ctx.arcTo(x + w, y, x + w, y + h, rr);
+	ctx.arcTo(x + w, y + h, x, y + h, rr);
+	ctx.arcTo(x, y + h, x, y, rr);
+	ctx.arcTo(x, y, x + w, y, rr);
+	ctx.closePath();
 }
 
 const fixedPosForce = () => {
-  const self = { nodes: [] }
-  const res = function tick() {
-    for (let i = 0; i < self.nodes.length; i++) {
-      const n = self.nodes[i]
-      if (!n._posFixed) continue
-      n.x = n._posFixed.x
-      n.y = n._posFixed.y
-    }
-  }
-  res.initialize = (nodes) => (self.nodes = nodes)
-  res.setNodeCoords = (node, x, y) => {
-    node._posFixed = { x, y }
-    node.x = x
-    node.y = y
-  }
-  return res
-}
+	const self = { nodes: [] };
+	const res = function tick() {
+		for (let i = 0; i < self.nodes.length; i++) {
+			const n = self.nodes[i];
+			if (!n._posFixed) continue;
+			n.x = n._posFixed.x;
+			n.y = n._posFixed.y;
+		}
+	};
+	res.initialize = (nodes) => (self.nodes = nodes);
+	res.setNodeCoords = (node, x, y) => {
+		node._posFixed = { x, y };
+		node.x = x;
+		node.y = y;
+	};
+	return res;
+};
 
 // ArangoDB-style cluster force — reuses allocations
 const forceCluster = (strength = 0.35) => {
-  let nodes = []
-  // Reuse these maps across ticks to avoid GC
-  const centerX = new Map()
-  const centerY = new Map()
-  const counts = new Map()
+	let nodes = [];
+	// Reuse these maps across ticks to avoid GC
+	const centerX = new Map();
+	const centerY = new Map();
+	const counts = new Map();
 
-  function force(alpha) {
-    // Reset accumulators
-    centerX.forEach((_, k) => { centerX.set(k, 0); centerY.set(k, 0); counts.set(k, 0) })
+	function force(alpha) {
+		// Reset accumulators
+		centerX.forEach((_, k) => {
+			centerX.set(k, 0);
+			centerY.set(k, 0);
+			counts.set(k, 0);
+		});
 
-    for (let i = 0; i < nodes.length; i++) {
-      const n = nodes[i]
-      const g = n.group
-      if (!g) continue
-      if (!counts.has(g)) { centerX.set(g, 0); centerY.set(g, 0); counts.set(g, 0) }
-      centerX.set(g, centerX.get(g) + n.x)
-      centerY.set(g, centerY.get(g) + n.y)
-      counts.set(g, counts.get(g) + 1)
-    }
+		for (let i = 0; i < nodes.length; i++) {
+			const n = nodes[i];
+			const g = n.group;
+			if (!g) continue;
+			if (!counts.has(g)) {
+				centerX.set(g, 0);
+				centerY.set(g, 0);
+				counts.set(g, 0);
+			}
+			centerX.set(g, centerX.get(g) + n.x);
+			centerY.set(g, centerY.get(g) + n.y);
+			counts.set(g, counts.get(g) + 1);
+		}
 
-    // Normalize to centroids
-    counts.forEach((c, g) => {
-      if (c > 0) {
-        centerX.set(g, centerX.get(g) / c)
-        centerY.set(g, centerY.get(g) / c)
-      }
-    })
+		// Normalize to centroids
+		counts.forEach((c, g) => {
+			if (c > 0) {
+				centerX.set(g, centerX.get(g) / c);
+				centerY.set(g, centerY.get(g) / c);
+			}
+		});
 
-    const s = alpha * strength
-    for (let i = 0; i < nodes.length; i++) {
-      const n = nodes[i]
-      if (!n.group || n._posFixed) continue
-      const cx = centerX.get(n.group)
-      const cy = centerY.get(n.group)
-      if (cx === undefined) continue
-      n.vx += (cx - n.x) * s
-      n.vy += (cy - n.y) * s
-    }
-  }
+		const s = alpha * strength;
+		for (let i = 0; i < nodes.length; i++) {
+			const n = nodes[i];
+			if (!n.group || n._posFixed) continue;
+			const cx = centerX.get(n.group);
+			const cy = centerY.get(n.group);
+			if (cx === undefined) continue;
+			n.vx += (cx - n.x) * s;
+			n.vy += (cy - n.y) * s;
+		}
+	}
 
-  force.initialize = (_) => (nodes = _)
-  force.strength = (s) => { strength = s; return force }
-  return force
-}
+	force.initialize = (_) => (nodes = _);
+	force.strength = (s) => {
+		strength = s;
+		return force;
+	};
+	return force;
+};
 
 export default class D3Graph extends React.Component {
-  width = 100
-  height = 100
-  outer = React.createRef()
-  devicePixelRatio = window.devicePixelRatio || 1
-
-  state = {
-    transform: d3.zoomTransform({}),
-  }
-
-  document = {
-    nodes: new Map(),
-    edges: new Map(),
-  }
-
-  nodeDegrees = new Map()
-  adjacencyMap = new Map()
-  groupColors = new Map()
-  animationFrameId = null
-  lastFrameTime = 0
-  frameCount = 0
-
-  // Pre-cached per-node render data (avoids per-frame allocation)
-  nodeRenderCache = new Map()
-
-  // Cached hull paths (recomputed every HULL_INTERVAL frames)
-  cachedHulls = null
-
-  // Pulse animation state
-  pulsingNodes = new Map()
-
-  computeNodeDegrees = () => {
-    this.nodeDegrees.clear()
-    this.adjacencyMap.clear()
-
-    this.document.nodes.forEach((n) => {
-      this.nodeDegrees.set(n.id, 0)
-      this.adjacencyMap.set(n.id, new Set())
-    })
-
-    this.document.edges.forEach((edge) => {
-      const srcId = typeof edge.source === 'object' ? edge.source.id : edge.source
-      const tgtId = typeof edge.target === 'object' ? edge.target.id : edge.target
-      this.nodeDegrees.set(srcId, (this.nodeDegrees.get(srcId) || 0) + 1)
-      this.nodeDegrees.set(tgtId, (this.nodeDegrees.get(tgtId) || 0) + 1)
-      if (this.adjacencyMap.has(srcId)) this.adjacencyMap.get(srcId).add(tgtId)
-      if (this.adjacencyMap.has(tgtId)) this.adjacencyMap.get(tgtId).add(srcId)
-    })
-
-    this.maxDegree = 1
-    this.nodeDegrees.forEach((deg) => {
-      if (deg > this.maxDegree) this.maxDegree = deg
-    })
-
-    this.groupColors.clear()
-    this.document.nodes.forEach((n) => {
-      if (n.group && n.color && !this.groupColors.has(n.group)) {
-        this.groupColors.set(n.group, n.color)
-      }
-    })
-
-    // Pre-cache radius and colors per node (avoids recalc every frame)
-    this.nodeRenderCache.clear()
-    this.document.nodes.forEach((n) => {
-      const degree = this.nodeDegrees.get(n.id) || 0
-      let radius = DEFAULT_NODE_RADIUS
-      if (this.maxDegree > 1) {
-        const t = Math.sqrt(degree / this.maxDegree)
-        radius = MIN_NODE_RADIUS + t * (MAX_NODE_RADIUS - MIN_NODE_RADIUS)
-      }
-      const color = n.color || '#848484'
-      this.nodeRenderCache.set(n.id, {
-        radius,
-        degree,
-        color,
-        colorDark: darkenColor(color, 0.25),
-      })
-    })
-
-    this.cachedHulls = null // invalidate hull cache
-  }
-
-  getNodeRadius = (node) => {
-    const cached = this.nodeRenderCache.get(node.id)
-    return cached ? cached.radius : DEFAULT_NODE_RADIUS
-  }
-
-  isInNeighborhood = (nodeId) => {
-    const hoveredNode = this.props.activeNode
-    if (!hoveredNode || !this._isHovering) return true
-    if (nodeId === hoveredNode.id) return true
-    const neighbors = this.adjacencyMap.get(hoveredNode.id)
-    return neighbors && neighbors.has(nodeId)
-  }
-
-  isEdgeInNeighborhood = (edge) => {
-    const hoveredNode = this.props.activeNode
-    if (!hoveredNode || !this._isHovering) return true
-    const srcId = typeof edge.source === 'object' ? edge.source.id : edge.source
-    const tgtId = typeof edge.target === 'object' ? edge.target.id : edge.target
-    return srcId === hoveredNode.id || tgtId === hoveredNode.id
-  }
-
-  getWorldViewport = () => {
-    const k = this.state.transform.k
-    const tx = this.state.transform.x
-    const ty = this.state.transform.y
-    return {
-      x0: -tx / k, y0: -ty / k,
-      x1: (this.width - tx) / k, y1: (this.height - ty) / k,
-    }
-  }
-
-  isInViewport = (x, y, pad = 60) => {
-    const vp = this._viewport
-    if (!vp) return true
-    return x >= vp.x0 - pad && x <= vp.x1 + pad && y >= vp.y0 - pad && y <= vp.y1 + pad
-  }
-
-  // Hull computation — cached and throttled
-  computeHulls = () => {
-    const nodeCount = this.document.nodes.size
-    if (nodeCount > PERF.HUGE_GRAPH || nodeCount < 4) {
-      this.cachedHulls = []
-      return
-    }
-
-    const byGroup = new Map()
-    this.document.nodes.forEach((n) => {
-      if (!n.group) return
-      if (!byGroup.has(n.group)) byGroup.set(n.group, [])
-      byGroup.get(n.group).push([n.x, n.y])
-    })
-
-    const hulls = []
-    byGroup.forEach((points, group) => {
-      if (points.length < 3) return
-      const hull = d3.polygonHull(points)
-      if (!hull) return
-      hulls.push({ hull, color: this.groupColors.get(group) || '#888888' })
-    })
-    this.cachedHulls = hulls
-  }
-
-  drawHulls = (context) => {
-    if (!this.cachedHulls || !this.cachedHulls.length) return
-
-    context.save()
-    context.lineJoin = 'round'
-    context.lineWidth = 1.5
-
-    for (let h = 0; h < this.cachedHulls.length; h++) {
-      const { hull, color } = this.cachedHulls[h]
-      context.fillStyle = hexToRgba(color, THEME.hullAlpha)
-      context.strokeStyle = hexToRgba(color, THEME.hullStrokeAlpha)
-
-      const pad = THEME.hullPadding
-      context.beginPath()
-      for (let i = 0; i < hull.length; i++) {
-        const p0 = hull[(i - 1 + hull.length) % hull.length]
-        const p1 = hull[i]
-        const p2 = hull[(i + 1) % hull.length]
-        const v1x = p1[0] - p0[0], v1y = p1[1] - p0[1]
-        const v2x = p2[0] - p1[0], v2y = p2[1] - p1[1]
-        const len1 = Math.hypot(v1x, v1y) || 1
-        const len2 = Math.hypot(v2x, v2y) || 1
-        const pInX = p1[0] - (v1x / len1) * pad, pInY = p1[1] - (v1y / len1) * pad
-        const pOutX = p1[0] + (v2x / len2) * pad, pOutY = p1[1] + (v2y / len2) * pad
-        if (i === 0) context.moveTo(pInX, pInY)
-        else context.lineTo(pInX, pInY)
-        context.quadraticCurveTo(p1[0], p1[1], pOutX, pOutY)
-      }
-      context.closePath()
-      context.fill()
-      context.stroke()
-    }
-    context.restore()
-  }
-
-  // Minimap — throttled, simple rendering
-  drawMinimap = () => {
-    if (!this.minimapCanvas || !this.document.nodes.size) return
-    // Only redraw minimap every N frames
-    if (this.frameCount % PERF.MINIMAP_INTERVAL !== 0) return
-
-    const mmw = this.minimapCanvas.width
-    const mmh = this.minimapCanvas.height
-    const mmctx = this.minimapContext
-
-    mmctx.clearRect(0, 0, mmw, mmh)
-
-    mmctx.fillStyle = 'rgba(20, 22, 30, 0.85)'
-    roundRect(mmctx, 0, 0, mmw, mmh, 6)
-    mmctx.fill()
-
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
-    this.document.nodes.forEach((n) => {
-      if (n.x < minX) minX = n.x
-      if (n.y < minY) minY = n.y
-      if (n.x > maxX) maxX = n.x
-      if (n.y > maxY) maxY = n.y
-    })
-
-    const pad = 10
-    const gw = (maxX - minX) || 1
-    const gh = (maxY - minY) || 1
-    const sx = (mmw - pad * 2) / gw
-    const sy = (mmh - pad * 2) / gh
-    const s = Math.min(sx, sy)
-    const ox = (mmw - s * gw) / 2
-    const oy = (mmh - s * gh) / 2
-
-    mmctx.save()
-    mmctx.translate(ox - minX * s, oy - minY * s)
-    mmctx.scale(s, s)
-
-    // Skip edges in minimap for large graphs
-    if (this.document.edges.size < 500) {
-      mmctx.strokeStyle = 'rgba(255,255,255,0.1)'
-      mmctx.lineWidth = 1 / s
-      mmctx.beginPath()
-      this.document.edges.forEach((edge) => {
-        if (!edge.source.x) return
-        mmctx.moveTo(edge.source.x, edge.source.y)
-        mmctx.lineTo(edge.target.x, edge.target.y)
-      })
-      mmctx.stroke()
-    }
-
-    // Batch node drawing by color for fewer state changes
-    const dotSize = Math.max(1.5, 2 / s)
-    mmctx.globalAlpha = 0.8
-    // Simple single-pass: just draw all nodes as one color for speed
-    mmctx.fillStyle = 'rgba(180,190,200,0.9)'
-    mmctx.beginPath()
-    this.document.nodes.forEach((n) => {
-      mmctx.moveTo(n.x + dotSize, n.y)
-      mmctx.arc(n.x, n.y, dotSize, 0, Math.PI * 2)
-    })
-    mmctx.fill()
-    mmctx.globalAlpha = 1
-
-    // Viewport rectangle
-    const vp = this.getWorldViewport()
-    mmctx.strokeStyle = 'rgba(80,166,255,0.9)'
-    mmctx.lineWidth = 2 / s
-    mmctx.fillStyle = 'rgba(80,166,255,0.08)'
-    mmctx.strokeRect(vp.x0, vp.y0, vp.x1 - vp.x0, vp.y1 - vp.y0)
-    mmctx.fillRect(vp.x0, vp.y0, vp.x1 - vp.x0, vp.y1 - vp.y0)
-
-    mmctx.restore()
-  }
-
-  labelEdge = (context, edge) => {
-    const zoom = this.state.transform.k * this.devicePixelRatio
-    if (this.document.edges.size > 200 && zoom < 1.5) return
-    if (this.document.edges.size > 40 && zoom < 1.0) return
-    if (zoom < 0.6) return
-
-    const srcR = this.getNodeRadius(edge.source)
-    const tgtR = this.getNodeRadius(edge.target)
-    if (edge.arc.distance < srcR + tgtR + 40) return
-
-    const fontSize = 11
-    context.font = `500 ${fontSize}px ${THEME.labelFont}`
-    context.textAlign = 'center'
-    context.textBaseline = 'middle'
-
-    const maxWidth = 120
-    const bgPadding = 4
-    let { width } = context.measureText(edge.label)
-    width = Math.min(width, maxWidth)
-
-    const { centerX: cx, centerY: cy } = edge.arc
-    const rw = width + 2 * bgPadding
-    const rh = fontSize + bgPadding
-
-    context.globalAlpha = 0.88
-    context.fillStyle = '#ffffff'
-    roundRect(context, cx - rw / 2, cy - rh / 2, rw, rh, 3)
-    context.fill()
-    context.globalAlpha = 1
-
-    context.fillStyle = '#333333'
-    context.fillText(edge.label, cx, cy, maxWidth)
-  }
-
-  labelNode = (context, node) => {
-    const zoom = this.state.transform.k * this.devicePixelRatio
-    const nodeCount = this.document.nodes.size
-    const cached = this.nodeRenderCache.get(node.id)
-    const degree = cached ? cached.degree : 0
-    const radius = cached ? cached.radius : DEFAULT_NODE_RADIUS
-
-    if (nodeCount > 500 && zoom < 2.0 && degree < 3) return
-    if (nodeCount > 200 && zoom < 1.2 && degree < 2) return
-    if (nodeCount > 50 && zoom < 0.8) return
-    if (zoom < 0.4) return
-    if (nodeCount > 100 && degree < 2 && zoom < 1.5) return
-
-    const label = node.label || ''
-    if (!label) return
-
-    const fontSize = Math.max(10, Math.min(14, radius * 0.9))
-    context.font = `600 ${fontSize}px ${THEME.labelFont}`
-    context.textAlign = 'center'
-    context.textBaseline = 'middle'
-
-    const maxWidth = radius * 4
-    let { width: textWidth } = context.measureText(label)
-    textWidth = Math.min(textWidth, maxWidth)
-
-    const bgPadding = 3
-    const textY = node.y + radius + fontSize / 2 + 4
-    const rw = textWidth + 2 * bgPadding
-    const rh = fontSize + bgPadding
-
-    context.globalAlpha = 0.88
-    context.fillStyle = '#2A2C34'
-    roundRect(context, node.x - rw / 2, textY - rh / 2, rw, rh, rh / 2)
-    context.fill()
-    context.globalAlpha = 1
-
-    context.fillStyle = '#FFFFFF'
-    context.fillText(label, node.x, textY, maxWidth)
-  }
-
-  _drawAll = () => {
-    const context = this.canvasContext
-    if (!context) return
-
-    const { highlightPredicate } = this.props
-    this._isHovering = !!this.props.hoveredNode
-    this.frameCount++
-
-    context.save()
-    const { devicePixelRatio: dpr } = this
-    context.clearRect(0, 0, this.width * dpr, this.height * dpr)
-    context.translate(this.state.transform.x * dpr, this.state.transform.y * dpr)
-    context.scale(this.state.transform.k * dpr, this.state.transform.k * dpr)
-
-    this._viewport = this.getWorldViewport()
-
-    const zoom = this.state.transform.k * dpr
-    const isZoomedOut = zoom < 0.3
-    const nodeCount = this.document.nodes.size
-    const isLargeGraph = nodeCount > PERF.LARGE_GRAPH
-    const isHugeGraph = nodeCount > PERF.HUGE_GRAPH
-
-    // --- Hulls (throttled) ---
-    if (!isZoomedOut && !isHugeGraph) {
-      if (this.frameCount % PERF.HULL_INTERVAL === 0 || !this.cachedHulls) {
-        this.computeHulls()
-      }
-      this.drawHulls(context)
-    }
-
-    // --- Arc helpers (defined once, not per-edge) ---
-    const addArrow = (arc, target, vx, vy, nodeRadius) => {
-      const baseOffset = nodeRadius + ARROW_LENGTH
-      arc.arrowBase0 = target.x - vx * baseOffset
-      arc.arrowBase1 = target.y - vy * baseOffset
-      arc.arrowEnd0 = target.x - nodeRadius * vx
-      arc.arrowEnd1 = target.y - nodeRadius * vy
-      arc.arrowPt10 = arc.arrowBase0 + ARROW_WIDTH * vy
-      arc.arrowPt11 = arc.arrowBase1 - ARROW_WIDTH * vx
-      arc.arrowPt20 = arc.arrowBase0 - ARROW_WIDTH * vy
-      arc.arrowPt21 = arc.arrowBase1 + ARROW_WIDTH * vx
-      arc.hasArrow = true
-    }
-
-    const getArc = (edge) => {
-      const dx = edge.target.x - edge.source.x
-      const dy = edge.target.y - edge.source.y
-      const l = Math.sqrt(dx * dx + dy * dy)
-
-      const srcR = this.getNodeRadius(edge.source)
-      const tgtR = this.getNodeRadius(edge.target)
-
-      const arc = { radius: -1, distance: l, centerX: edge.source.x + dx / 2, centerY: edge.source.y + dy / 2, hasArrow: false }
-
-      if (!edge.siblingCount || edge.siblingCount < 2 ||
-          (edge.siblingCount % 2 && edge.siblingIndex === 0) ||
-          l < srcR + tgtR) {
-        if (l > srcR + tgtR + 2 * ARROW_LENGTH) {
-          addArrow(arc, edge.target, dx / l, dy / l, tgtR)
-        }
-        return arc
-      }
-
-      const LR = 4
-      let offset
-      if (edge.siblingCount % 2) {
-        offset = LR * (1 + Math.ceil(edge.siblingIndex / 2) * 2)
-      } else {
-        offset = LR * (1 + Math.floor(edge.siblingIndex / 2) * 2)
-      }
-      if (edge.siblingCount * LR > (0.9 * l) / 2) {
-        offset = (offset * 0.9 * l) / 2 / edge.siblingCount / LR
-      }
-
-      const norm0 = edge.siblingIndex % 2 ? dy / l : -dy / l
-      const norm1 = edge.siblingIndex % 2 ? -dx / l : dx / l
-      const R = (offset * offset + (l * l) / 4) / 2 / offset
-      const h2 = (R * offset) / (R - offset)
-
-      arc.radius = R
-      arc.centerX = edge.source.x + dx / 2 + norm0 * offset
-      arc.centerY = edge.source.y + dy / 2 + norm1 * offset
-      arc.controlX = edge.source.x + dx / 2 + norm0 * (offset + h2)
-      arc.controlY = edge.source.y + dy / 2 + norm1 * (offset + h2)
-
-      if (l > srcR + tgtR + 2 * ARROW_LENGTH) {
-        const rotateDir = edge.siblingIndex % 2 ? +1 : -1
-        const alpha = Math.asin(Math.min(1, l / 2 / R))
-        const theta = Math.asin(Math.min(1, tgtR / 2 / R))
-        const ra = rotateDir * (alpha - theta)
-        const cosA = Math.cos(ra), sinA = Math.sin(ra)
-        const ndx = dx / l, ndy = dy / l
-        addArrow(arc, edge.target, ndx * cosA - ndy * sinA, ndx * sinA + ndy * cosA, tgtR)
-      }
-
-      return arc
-    }
-
-    // --- Edges ---
-    context.lineCap = 'round'
-    let edgesDrawn = 0
-    this.document.edges.forEach((edge) => {
-      // Hard cap on visible edges for huge graphs
-      if (isHugeGraph && edgesDrawn >= PERF.MAX_VISIBLE_EDGES) return
-
-      // Viewport culling
-      if (!this.isInViewport(edge.source.x, edge.source.y, 100) &&
-          !this.isInViewport(edge.target.x, edge.target.y, 100)) return
-
-      edgesDrawn++
-      const arc = (edge.arc = getArc(edge))
-
-      const isHighlighted = edge.predicate === highlightPredicate
-      const isActive = edge === this.props.activeEdge
-      const inNeighborhood = this.isEdgeInNeighborhood(edge)
-
-      context.strokeStyle = edge.color
-      if (this._isHovering && !inNeighborhood) {
-        context.globalAlpha = THEME.edgeAlphaDimmed
-        context.lineWidth = 0.5
-      } else if (isActive) {
-        context.globalAlpha = THEME.edgeAlphaHighlight
-        context.lineWidth = THEME.edgeWidthActive
-      } else if (isHighlighted || (this._isHovering && inNeighborhood)) {
-        context.globalAlpha = THEME.edgeAlphaHighlight
-        context.lineWidth = THEME.edgeWidthHighlight
-      } else {
-        context.globalAlpha = THEME.edgeAlphaDefault
-        context.lineWidth = THEME.edgeWidthDefault
-      }
-
-      context.beginPath()
-      context.moveTo(edge.source.x, edge.source.y)
-      if (arc.radius <= 0) {
-        context.lineTo(edge.target.x, edge.target.y)
-      } else {
-        context.arcTo(arc.controlX, arc.controlY, edge.target.x, edge.target.y, arc.radius)
-      }
-      context.stroke()
-
-      // Arrowhead — skip for huge graphs when zoomed out
-      if (arc.hasArrow && !(isHugeGraph && isZoomedOut)) {
-        context.fillStyle = edge.color
-        context.beginPath()
-        context.moveTo(arc.arrowEnd0, arc.arrowEnd1)
-        context.lineTo(arc.arrowPt10, arc.arrowPt11)
-        context.lineTo(arc.arrowPt20, arc.arrowPt21)
-        context.closePath()
-        context.fill()
-      }
-
-      context.globalAlpha = 1
-      if (!isLargeGraph && (!this._isHovering || inNeighborhood)) {
-        this.labelEdge(context, edge)
-      }
-    })
-
-    // --- Nodes ---
-    this.document.nodes.forEach((d) => {
-      if (!this.isInViewport(d.x, d.y, 50)) return
-
-      const cached = this.nodeRenderCache.get(d.id)
-      const radius = cached ? cached.radius : DEFAULT_NODE_RADIUS
-      const color = cached ? cached.color : '#848484'
-      const isActive = d === this.props.activeNode
-      const inNeighborhood = this.isInNeighborhood(d.id)
-      const dimmed = this._isHovering && !inNeighborhood
-
-      if (dimmed) context.globalAlpha = THEME.nodeDimmedAlpha
-
-      // LOD: dots at very low zoom
-      if (isZoomedOut) {
-        context.fillStyle = color
-        context.beginPath()
-        context.arc(d.x, d.y, Math.max(2, radius * 0.3), 0, 2 * Math.PI)
-        context.fill()
-        context.globalAlpha = 1
-        return
-      }
-
-      // Solid fill
-      context.fillStyle = color
-      context.beginPath()
-      context.arc(d.x, d.y, radius, 0, 2 * Math.PI, true)
-      context.fill()
-
-      // Border
-      context.strokeStyle = cached ? cached.colorDark : darkenColor(color, 0.25)
-      context.lineWidth = isActive ? THEME.nodeBorderActive : THEME.nodeBorderDefault
-      context.stroke()
-
-      // Active glow
-      if (isActive && !dimmed) {
-        context.strokeStyle = color
-        context.globalAlpha = 0.4
-        context.lineWidth = 4
-        context.beginPath()
-        context.arc(d.x, d.y, radius + 4, 0, 2 * Math.PI, true)
-        context.stroke()
-        context.globalAlpha = dimmed ? THEME.nodeDimmedAlpha : 1
-      }
-
-      // Search pulse
-      const pulse = this.pulsingNodes.get(d.id)
-      if (pulse && pulse > 0) {
-        context.strokeStyle = '#50A6FF'
-        context.globalAlpha = 0.6 * pulse
-        context.lineWidth = 8 * pulse
-        context.beginPath()
-        context.arc(d.x, d.y, radius + 10 * (1 - pulse), 0, 2 * Math.PI)
-        context.stroke()
-        context.globalAlpha = 1
-      }
-
-      // Expanded dot
-      if (d.expanded) {
-        context.fillStyle = '#ffffff'
-        context.beginPath()
-        context.arc(d.x + radius * 0.55, d.y - radius * 0.55, 3, 0, 2 * Math.PI)
-        context.fill()
-      }
-
-      context.globalAlpha = 1
-      if (!dimmed) this.labelNode(context, d)
-    })
-
-    context.restore()
-    this.drawMinimap()
-  }
-
-  startAnimationLoop = () => {
-    const animate = (timestamp) => {
-      const delta = timestamp - (this.lastFrameTime || timestamp)
-      this.lastFrameTime = timestamp
-
-      let hasPulse = false
-      this.pulsingNodes.forEach((val, key) => {
-        const newVal = val - delta * 0.002
-        if (newVal <= 0) this.pulsingNodes.delete(key)
-        else { this.pulsingNodes.set(key, newVal); hasPulse = true }
-      })
-
-      if (hasPulse) this._drawAll()
-
-      this.animationFrameId = requestAnimationFrame(animate)
-    }
-    this.animationFrameId = requestAnimationFrame(animate)
-  }
-
-  drawGraph = debounce(this._drawAll, 5, { leading: true, trailing: true })
-
-  createForces = () => {
-    this.d3simulation
-      .alphaTarget(0)
-      .alphaMin(0.005)
-      .alphaDecay(0.05)
-      .velocityDecay(0.5)
-      .force('link', d3.forceLink()
-        .distance((d) => {
-          const srcDeg = this.nodeDegrees.get(typeof d.source === 'object' ? d.source.id : d.source) || 1
-          const tgtDeg = this.nodeDegrees.get(typeof d.target === 'object' ? d.target.id : d.target) || 1
-          const srcG = typeof d.source === 'object' ? d.source.group : null
-          const tgtG = typeof d.target === 'object' ? d.target.group : null
-          const cross = srcG && tgtG && srcG !== tgtG
-          return (cross ? 100 : 60) + Math.sqrt(srcDeg + tgtDeg) * 15
-        })
-        .strength((d) => {
-          const srcG = typeof d.source === 'object' ? d.source.group : null
-          const tgtG = typeof d.target === 'object' ? d.target.group : null
-          return srcG === tgtG ? 0.4 : 0.15
-        })
-        .id((d) => d.id),
-      )
-      .force('charge', d3.forceManyBody()
-        .strength((d) => {
-          const degree = this.nodeDegrees.get(d.id) || 0
-          return -200 - degree * 30
-        })
-        .distanceMax(500)
-        .theta(0.9),
-      )
-      .force('collision', d3.forceCollide()
-        .radius((d) => this.getNodeRadius(d) + 8)
-        .strength(0.8),
-      )
-      .force('cluster', forceCluster(0.35))
-      .force('fixedPosForce', fixedPosForce())
-
-    this.fixedPosForce = this.d3simulation.force('fixedPosForce')
-    this.edgesForce = this.d3simulation.force('link')
-  }
-
-  componentDidMount() {
-    this.d3simulation = d3.forceSimulation().on('tick', this.drawGraph)
-    this.createForces()
-
-    this.graphCanvas = d3
-      .select(this.outer.current)
-      .append('canvas')
-      .attr('width', this.width)
-      .attr('height', this.height)
-      .node()
-
-    this.minimapCanvas = document.createElement('canvas')
-    this.minimapCanvas.className = 'graph-minimap'
-    this.minimapCanvas.width = 180
-    this.minimapCanvas.height = 120
-    this.outer.current.appendChild(this.minimapCanvas)
-    this.minimapContext = this.minimapCanvas.getContext('2d')
-    this.minimapCanvas.addEventListener('click', this.onMinimapClick)
-
-    this.zoomBehavior = d3
-      .zoom()
-      .scaleExtent([(1 / 8) * this.devicePixelRatio, 6 * this.devicePixelRatio])
-      .on('zoom', this.onZoom)
-
-    d3.select(this.graphCanvas)
-      .on('click', this.onClick)
-      .on('dblclick', this.onDoubleClick)
-      .on('mousemove', this.onMouseMove)
-      .call(d3.drag().subject(this.dragsubject).on('start', this.dragstarted).on('drag', this.dragged))
-      .call(this.zoomBehavior)
-
-    this.onResize()
-    this.updateDocument(this.props.nodes, this.props.edges)
-    this.startAnimationLoop()
-    this.resizeObserver = window.setInterval(this.onResize, 1000)
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.resizeObserver)
-    if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId)
-    if (this.minimapCanvas) this.minimapCanvas.removeEventListener('click', this.onMinimapClick)
-  }
-
-  onMinimapClick = (e) => {
-    if (!this.document.nodes.size) return
-    const rect = this.minimapCanvas.getBoundingClientRect()
-    const px = e.clientX - rect.left, py = e.clientY - rect.top
-    const mmw = this.minimapCanvas.width, mmh = this.minimapCanvas.height
-
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
-    this.document.nodes.forEach((n) => {
-      if (n.x < minX) minX = n.x; if (n.y < minY) minY = n.y
-      if (n.x > maxX) maxX = n.x; if (n.y > maxY) maxY = n.y
-    })
-
-    const pad = 10, gw = (maxX - minX) || 1, gh = (maxY - minY) || 1
-    const s = Math.min((mmw - pad * 2) / gw, (mmh - pad * 2) / gh)
-    const ox = (mmw - s * gw) / 2, oy = (mmh - s * gh) / 2
-    const wx = (px - ox + minX * s) / s, wy = (py - oy + minY * s) / s
-
-    const k = this.state.transform.k
-    d3.select(this.graphCanvas).transition().duration(300)
-      .call(this.zoomBehavior.transform, d3.zoomIdentity.translate(this.width / 2 - wx * k, this.height / 2 - wy * k).scale(k))
-  }
-
-  getD3EventCoords = (event) => this.state.transform.invert([event.x, event.y])
-
-  findNodeAtPos = (x, y) => {
-    let minNode, minD = 1e10
-    this.document.nodes.forEach((n) => {
-      const r = this.getNodeRadius(n)
-      const d = (n.x - x) * (n.x - x) + (n.y - y) * (n.y - y)
-      if (d < r * r && d < minD) { minNode = n; minD = d }
-    })
-    return minNode
-  }
-
-  findEdgeAtPos = (x, y) => {
-    let minEdge, minD = 1e10
-    this.document.edges.forEach((edge) => {
-      if (!edge.arc) return
-      const { centerX: cx, centerY: cy } = edge.arc
-      const d = (cx - x) * (cx - x) + (cy - y) * (cy - y)
-      if (d < minD) { minEdge = edge; minD = d }
-    })
-    return minD > 225 ? undefined : minEdge
-  }
-
-  onMouseMove = () => {
-    const { offsetX: x, offsetY: y } = currentEvent
-    const pt = this.getD3EventCoords({ x, y })
-    const node = this.findNodeAtPos(...pt)
-    this.props.onNodeHovered(node)
-    if (this.graphCanvas) this.graphCanvas.style.cursor = node ? 'pointer' : 'default'
-    if (!node) this.props.onEdgeHovered(this.findEdgeAtPos(...pt))
-    this.drawGraph()
-  }
-
-  onClick = () => {
-    const { offsetX: x, offsetY: y } = currentEvent
-    const pt = this.getD3EventCoords({ x, y })
-    const node = this.findNodeAtPos(...pt)
-    if (node) { currentEvent.stopImmediatePropagation(); return this.props.onNodeSelected(node) }
-    const edge = this.findEdgeAtPos(...pt)
-    if (edge) { currentEvent.stopImmediatePropagation(); return this.props.onEdgeSelected(edge) }
-  }
-
-  onDoubleClick = () => {
-    const { offsetX: x, offsetY: y } = currentEvent
-    const pt = this.getD3EventCoords({ x, y })
-    const node = this.findNodeAtPos(...pt)
-    if (node) { currentEvent.stopImmediatePropagation(); return this.props.onNodeDoubleClicked(node) }
-  }
-
-  dragsubject = () => {
-    const { offsetX: x, offsetY: y } = currentEvent.sourceEvent
-    const pt = this.getD3EventCoords({ x, y })
-    const node = this.findNodeAtPos(...pt)
-    this.props.onNodeSelected(node)
-    return node
-  }
-
-  dragstarted = () => {
-    if (!currentEvent.active) setTimeout(() => this.d3simulation.alpha(0.5).restart(), DOUBLE_CLICK_MS)
-  }
-
-  dragged = () => {
-    const { offsetX: x, offsetY: y } = currentEvent.sourceEvent
-    const pt = this.getD3EventCoords({ x, y })
-    this.fixedPosForce.setNodeCoords(currentEvent.subject, ...pt)
-    this.drawGraph()
-    this.d3simulation.alpha(Math.max(0.12, this.d3simulation.alpha()))
-  }
-
-  _updateZoom = (transform) => {
-    if (this.state.transform.toString() !== transform.toString()) this.setState({ transform })
-  }
-  updateZoom = debounce(this._updateZoom, 2, { leading: true, trailing: true })
-  onZoom = () => this.updateZoom(currentEvent.transform)
-
-  zoomToFit = () => {
-    if (!this.graphCanvas || !this.document.nodes.size) return
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
-    this.document.nodes.forEach((n) => {
-      const r = this.getNodeRadius(n) + 20
-      if (n.x - r < minX) minX = n.x - r; if (n.y - r < minY) minY = n.y - r
-      if (n.x + r > maxX) maxX = n.x + r; if (n.y + r > maxY) maxY = n.y + r
-    })
-    const p = 40, gw = maxX - minX + p * 2, gh = maxY - minY + p * 2
-    const scale = Math.min(this.width / gw, this.height / gh, 2) * 0.9
-    const transform = d3.zoomIdentity.translate(this.width / 2, this.height / 2).scale(scale).translate(-(minX + maxX) / 2, -(minY + maxY) / 2)
-    d3.select(this.graphCanvas).transition().duration(500).call(this.zoomBehavior.transform, transform)
-  }
-
-  focusNode = (node) => {
-    if (!this.graphCanvas || !node) return
-    const k = 2.2
-    d3.select(this.graphCanvas).transition().duration(500).ease(d3.easeCubicOut)
-      .call(this.zoomBehavior.transform, d3.zoomIdentity.translate(this.width / 2 - node.x * k, this.height / 2 - node.y * k).scale(k))
-    this.pulsingNodes.set(node.id, 1.0)
-  }
-
-  searchNode = (query) => {
-    if (!query) return null
-    const q = query.toLowerCase().trim()
-    let found = null
-    this.document.nodes.forEach((n) => {
-      if (found) return
-      const name = (n.name || n.label || '').toLowerCase()
-      const uid = (n.uid || n.id || '').toLowerCase()
-      if (name.includes(q) || uid === q) found = n
-    })
-    return found
-  }
-
-  onResize = () => {
-    let resized = false
-    if (this.outer.current) {
-      const el = this.outer.current
-      resized |= this.width !== el.offsetWidth
-      resized |= this.height !== el.offsetHeight
-      this.width = el.offsetWidth
-      this.height = el.offsetHeight
-    }
-    if (!resized) return
-
-    this.zoomBehavior.scaleTo(d3.select(this.graphCanvas), 1)
-    this.zoomBehavior.translateTo(d3.select(this.graphCanvas), 0, 0)
-
-    const { width, height } = this
-    this.d3simulation
-      .force('x', d3.forceX(0).strength((0.02 * height) / width))
-      .force('y', d3.forceY(0).strength((0.02 * width) / height))
-
-    d3.select(this.graphCanvas)
-      .attr('width', this.width * this.devicePixelRatio)
-      .attr('height', this.height * this.devicePixelRatio)
-
-    this.canvasContext = this.graphCanvas.getContext('2d')
-    this._drawAll()
-  }
-
-  updateDocument = (nodes, edges) => {
-    if (!this.d3simulation || !nodes || !edges) return
-
-    const newNodesReceived = this.document.nodesLength !== nodes.size || this.document.edgesLength !== edges.size
-
-    this.document = { edges, edgesLength: edges.size, nodes, nodesLength: nodes.size }
-    this.computeNodeDegrees()
-
-    if (newNodesReceived) {
-      this.d3simulation
-        .force('link', d3.forceLink()
-          .distance((d) => {
-            const srcDeg = this.nodeDegrees.get(typeof d.source === 'object' ? d.source.id : d.source) || 1
-            const tgtDeg = this.nodeDegrees.get(typeof d.target === 'object' ? d.target.id : d.target) || 1
-            const srcG = typeof d.source === 'object' ? d.source.group : null
-            const tgtG = typeof d.target === 'object' ? d.target.group : null
-            return ((srcG && tgtG && srcG !== tgtG) ? 100 : 60) + Math.sqrt(srcDeg + tgtDeg) * 15
-          })
-          .strength((d) => {
-            const srcG = typeof d.source === 'object' ? d.source.group : null
-            const tgtG = typeof d.target === 'object' ? d.target.group : null
-            return srcG === tgtG ? 0.4 : 0.15
-          })
-          .id((d) => d.id),
-        )
-        .force('charge', d3.forceManyBody()
-          .strength((d) => -200 - (this.nodeDegrees.get(d.id) || 0) * 30)
-          .distanceMax(500).theta(0.9),
-        )
-        .force('collision', d3.forceCollide().radius((d) => this.getNodeRadius(d) + 8).strength(0.8))
-        .force('cluster', forceCluster(0.35))
-
-      this.edgesForce = this.d3simulation.force('link')
-      this.d3simulation.alpha(0.5).restart()
-    }
-
-    this.d3simulation.nodes(Array.from(nodes.values()))
-    this.edgesForce.links(Array.from(edges.values()))
-  }
-
-  render() {
-    this.updateDocument(this.props.nodes, this.props.edges)
-    this.onResize()
-    this.drawGraph()
-    return <div ref={this.outer} className='graph-outer' />
-  }
+	width = 100;
+	height = 100;
+	outer = React.createRef();
+	devicePixelRatio = window.devicePixelRatio || 1;
+
+	state = {
+		transform: d3.zoomTransform({}),
+	};
+
+	document = {
+		nodes: new Map(),
+		edges: new Map(),
+	};
+
+	nodeDegrees = new Map();
+	adjacencyMap = new Map();
+	groupColors = new Map();
+	animationFrameId = null;
+	lastFrameTime = 0;
+	frameCount = 0;
+
+	// Pre-cached per-node render data (avoids per-frame allocation)
+	nodeRenderCache = new Map();
+
+	// Cached hull paths (recomputed every HULL_INTERVAL frames)
+	cachedHulls = null;
+
+	// Pulse animation state
+	pulsingNodes = new Map();
+
+	computeNodeDegrees = () => {
+		this.nodeDegrees.clear();
+		this.adjacencyMap.clear();
+
+		this.document.nodes.forEach((n) => {
+			this.nodeDegrees.set(n.id, 0);
+			this.adjacencyMap.set(n.id, new Set());
+		});
+
+		this.document.edges.forEach((edge) => {
+			const srcId =
+				typeof edge.source === "object" ? edge.source.id : edge.source;
+			const tgtId =
+				typeof edge.target === "object" ? edge.target.id : edge.target;
+			this.nodeDegrees.set(srcId, (this.nodeDegrees.get(srcId) || 0) + 1);
+			this.nodeDegrees.set(tgtId, (this.nodeDegrees.get(tgtId) || 0) + 1);
+			if (this.adjacencyMap.has(srcId)) this.adjacencyMap.get(srcId).add(tgtId);
+			if (this.adjacencyMap.has(tgtId)) this.adjacencyMap.get(tgtId).add(srcId);
+		});
+
+		this.maxDegree = 1;
+		this.nodeDegrees.forEach((deg) => {
+			if (deg > this.maxDegree) this.maxDegree = deg;
+		});
+
+		this.groupColors.clear();
+		this.document.nodes.forEach((n) => {
+			if (n.group && n.color && !this.groupColors.has(n.group)) {
+				this.groupColors.set(n.group, n.color);
+			}
+		});
+
+		// Pre-cache radius and colors per node (avoids recalc every frame)
+		this.nodeRenderCache.clear();
+		this.document.nodes.forEach((n) => {
+			const degree = this.nodeDegrees.get(n.id) || 0;
+			let radius = DEFAULT_NODE_RADIUS;
+			if (this.maxDegree > 1) {
+				const t = Math.sqrt(degree / this.maxDegree);
+				radius = MIN_NODE_RADIUS + t * (MAX_NODE_RADIUS - MIN_NODE_RADIUS);
+			}
+			const color = n.color || "#848484";
+			this.nodeRenderCache.set(n.id, {
+				radius,
+				degree,
+				color,
+				colorDark: darkenColor(color, 0.25),
+			});
+		});
+
+		this.cachedHulls = null; // invalidate hull cache
+	};
+
+	getNodeRadius = (node) => {
+		const cached = this.nodeRenderCache.get(node.id);
+		return cached ? cached.radius : DEFAULT_NODE_RADIUS;
+	};
+
+	isInNeighborhood = (nodeId) => {
+		const hoveredNode = this.props.activeNode;
+		if (!hoveredNode || !this._isHovering) return true;
+		if (nodeId === hoveredNode.id) return true;
+		const neighbors = this.adjacencyMap.get(hoveredNode.id);
+		return neighbors && neighbors.has(nodeId);
+	};
+
+	isEdgeInNeighborhood = (edge) => {
+		const hoveredNode = this.props.activeNode;
+		if (!hoveredNode || !this._isHovering) return true;
+		const srcId =
+			typeof edge.source === "object" ? edge.source.id : edge.source;
+		const tgtId =
+			typeof edge.target === "object" ? edge.target.id : edge.target;
+		return srcId === hoveredNode.id || tgtId === hoveredNode.id;
+	};
+
+	getWorldViewport = () => {
+		const k = this.state.transform.k;
+		const tx = this.state.transform.x;
+		const ty = this.state.transform.y;
+		return {
+			x0: -tx / k,
+			y0: -ty / k,
+			x1: (this.width - tx) / k,
+			y1: (this.height - ty) / k,
+		};
+	};
+
+	isInViewport = (x, y, pad = 60) => {
+		const vp = this._viewport;
+		if (!vp) return true;
+		return (
+			x >= vp.x0 - pad &&
+			x <= vp.x1 + pad &&
+			y >= vp.y0 - pad &&
+			y <= vp.y1 + pad
+		);
+	};
+
+	// Hull computation — cached and throttled
+	computeHulls = () => {
+		const nodeCount = this.document.nodes.size;
+		if (nodeCount > PERF.HUGE_GRAPH || nodeCount < 4) {
+			this.cachedHulls = [];
+			return;
+		}
+
+		const byGroup = new Map();
+		this.document.nodes.forEach((n) => {
+			if (!n.group) return;
+			if (!byGroup.has(n.group)) byGroup.set(n.group, []);
+			byGroup.get(n.group).push([n.x, n.y]);
+		});
+
+		const hulls = [];
+		byGroup.forEach((points, group) => {
+			if (points.length < 3) return;
+			const hull = d3.polygonHull(points);
+			if (!hull) return;
+			hulls.push({ hull, color: this.groupColors.get(group) || "#888888" });
+		});
+		this.cachedHulls = hulls;
+	};
+
+	drawHulls = (context) => {
+		if (!this.cachedHulls || !this.cachedHulls.length) return;
+
+		context.save();
+		context.lineJoin = "round";
+		context.lineWidth = 1.5;
+
+		for (let h = 0; h < this.cachedHulls.length; h++) {
+			const { hull, color } = this.cachedHulls[h];
+			context.fillStyle = hexToRgba(color, THEME.hullAlpha);
+			context.strokeStyle = hexToRgba(color, THEME.hullStrokeAlpha);
+
+			const pad = THEME.hullPadding;
+			context.beginPath();
+			for (let i = 0; i < hull.length; i++) {
+				const p0 = hull[(i - 1 + hull.length) % hull.length];
+				const p1 = hull[i];
+				const p2 = hull[(i + 1) % hull.length];
+				const v1x = p1[0] - p0[0],
+					v1y = p1[1] - p0[1];
+				const v2x = p2[0] - p1[0],
+					v2y = p2[1] - p1[1];
+				const len1 = Math.hypot(v1x, v1y) || 1;
+				const len2 = Math.hypot(v2x, v2y) || 1;
+				const pInX = p1[0] - (v1x / len1) * pad,
+					pInY = p1[1] - (v1y / len1) * pad;
+				const pOutX = p1[0] + (v2x / len2) * pad,
+					pOutY = p1[1] + (v2y / len2) * pad;
+				if (i === 0) context.moveTo(pInX, pInY);
+				else context.lineTo(pInX, pInY);
+				context.quadraticCurveTo(p1[0], p1[1], pOutX, pOutY);
+			}
+			context.closePath();
+			context.fill();
+			context.stroke();
+		}
+		context.restore();
+	};
+
+	// Minimap — throttled, simple rendering
+	drawMinimap = () => {
+		if (!this.minimapCanvas || !this.document.nodes.size) return;
+		// Only redraw minimap every N frames
+		if (this.frameCount % PERF.MINIMAP_INTERVAL !== 0) return;
+
+		const mmw = this.minimapCanvas.width;
+		const mmh = this.minimapCanvas.height;
+		const mmctx = this.minimapContext;
+
+		mmctx.clearRect(0, 0, mmw, mmh);
+
+		mmctx.fillStyle = "rgba(20, 22, 30, 0.85)";
+		roundRect(mmctx, 0, 0, mmw, mmh, 6);
+		mmctx.fill();
+
+		let minX = Infinity,
+			minY = Infinity,
+			maxX = -Infinity,
+			maxY = -Infinity;
+		this.document.nodes.forEach((n) => {
+			if (n.x < minX) minX = n.x;
+			if (n.y < minY) minY = n.y;
+			if (n.x > maxX) maxX = n.x;
+			if (n.y > maxY) maxY = n.y;
+		});
+
+		const pad = 10;
+		const gw = maxX - minX || 1;
+		const gh = maxY - minY || 1;
+		const sx = (mmw - pad * 2) / gw;
+		const sy = (mmh - pad * 2) / gh;
+		const s = Math.min(sx, sy);
+		const ox = (mmw - s * gw) / 2;
+		const oy = (mmh - s * gh) / 2;
+
+		mmctx.save();
+		mmctx.translate(ox - minX * s, oy - minY * s);
+		mmctx.scale(s, s);
+
+		// Skip edges in minimap for large graphs
+		if (this.document.edges.size < 500) {
+			mmctx.strokeStyle = "rgba(255,255,255,0.1)";
+			mmctx.lineWidth = 1 / s;
+			mmctx.beginPath();
+			this.document.edges.forEach((edge) => {
+				if (!edge.source.x) return;
+				mmctx.moveTo(edge.source.x, edge.source.y);
+				mmctx.lineTo(edge.target.x, edge.target.y);
+			});
+			mmctx.stroke();
+		}
+
+		// Batch node drawing by color for fewer state changes
+		const dotSize = Math.max(1.5, 2 / s);
+		mmctx.globalAlpha = 0.8;
+		// Simple single-pass: just draw all nodes as one color for speed
+		mmctx.fillStyle = "rgba(180,190,200,0.9)";
+		mmctx.beginPath();
+		this.document.nodes.forEach((n) => {
+			mmctx.moveTo(n.x + dotSize, n.y);
+			mmctx.arc(n.x, n.y, dotSize, 0, Math.PI * 2);
+		});
+		mmctx.fill();
+		mmctx.globalAlpha = 1;
+
+		// Viewport rectangle
+		const vp = this.getWorldViewport();
+		mmctx.strokeStyle = "rgba(80,166,255,0.9)";
+		mmctx.lineWidth = 2 / s;
+		mmctx.fillStyle = "rgba(80,166,255,0.08)";
+		mmctx.strokeRect(vp.x0, vp.y0, vp.x1 - vp.x0, vp.y1 - vp.y0);
+		mmctx.fillRect(vp.x0, vp.y0, vp.x1 - vp.x0, vp.y1 - vp.y0);
+
+		mmctx.restore();
+	};
+
+	labelEdge = (context, edge) => {
+		const zoom = this.state.transform.k * this.devicePixelRatio;
+		if (this.document.edges.size > 200 && zoom < 1.5) return;
+		if (this.document.edges.size > 40 && zoom < 1.0) return;
+		if (zoom < 0.6) return;
+
+		const srcR = this.getNodeRadius(edge.source);
+		const tgtR = this.getNodeRadius(edge.target);
+		if (edge.arc.distance < srcR + tgtR + 40) return;
+
+		const fontSize = 11;
+		context.font = `500 ${fontSize}px ${THEME.labelFont}`;
+		context.textAlign = "center";
+		context.textBaseline = "middle";
+
+		const maxWidth = 120;
+		const bgPadding = 4;
+		let { width } = context.measureText(edge.label);
+		width = Math.min(width, maxWidth);
+
+		const { centerX: cx, centerY: cy } = edge.arc;
+		const rw = width + 2 * bgPadding;
+		const rh = fontSize + bgPadding;
+
+		context.globalAlpha = 0.88;
+		context.fillStyle = "#ffffff";
+		roundRect(context, cx - rw / 2, cy - rh / 2, rw, rh, 3);
+		context.fill();
+		context.globalAlpha = 1;
+
+		context.fillStyle = "#333333";
+		context.fillText(edge.label, cx, cy, maxWidth);
+	};
+
+	labelNode = (context, node) => {
+		const zoom = this.state.transform.k * this.devicePixelRatio;
+		const nodeCount = this.document.nodes.size;
+		const cached = this.nodeRenderCache.get(node.id);
+		const degree = cached ? cached.degree : 0;
+		const radius = cached ? cached.radius : DEFAULT_NODE_RADIUS;
+
+		if (nodeCount > 500 && zoom < 2.0 && degree < 3) return;
+		if (nodeCount > 200 && zoom < 1.2 && degree < 2) return;
+		if (nodeCount > 50 && zoom < 0.8) return;
+		if (zoom < 0.4) return;
+		if (nodeCount > 100 && degree < 2 && zoom < 1.5) return;
+
+		const label = node.label || "";
+		if (!label) return;
+
+		const fontSize = Math.max(10, Math.min(14, radius * 0.9));
+		context.font = `600 ${fontSize}px ${THEME.labelFont}`;
+		context.textAlign = "center";
+		context.textBaseline = "middle";
+
+		const maxWidth = radius * 4;
+		let { width: textWidth } = context.measureText(label);
+		textWidth = Math.min(textWidth, maxWidth);
+
+		const bgPadding = 3;
+		const textY = node.y + radius + fontSize / 2 + 4;
+		const rw = textWidth + 2 * bgPadding;
+		const rh = fontSize + bgPadding;
+
+		context.globalAlpha = 0.88;
+		context.fillStyle = "#2A2C34";
+		roundRect(context, node.x - rw / 2, textY - rh / 2, rw, rh, rh / 2);
+		context.fill();
+		context.globalAlpha = 1;
+
+		context.fillStyle = "#FFFFFF";
+		context.fillText(label, node.x, textY, maxWidth);
+	};
+
+	_drawAll = () => {
+		const context = this.canvasContext;
+		if (!context) return;
+
+		const { highlightPredicate } = this.props;
+		this._isHovering = !!this.props.hoveredNode;
+		this.frameCount++;
+
+		context.save();
+		const { devicePixelRatio: dpr } = this;
+		context.clearRect(0, 0, this.width * dpr, this.height * dpr);
+		context.translate(
+			this.state.transform.x * dpr,
+			this.state.transform.y * dpr,
+		);
+		context.scale(this.state.transform.k * dpr, this.state.transform.k * dpr);
+
+		this._viewport = this.getWorldViewport();
+
+		const zoom = this.state.transform.k * dpr;
+		const isZoomedOut = zoom < 0.3;
+		const nodeCount = this.document.nodes.size;
+		const isLargeGraph = nodeCount > PERF.LARGE_GRAPH;
+		const isHugeGraph = nodeCount > PERF.HUGE_GRAPH;
+
+		// --- Hulls (throttled) ---
+		if (!isZoomedOut && !isHugeGraph) {
+			if (this.frameCount % PERF.HULL_INTERVAL === 0 || !this.cachedHulls) {
+				this.computeHulls();
+			}
+			this.drawHulls(context);
+		}
+
+		// --- Arc helpers (defined once, not per-edge) ---
+		const addArrow = (arc, target, vx, vy, nodeRadius) => {
+			const baseOffset = nodeRadius + ARROW_LENGTH;
+			arc.arrowBase0 = target.x - vx * baseOffset;
+			arc.arrowBase1 = target.y - vy * baseOffset;
+			arc.arrowEnd0 = target.x - nodeRadius * vx;
+			arc.arrowEnd1 = target.y - nodeRadius * vy;
+			arc.arrowPt10 = arc.arrowBase0 + ARROW_WIDTH * vy;
+			arc.arrowPt11 = arc.arrowBase1 - ARROW_WIDTH * vx;
+			arc.arrowPt20 = arc.arrowBase0 - ARROW_WIDTH * vy;
+			arc.arrowPt21 = arc.arrowBase1 + ARROW_WIDTH * vx;
+			arc.hasArrow = true;
+		};
+
+		const getArc = (edge) => {
+			const dx = edge.target.x - edge.source.x;
+			const dy = edge.target.y - edge.source.y;
+			const l = Math.sqrt(dx * dx + dy * dy);
+
+			const srcR = this.getNodeRadius(edge.source);
+			const tgtR = this.getNodeRadius(edge.target);
+
+			const arc = {
+				radius: -1,
+				distance: l,
+				centerX: edge.source.x + dx / 2,
+				centerY: edge.source.y + dy / 2,
+				hasArrow: false,
+			};
+
+			if (
+				!edge.siblingCount ||
+				edge.siblingCount < 2 ||
+				(edge.siblingCount % 2 && edge.siblingIndex === 0) ||
+				l < srcR + tgtR
+			) {
+				if (l > srcR + tgtR + 2 * ARROW_LENGTH) {
+					addArrow(arc, edge.target, dx / l, dy / l, tgtR);
+				}
+				return arc;
+			}
+
+			const LR = 4;
+			let offset;
+			if (edge.siblingCount % 2) {
+				offset = LR * (1 + Math.ceil(edge.siblingIndex / 2) * 2);
+			} else {
+				offset = LR * (1 + Math.floor(edge.siblingIndex / 2) * 2);
+			}
+			if (edge.siblingCount * LR > (0.9 * l) / 2) {
+				offset = (offset * 0.9 * l) / 2 / edge.siblingCount / LR;
+			}
+
+			const norm0 = edge.siblingIndex % 2 ? dy / l : -dy / l;
+			const norm1 = edge.siblingIndex % 2 ? -dx / l : dx / l;
+			const R = (offset * offset + (l * l) / 4) / 2 / offset;
+			const h2 = (R * offset) / (R - offset);
+
+			arc.radius = R;
+			arc.centerX = edge.source.x + dx / 2 + norm0 * offset;
+			arc.centerY = edge.source.y + dy / 2 + norm1 * offset;
+			arc.controlX = edge.source.x + dx / 2 + norm0 * (offset + h2);
+			arc.controlY = edge.source.y + dy / 2 + norm1 * (offset + h2);
+
+			if (l > srcR + tgtR + 2 * ARROW_LENGTH) {
+				const rotateDir = edge.siblingIndex % 2 ? +1 : -1;
+				const alpha = Math.asin(Math.min(1, l / 2 / R));
+				const theta = Math.asin(Math.min(1, tgtR / 2 / R));
+				const ra = rotateDir * (alpha - theta);
+				const cosA = Math.cos(ra),
+					sinA = Math.sin(ra);
+				const ndx = dx / l,
+					ndy = dy / l;
+				addArrow(
+					arc,
+					edge.target,
+					ndx * cosA - ndy * sinA,
+					ndx * sinA + ndy * cosA,
+					tgtR,
+				);
+			}
+
+			return arc;
+		};
+
+		// --- Edges ---
+		context.lineCap = "round";
+		let edgesDrawn = 0;
+		this.document.edges.forEach((edge) => {
+			// Hard cap on visible edges for huge graphs
+			if (isHugeGraph && edgesDrawn >= PERF.MAX_VISIBLE_EDGES) return;
+
+			// Viewport culling
+			if (
+				!this.isInViewport(edge.source.x, edge.source.y, 100) &&
+				!this.isInViewport(edge.target.x, edge.target.y, 100)
+			)
+				return;
+
+			edgesDrawn++;
+			const arc = (edge.arc = getArc(edge));
+
+			const isHighlighted = edge.predicate === highlightPredicate;
+			const isActive = edge === this.props.activeEdge;
+			const inNeighborhood = this.isEdgeInNeighborhood(edge);
+
+			context.strokeStyle = edge.color;
+			if (this._isHovering && !inNeighborhood) {
+				context.globalAlpha = THEME.edgeAlphaDimmed;
+				context.lineWidth = 0.5;
+			} else if (isActive) {
+				context.globalAlpha = THEME.edgeAlphaHighlight;
+				context.lineWidth = THEME.edgeWidthActive;
+			} else if (isHighlighted || (this._isHovering && inNeighborhood)) {
+				context.globalAlpha = THEME.edgeAlphaHighlight;
+				context.lineWidth = THEME.edgeWidthHighlight;
+			} else {
+				context.globalAlpha = THEME.edgeAlphaDefault;
+				context.lineWidth = THEME.edgeWidthDefault;
+			}
+
+			context.beginPath();
+			context.moveTo(edge.source.x, edge.source.y);
+			if (arc.radius <= 0) {
+				context.lineTo(edge.target.x, edge.target.y);
+			} else {
+				context.arcTo(
+					arc.controlX,
+					arc.controlY,
+					edge.target.x,
+					edge.target.y,
+					arc.radius,
+				);
+			}
+			context.stroke();
+
+			// Arrowhead — skip for huge graphs when zoomed out
+			if (arc.hasArrow && !(isHugeGraph && isZoomedOut)) {
+				context.fillStyle = edge.color;
+				context.beginPath();
+				context.moveTo(arc.arrowEnd0, arc.arrowEnd1);
+				context.lineTo(arc.arrowPt10, arc.arrowPt11);
+				context.lineTo(arc.arrowPt20, arc.arrowPt21);
+				context.closePath();
+				context.fill();
+			}
+
+			context.globalAlpha = 1;
+			if (!isLargeGraph && (!this._isHovering || inNeighborhood)) {
+				this.labelEdge(context, edge);
+			}
+		});
+
+		// --- Nodes ---
+		this.document.nodes.forEach((d) => {
+			if (!this.isInViewport(d.x, d.y, 50)) return;
+
+			const cached = this.nodeRenderCache.get(d.id);
+			const radius = cached ? cached.radius : DEFAULT_NODE_RADIUS;
+			const color = cached ? cached.color : "#848484";
+			const isActive = d === this.props.activeNode;
+			const inNeighborhood = this.isInNeighborhood(d.id);
+			const dimmed = this._isHovering && !inNeighborhood;
+
+			if (dimmed) context.globalAlpha = THEME.nodeDimmedAlpha;
+
+			// LOD: dots at very low zoom
+			if (isZoomedOut) {
+				context.fillStyle = color;
+				context.beginPath();
+				context.arc(d.x, d.y, Math.max(2, radius * 0.3), 0, 2 * Math.PI);
+				context.fill();
+				context.globalAlpha = 1;
+				return;
+			}
+
+			// Solid fill
+			context.fillStyle = color;
+			context.beginPath();
+			context.arc(d.x, d.y, radius, 0, 2 * Math.PI, true);
+			context.fill();
+
+			// Border
+			context.strokeStyle = cached
+				? cached.colorDark
+				: darkenColor(color, 0.25);
+			context.lineWidth = isActive
+				? THEME.nodeBorderActive
+				: THEME.nodeBorderDefault;
+			context.stroke();
+
+			// Active glow
+			if (isActive && !dimmed) {
+				context.strokeStyle = color;
+				context.globalAlpha = 0.4;
+				context.lineWidth = 4;
+				context.beginPath();
+				context.arc(d.x, d.y, radius + 4, 0, 2 * Math.PI, true);
+				context.stroke();
+				context.globalAlpha = dimmed ? THEME.nodeDimmedAlpha : 1;
+			}
+
+			// Search pulse
+			const pulse = this.pulsingNodes.get(d.id);
+			if (pulse && pulse > 0) {
+				context.strokeStyle = "#50A6FF";
+				context.globalAlpha = 0.6 * pulse;
+				context.lineWidth = 8 * pulse;
+				context.beginPath();
+				context.arc(d.x, d.y, radius + 10 * (1 - pulse), 0, 2 * Math.PI);
+				context.stroke();
+				context.globalAlpha = 1;
+			}
+
+			// Expanded dot
+			if (d.expanded) {
+				context.fillStyle = "#ffffff";
+				context.beginPath();
+				context.arc(
+					d.x + radius * 0.55,
+					d.y - radius * 0.55,
+					3,
+					0,
+					2 * Math.PI,
+				);
+				context.fill();
+			}
+
+			context.globalAlpha = 1;
+			if (!dimmed) this.labelNode(context, d);
+		});
+
+		context.restore();
+		this.drawMinimap();
+	};
+
+	startAnimationLoop = () => {
+		const animate = (timestamp) => {
+			const delta = timestamp - (this.lastFrameTime || timestamp);
+			this.lastFrameTime = timestamp;
+
+			let hasPulse = false;
+			this.pulsingNodes.forEach((val, key) => {
+				const newVal = val - delta * 0.002;
+				if (newVal <= 0) this.pulsingNodes.delete(key);
+				else {
+					this.pulsingNodes.set(key, newVal);
+					hasPulse = true;
+				}
+			});
+
+			if (hasPulse) this._drawAll();
+
+			this.animationFrameId = requestAnimationFrame(animate);
+		};
+		this.animationFrameId = requestAnimationFrame(animate);
+	};
+
+	drawGraph = debounce(this._drawAll, 5, { leading: true, trailing: true });
+
+	createForces = () => {
+		this.d3simulation
+			.alphaTarget(0)
+			.alphaMin(0.005)
+			.alphaDecay(0.05)
+			.velocityDecay(0.5)
+			.force(
+				"link",
+				d3
+					.forceLink()
+					.distance((d) => {
+						const srcDeg =
+							this.nodeDegrees.get(
+								typeof d.source === "object" ? d.source.id : d.source,
+							) || 1;
+						const tgtDeg =
+							this.nodeDegrees.get(
+								typeof d.target === "object" ? d.target.id : d.target,
+							) || 1;
+						const srcG = typeof d.source === "object" ? d.source.group : null;
+						const tgtG = typeof d.target === "object" ? d.target.group : null;
+						const cross = srcG && tgtG && srcG !== tgtG;
+						return (cross ? 100 : 60) + Math.sqrt(srcDeg + tgtDeg) * 15;
+					})
+					.strength((d) => {
+						const srcG = typeof d.source === "object" ? d.source.group : null;
+						const tgtG = typeof d.target === "object" ? d.target.group : null;
+						return srcG === tgtG ? 0.4 : 0.15;
+					})
+					.id((d) => d.id),
+			)
+			.force(
+				"charge",
+				d3
+					.forceManyBody()
+					.strength((d) => {
+						const degree = this.nodeDegrees.get(d.id) || 0;
+						return -200 - degree * 30;
+					})
+					.distanceMax(500)
+					.theta(0.9),
+			)
+			.force(
+				"collision",
+				d3
+					.forceCollide()
+					.radius((d) => this.getNodeRadius(d) + 8)
+					.strength(0.8),
+			)
+			.force("cluster", forceCluster(0.35))
+			.force("fixedPosForce", fixedPosForce());
+
+		this.fixedPosForce = this.d3simulation.force("fixedPosForce");
+		this.edgesForce = this.d3simulation.force("link");
+	};
+
+	componentDidMount() {
+		this.d3simulation = d3.forceSimulation().on("tick", this.drawGraph);
+		this.createForces();
+
+		this.graphCanvas = d3
+			.select(this.outer.current)
+			.append("canvas")
+			.attr("width", this.width)
+			.attr("height", this.height)
+			.node();
+
+		this.minimapCanvas = document.createElement("canvas");
+		this.minimapCanvas.className = "graph-minimap";
+		this.minimapCanvas.width = 180;
+		this.minimapCanvas.height = 120;
+		this.outer.current.appendChild(this.minimapCanvas);
+		this.minimapContext = this.minimapCanvas.getContext("2d");
+		this.minimapCanvas.addEventListener("click", this.onMinimapClick);
+
+		this.zoomBehavior = d3
+			.zoom()
+			.scaleExtent([(1 / 8) * this.devicePixelRatio, 6 * this.devicePixelRatio])
+			.on("zoom", this.onZoom);
+
+		d3.select(this.graphCanvas)
+			.on("click", this.onClick)
+			.on("dblclick", this.onDoubleClick)
+			.on("mousemove", this.onMouseMove)
+			.call(
+				d3
+					.drag()
+					.subject(this.dragsubject)
+					.on("start", this.dragstarted)
+					.on("drag", this.dragged),
+			)
+			.call(this.zoomBehavior);
+
+		this.onResize();
+		this.updateDocument(this.props.nodes, this.props.edges);
+		this.startAnimationLoop();
+		this.resizeObserver = window.setInterval(this.onResize, 1000);
+	}
+
+	componentWillUnmount() {
+		clearInterval(this.resizeObserver);
+		if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId);
+		if (this.minimapCanvas)
+			this.minimapCanvas.removeEventListener("click", this.onMinimapClick);
+	}
+
+	onMinimapClick = (e) => {
+		if (!this.document.nodes.size) return;
+		const rect = this.minimapCanvas.getBoundingClientRect();
+		const px = e.clientX - rect.left,
+			py = e.clientY - rect.top;
+		const mmw = this.minimapCanvas.width,
+			mmh = this.minimapCanvas.height;
+
+		let minX = Infinity,
+			minY = Infinity,
+			maxX = -Infinity,
+			maxY = -Infinity;
+		this.document.nodes.forEach((n) => {
+			if (n.x < minX) minX = n.x;
+			if (n.y < minY) minY = n.y;
+			if (n.x > maxX) maxX = n.x;
+			if (n.y > maxY) maxY = n.y;
+		});
+
+		const pad = 10,
+			gw = maxX - minX || 1,
+			gh = maxY - minY || 1;
+		const s = Math.min((mmw - pad * 2) / gw, (mmh - pad * 2) / gh);
+		const ox = (mmw - s * gw) / 2,
+			oy = (mmh - s * gh) / 2;
+		const wx = (px - ox + minX * s) / s,
+			wy = (py - oy + minY * s) / s;
+
+		const k = this.state.transform.k;
+		d3.select(this.graphCanvas)
+			.transition()
+			.duration(300)
+			.call(
+				this.zoomBehavior.transform,
+				d3.zoomIdentity
+					.translate(this.width / 2 - wx * k, this.height / 2 - wy * k)
+					.scale(k),
+			);
+	};
+
+	getD3EventCoords = (event) => this.state.transform.invert([event.x, event.y]);
+
+	findNodeAtPos = (x, y) => {
+		let minNode,
+			minD = 1e10;
+		this.document.nodes.forEach((n) => {
+			const r = this.getNodeRadius(n);
+			const d = (n.x - x) * (n.x - x) + (n.y - y) * (n.y - y);
+			if (d < r * r && d < minD) {
+				minNode = n;
+				minD = d;
+			}
+		});
+		return minNode;
+	};
+
+	findEdgeAtPos = (x, y) => {
+		let minEdge,
+			minD = 1e10;
+		this.document.edges.forEach((edge) => {
+			if (!edge.arc) return;
+			const { centerX: cx, centerY: cy } = edge.arc;
+			const d = (cx - x) * (cx - x) + (cy - y) * (cy - y);
+			if (d < minD) {
+				minEdge = edge;
+				minD = d;
+			}
+		});
+		return minD > 225 ? undefined : minEdge;
+	};
+
+	onMouseMove = () => {
+		const { offsetX: x, offsetY: y } = currentEvent;
+		const pt = this.getD3EventCoords({ x, y });
+		const node = this.findNodeAtPos(...pt);
+		this.props.onNodeHovered(node);
+		if (this.graphCanvas)
+			this.graphCanvas.style.cursor = node ? "pointer" : "default";
+		if (!node) this.props.onEdgeHovered(this.findEdgeAtPos(...pt));
+		this.drawGraph();
+	};
+
+	onClick = () => {
+		const { offsetX: x, offsetY: y } = currentEvent;
+		const pt = this.getD3EventCoords({ x, y });
+		const node = this.findNodeAtPos(...pt);
+		if (node) {
+			currentEvent.stopImmediatePropagation();
+			return this.props.onNodeSelected(node);
+		}
+		const edge = this.findEdgeAtPos(...pt);
+		if (edge) {
+			currentEvent.stopImmediatePropagation();
+			return this.props.onEdgeSelected(edge);
+		}
+	};
+
+	onDoubleClick = () => {
+		const { offsetX: x, offsetY: y } = currentEvent;
+		const pt = this.getD3EventCoords({ x, y });
+		const node = this.findNodeAtPos(...pt);
+		if (node) {
+			currentEvent.stopImmediatePropagation();
+			return this.props.onNodeDoubleClicked(node);
+		}
+	};
+
+	dragsubject = () => {
+		const { offsetX: x, offsetY: y } = currentEvent.sourceEvent;
+		const pt = this.getD3EventCoords({ x, y });
+		const node = this.findNodeAtPos(...pt);
+		this.props.onNodeSelected(node);
+		return node;
+	};
+
+	dragstarted = () => {
+		if (!currentEvent.active)
+			setTimeout(() => this.d3simulation.alpha(0.5).restart(), DOUBLE_CLICK_MS);
+	};
+
+	dragged = () => {
+		const { offsetX: x, offsetY: y } = currentEvent.sourceEvent;
+		const pt = this.getD3EventCoords({ x, y });
+		this.fixedPosForce.setNodeCoords(currentEvent.subject, ...pt);
+		this.drawGraph();
+		this.d3simulation.alpha(Math.max(0.12, this.d3simulation.alpha()));
+	};
+
+	_updateZoom = (transform) => {
+		if (this.state.transform.toString() !== transform.toString())
+			this.setState({ transform });
+	};
+	updateZoom = debounce(this._updateZoom, 2, { leading: true, trailing: true });
+	onZoom = () => this.updateZoom(currentEvent.transform);
+
+	zoomToFit = () => {
+		if (!this.graphCanvas || !this.document.nodes.size) return;
+		let minX = Infinity,
+			minY = Infinity,
+			maxX = -Infinity,
+			maxY = -Infinity;
+		this.document.nodes.forEach((n) => {
+			const r = this.getNodeRadius(n) + 20;
+			if (n.x - r < minX) minX = n.x - r;
+			if (n.y - r < minY) minY = n.y - r;
+			if (n.x + r > maxX) maxX = n.x + r;
+			if (n.y + r > maxY) maxY = n.y + r;
+		});
+		const p = 40,
+			gw = maxX - minX + p * 2,
+			gh = maxY - minY + p * 2;
+		const scale = Math.min(this.width / gw, this.height / gh, 2) * 0.9;
+		const transform = d3.zoomIdentity
+			.translate(this.width / 2, this.height / 2)
+			.scale(scale)
+			.translate(-(minX + maxX) / 2, -(minY + maxY) / 2);
+		d3.select(this.graphCanvas)
+			.transition()
+			.duration(500)
+			.call(this.zoomBehavior.transform, transform);
+	};
+
+	focusNode = (node) => {
+		if (!this.graphCanvas || !node) return;
+		const k = 2.2;
+		d3.select(this.graphCanvas)
+			.transition()
+			.duration(500)
+			.ease(d3.easeCubicOut)
+			.call(
+				this.zoomBehavior.transform,
+				d3.zoomIdentity
+					.translate(this.width / 2 - node.x * k, this.height / 2 - node.y * k)
+					.scale(k),
+			);
+		this.pulsingNodes.set(node.id, 1.0);
+	};
+
+	searchNode = (query) => {
+		if (!query) return null;
+		const q = query.toLowerCase().trim();
+		let found = null;
+		this.document.nodes.forEach((n) => {
+			if (found) return;
+			const name = (n.name || n.label || "").toLowerCase();
+			const uid = (n.uid || n.id || "").toLowerCase();
+			if (name.includes(q) || uid === q) found = n;
+		});
+		return found;
+	};
+
+	onResize = () => {
+		let resized = false;
+		if (this.outer.current) {
+			const el = this.outer.current;
+			resized |= this.width !== el.offsetWidth;
+			resized |= this.height !== el.offsetHeight;
+			this.width = el.offsetWidth;
+			this.height = el.offsetHeight;
+		}
+		if (!resized) return;
+
+		this.zoomBehavior.scaleTo(d3.select(this.graphCanvas), 1);
+		this.zoomBehavior.translateTo(d3.select(this.graphCanvas), 0, 0);
+
+		const { width, height } = this;
+		this.d3simulation
+			.force("x", d3.forceX(0).strength((0.02 * height) / width))
+			.force("y", d3.forceY(0).strength((0.02 * width) / height));
+
+		d3.select(this.graphCanvas)
+			.attr("width", this.width * this.devicePixelRatio)
+			.attr("height", this.height * this.devicePixelRatio);
+
+		this.canvasContext = this.graphCanvas.getContext("2d");
+		this._drawAll();
+	};
+
+	updateDocument = (nodes, edges) => {
+		if (!this.d3simulation || !nodes || !edges) return;
+
+		const newNodesReceived =
+			this.document.nodesLength !== nodes.size ||
+			this.document.edgesLength !== edges.size;
+
+		this.document = {
+			edges,
+			edgesLength: edges.size,
+			nodes,
+			nodesLength: nodes.size,
+		};
+		this.computeNodeDegrees();
+
+		if (newNodesReceived) {
+			this.d3simulation
+				.force(
+					"link",
+					d3
+						.forceLink()
+						.distance((d) => {
+							const srcDeg =
+								this.nodeDegrees.get(
+									typeof d.source === "object" ? d.source.id : d.source,
+								) || 1;
+							const tgtDeg =
+								this.nodeDegrees.get(
+									typeof d.target === "object" ? d.target.id : d.target,
+								) || 1;
+							const srcG = typeof d.source === "object" ? d.source.group : null;
+							const tgtG = typeof d.target === "object" ? d.target.group : null;
+							return (
+								(srcG && tgtG && srcG !== tgtG ? 100 : 60) +
+								Math.sqrt(srcDeg + tgtDeg) * 15
+							);
+						})
+						.strength((d) => {
+							const srcG = typeof d.source === "object" ? d.source.group : null;
+							const tgtG = typeof d.target === "object" ? d.target.group : null;
+							return srcG === tgtG ? 0.4 : 0.15;
+						})
+						.id((d) => d.id),
+				)
+				.force(
+					"charge",
+					d3
+						.forceManyBody()
+						.strength((d) => -200 - (this.nodeDegrees.get(d.id) || 0) * 30)
+						.distanceMax(500)
+						.theta(0.9),
+				)
+				.force(
+					"collision",
+					d3
+						.forceCollide()
+						.radius((d) => this.getNodeRadius(d) + 8)
+						.strength(0.8),
+				)
+				.force("cluster", forceCluster(0.35));
+
+			this.edgesForce = this.d3simulation.force("link");
+			this.d3simulation.alpha(0.5).restart();
+		}
+
+		this.d3simulation.nodes(Array.from(nodes.values()));
+		this.edgesForce.links(Array.from(edges.values()));
+	};
+
+	render() {
+		this.updateDocument(this.props.nodes, this.props.edges);
+		this.onResize();
+		this.drawGraph();
+		return <div ref={this.outer} className="graph-outer" />;
+	}
 }

--- a/client/src/components/D3Graph/index.js
+++ b/client/src/components/D3Graph/index.js
@@ -3,1189 +3,1179 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as d3 from "d3";
-import { event as currentEvent } from "d3-selection";
-import debounce from "lodash.debounce";
-import React from "react";
+import * as d3 from 'd3'
+import { event as currentEvent } from 'd3-selection'
+import debounce from 'lodash.debounce'
+import React from 'react'
 
-import "./D3Graph.scss";
+import './D3Graph.scss'
 
-const ARROW_LENGTH = 8;
-const ARROW_WIDTH = 4;
+const ARROW_LENGTH = 8
+const ARROW_WIDTH = 4
 
-const MIN_NODE_RADIUS = 8;
-const MAX_NODE_RADIUS = 40;
-const DEFAULT_NODE_RADIUS = 12;
-const DOUBLE_CLICK_MS = 250;
+const MIN_NODE_RADIUS = 8
+const MAX_NODE_RADIUS = 40
+const DEFAULT_NODE_RADIUS = 12
+const DOUBLE_CLICK_MS = 250
 
 // Performance thresholds
 const PERF = {
-	LARGE_GRAPH: 300, // nodes: disable expensive effects
-	HUGE_GRAPH: 800, // nodes: aggressive LOD
-	MAX_VISIBLE_EDGES: 2000, // max edges to render at once
-	MINIMAP_INTERVAL: 8, // only redraw minimap every N frames
-	HULL_INTERVAL: 5, // only recompute hulls every N frames
-};
+  LARGE_GRAPH: 300, // nodes: disable expensive effects
+  HUGE_GRAPH: 800, // nodes: aggressive LOD
+  MAX_VISIBLE_EDGES: 2000, // max edges to render at once
+  MINIMAP_INTERVAL: 8, // only redraw minimap every N frames
+  HULL_INTERVAL: 5, // only recompute hulls every N frames
+}
 
 const THEME = {
-	nodeBorderActive: 3,
-	nodeBorderDefault: 1.5,
-	edgeWidthActive: 3.0,
-	edgeWidthHighlight: 2.0,
-	edgeWidthDefault: 1.2,
-	edgeAlphaDefault: 0.35,
-	edgeAlphaHighlight: 0.9,
-	edgeAlphaDimmed: 0.06,
-	nodeDimmedAlpha: 0.12,
-	labelFont: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-	hullAlpha: 0.07,
-	hullStrokeAlpha: 0.25,
-	hullPadding: 30,
-};
+  nodeBorderActive: 3,
+  nodeBorderDefault: 1.5,
+  edgeWidthActive: 3.0,
+  edgeWidthHighlight: 2.0,
+  edgeWidthDefault: 1.2,
+  edgeAlphaDefault: 0.35,
+  edgeAlphaHighlight: 0.9,
+  edgeAlphaDimmed: 0.06,
+  nodeDimmedAlpha: 0.12,
+  labelFont: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  hullAlpha: 0.07,
+  hullStrokeAlpha: 0.25,
+  hullPadding: 30,
+}
 
 function parseHexColor(hex) {
-	if (!hex || hex[0] !== "#" || hex.length < 7)
-		return { r: 128, g: 128, b: 128 };
-	return {
-		r: parseInt(hex.slice(1, 3), 16),
-		g: parseInt(hex.slice(3, 5), 16),
-		b: parseInt(hex.slice(5, 7), 16),
-	};
+  if (!hex || hex[0] !== '#' || hex.length < 7)
+    return { r: 128, g: 128, b: 128 }
+  return {
+    r: parseInt(hex.slice(1, 3), 16),
+    g: parseInt(hex.slice(3, 5), 16),
+    b: parseInt(hex.slice(5, 7), 16),
+  }
 }
 
 function darkenColor(hex, factor = 0.3) {
-	const { r, g, b } = parseHexColor(hex);
-	return `rgb(${Math.round(r * (1 - factor))},${Math.round(g * (1 - factor))},${Math.round(b * (1 - factor))})`;
+  const { r, g, b } = parseHexColor(hex)
+  return `rgb(${Math.round(r * (1 - factor))},${Math.round(g * (1 - factor))},${Math.round(b * (1 - factor))})`
 }
 
 function hexToRgba(hex, alpha) {
-	const { r, g, b } = parseHexColor(hex);
-	return `rgba(${r},${g},${b},${alpha})`;
+  const { r, g, b } = parseHexColor(hex)
+  return `rgba(${r},${g},${b},${alpha})`
 }
 
 function roundRect(ctx, x, y, w, h, r) {
-	const rr = Math.min(r, w / 2, h / 2);
-	ctx.beginPath();
-	ctx.moveTo(x + rr, y);
-	ctx.arcTo(x + w, y, x + w, y + h, rr);
-	ctx.arcTo(x + w, y + h, x, y + h, rr);
-	ctx.arcTo(x, y + h, x, y, rr);
-	ctx.arcTo(x, y, x + w, y, rr);
-	ctx.closePath();
+  const rr = Math.min(r, w / 2, h / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + rr, y)
+  ctx.arcTo(x + w, y, x + w, y + h, rr)
+  ctx.arcTo(x + w, y + h, x, y + h, rr)
+  ctx.arcTo(x, y + h, x, y, rr)
+  ctx.arcTo(x, y, x + w, y, rr)
+  ctx.closePath()
 }
 
 const fixedPosForce = () => {
-	const self = { nodes: [] };
-	const res = function tick() {
-		for (let i = 0; i < self.nodes.length; i++) {
-			const n = self.nodes[i];
-			if (!n._posFixed) continue;
-			n.x = n._posFixed.x;
-			n.y = n._posFixed.y;
-		}
-	};
-	res.initialize = (nodes) => (self.nodes = nodes);
-	res.setNodeCoords = (node, x, y) => {
-		node._posFixed = { x, y };
-		node.x = x;
-		node.y = y;
-	};
-	return res;
-};
+  const self = { nodes: [] }
+  const res = function tick() {
+    for (let i = 0; i < self.nodes.length; i++) {
+      const n = self.nodes[i]
+      if (!n._posFixed) continue
+      n.x = n._posFixed.x
+      n.y = n._posFixed.y
+    }
+  }
+  res.initialize = (nodes) => (self.nodes = nodes)
+  res.setNodeCoords = (node, x, y) => {
+    node._posFixed = { x, y }
+    node.x = x
+    node.y = y
+  }
+  return res
+}
 
 // ArangoDB-style cluster force — reuses allocations
 const forceCluster = (strength = 0.35) => {
-	let nodes = [];
-	// Reuse these maps across ticks to avoid GC
-	const centerX = new Map();
-	const centerY = new Map();
-	const counts = new Map();
+  let nodes = []
+  // Reuse these maps across ticks to avoid GC
+  const centerX = new Map()
+  const centerY = new Map()
+  const counts = new Map()
 
-	function force(alpha) {
-		// Reset accumulators
-		centerX.forEach((_, k) => {
-			centerX.set(k, 0);
-			centerY.set(k, 0);
-			counts.set(k, 0);
-		});
+  function force(alpha) {
+    // Reset accumulators
+    centerX.forEach((_, k) => {
+      centerX.set(k, 0)
+      centerY.set(k, 0)
+      counts.set(k, 0)
+    })
 
-		for (let i = 0; i < nodes.length; i++) {
-			const n = nodes[i];
-			const g = n.group;
-			if (!g) continue;
-			if (!counts.has(g)) {
-				centerX.set(g, 0);
-				centerY.set(g, 0);
-				counts.set(g, 0);
-			}
-			centerX.set(g, centerX.get(g) + n.x);
-			centerY.set(g, centerY.get(g) + n.y);
-			counts.set(g, counts.get(g) + 1);
-		}
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i]
+      const g = n.group
+      if (!g) continue
+      if (!counts.has(g)) {
+        centerX.set(g, 0)
+        centerY.set(g, 0)
+        counts.set(g, 0)
+      }
+      centerX.set(g, centerX.get(g) + n.x)
+      centerY.set(g, centerY.get(g) + n.y)
+      counts.set(g, counts.get(g) + 1)
+    }
 
-		// Normalize to centroids
-		counts.forEach((c, g) => {
-			if (c > 0) {
-				centerX.set(g, centerX.get(g) / c);
-				centerY.set(g, centerY.get(g) / c);
-			}
-		});
+    // Normalize to centroids
+    counts.forEach((c, g) => {
+      if (c > 0) {
+        centerX.set(g, centerX.get(g) / c)
+        centerY.set(g, centerY.get(g) / c)
+      }
+    })
 
-		const s = alpha * strength;
-		for (let i = 0; i < nodes.length; i++) {
-			const n = nodes[i];
-			if (!n.group || n._posFixed) continue;
-			const cx = centerX.get(n.group);
-			const cy = centerY.get(n.group);
-			if (cx === undefined) continue;
-			n.vx += (cx - n.x) * s;
-			n.vy += (cy - n.y) * s;
-		}
-	}
+    const s = alpha * strength
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i]
+      if (!n.group || n._posFixed) continue
+      const cx = centerX.get(n.group)
+      const cy = centerY.get(n.group)
+      if (cx === undefined) continue
+      n.vx += (cx - n.x) * s
+      n.vy += (cy - n.y) * s
+    }
+  }
 
-	force.initialize = (_) => (nodes = _);
-	force.strength = (s) => {
-		strength = s;
-		return force;
-	};
-	return force;
-};
+  force.initialize = (_) => (nodes = _)
+  force.strength = (s) => {
+    strength = s
+    return force
+  }
+  return force
+}
 
 export default class D3Graph extends React.Component {
-	width = 100;
-	height = 100;
-	outer = React.createRef();
-	devicePixelRatio = window.devicePixelRatio || 1;
-
-	state = {
-		transform: d3.zoomTransform({}),
-	};
-
-	document = {
-		nodes: new Map(),
-		edges: new Map(),
-	};
-
-	nodeDegrees = new Map();
-	adjacencyMap = new Map();
-	groupColors = new Map();
-	animationFrameId = null;
-	lastFrameTime = 0;
-	frameCount = 0;
-
-	// Pre-cached per-node render data (avoids per-frame allocation)
-	nodeRenderCache = new Map();
-
-	// Cached hull paths (recomputed every HULL_INTERVAL frames)
-	cachedHulls = null;
-
-	// Pulse animation state
-	pulsingNodes = new Map();
-
-	computeNodeDegrees = () => {
-		this.nodeDegrees.clear();
-		this.adjacencyMap.clear();
-
-		this.document.nodes.forEach((n) => {
-			this.nodeDegrees.set(n.id, 0);
-			this.adjacencyMap.set(n.id, new Set());
-		});
-
-		this.document.edges.forEach((edge) => {
-			const srcId =
-				typeof edge.source === "object" ? edge.source.id : edge.source;
-			const tgtId =
-				typeof edge.target === "object" ? edge.target.id : edge.target;
-			this.nodeDegrees.set(srcId, (this.nodeDegrees.get(srcId) || 0) + 1);
-			this.nodeDegrees.set(tgtId, (this.nodeDegrees.get(tgtId) || 0) + 1);
-			if (this.adjacencyMap.has(srcId)) this.adjacencyMap.get(srcId).add(tgtId);
-			if (this.adjacencyMap.has(tgtId)) this.adjacencyMap.get(tgtId).add(srcId);
-		});
-
-		this.maxDegree = 1;
-		this.nodeDegrees.forEach((deg) => {
-			if (deg > this.maxDegree) this.maxDegree = deg;
-		});
-
-		this.groupColors.clear();
-		this.document.nodes.forEach((n) => {
-			if (n.group && n.color && !this.groupColors.has(n.group)) {
-				this.groupColors.set(n.group, n.color);
-			}
-		});
-
-		// Pre-cache radius and colors per node (avoids recalc every frame)
-		this.nodeRenderCache.clear();
-		this.document.nodes.forEach((n) => {
-			const degree = this.nodeDegrees.get(n.id) || 0;
-			let radius = DEFAULT_NODE_RADIUS;
-			if (this.maxDegree > 1) {
-				const t = Math.sqrt(degree / this.maxDegree);
-				radius = MIN_NODE_RADIUS + t * (MAX_NODE_RADIUS - MIN_NODE_RADIUS);
-			}
-			const color = n.color || "#848484";
-			this.nodeRenderCache.set(n.id, {
-				radius,
-				degree,
-				color,
-				colorDark: darkenColor(color, 0.25),
-			});
-		});
-
-		this.cachedHulls = null; // invalidate hull cache
-	};
-
-	getNodeRadius = (node) => {
-		const cached = this.nodeRenderCache.get(node.id);
-		return cached ? cached.radius : DEFAULT_NODE_RADIUS;
-	};
-
-	isInNeighborhood = (nodeId) => {
-		const hoveredNode = this.props.activeNode;
-		if (!hoveredNode || !this._isHovering) return true;
-		if (nodeId === hoveredNode.id) return true;
-		const neighbors = this.adjacencyMap.get(hoveredNode.id);
-		return neighbors && neighbors.has(nodeId);
-	};
-
-	isEdgeInNeighborhood = (edge) => {
-		const hoveredNode = this.props.activeNode;
-		if (!hoveredNode || !this._isHovering) return true;
-		const srcId =
-			typeof edge.source === "object" ? edge.source.id : edge.source;
-		const tgtId =
-			typeof edge.target === "object" ? edge.target.id : edge.target;
-		return srcId === hoveredNode.id || tgtId === hoveredNode.id;
-	};
-
-	getWorldViewport = () => {
-		const k = this.state.transform.k;
-		const tx = this.state.transform.x;
-		const ty = this.state.transform.y;
-		return {
-			x0: -tx / k,
-			y0: -ty / k,
-			x1: (this.width - tx) / k,
-			y1: (this.height - ty) / k,
-		};
-	};
-
-	isInViewport = (x, y, pad = 60) => {
-		const vp = this._viewport;
-		if (!vp) return true;
-		return (
-			x >= vp.x0 - pad &&
-			x <= vp.x1 + pad &&
-			y >= vp.y0 - pad &&
-			y <= vp.y1 + pad
-		);
-	};
-
-	// Hull computation — cached and throttled
-	computeHulls = () => {
-		const nodeCount = this.document.nodes.size;
-		if (nodeCount > PERF.HUGE_GRAPH || nodeCount < 4) {
-			this.cachedHulls = [];
-			return;
-		}
-
-		const byGroup = new Map();
-		this.document.nodes.forEach((n) => {
-			if (!n.group) return;
-			if (!byGroup.has(n.group)) byGroup.set(n.group, []);
-			byGroup.get(n.group).push([n.x, n.y]);
-		});
-
-		const hulls = [];
-		byGroup.forEach((points, group) => {
-			if (points.length < 3) return;
-			const hull = d3.polygonHull(points);
-			if (!hull) return;
-			hulls.push({ hull, color: this.groupColors.get(group) || "#888888" });
-		});
-		this.cachedHulls = hulls;
-	};
-
-	drawHulls = (context) => {
-		if (!this.cachedHulls || !this.cachedHulls.length) return;
-
-		context.save();
-		context.lineJoin = "round";
-		context.lineWidth = 1.5;
-
-		for (let h = 0; h < this.cachedHulls.length; h++) {
-			const { hull, color } = this.cachedHulls[h];
-			context.fillStyle = hexToRgba(color, THEME.hullAlpha);
-			context.strokeStyle = hexToRgba(color, THEME.hullStrokeAlpha);
-
-			const pad = THEME.hullPadding;
-			context.beginPath();
-			for (let i = 0; i < hull.length; i++) {
-				const p0 = hull[(i - 1 + hull.length) % hull.length];
-				const p1 = hull[i];
-				const p2 = hull[(i + 1) % hull.length];
-				const v1x = p1[0] - p0[0],
-					v1y = p1[1] - p0[1];
-				const v2x = p2[0] - p1[0],
-					v2y = p2[1] - p1[1];
-				const len1 = Math.hypot(v1x, v1y) || 1;
-				const len2 = Math.hypot(v2x, v2y) || 1;
-				const pInX = p1[0] - (v1x / len1) * pad,
-					pInY = p1[1] - (v1y / len1) * pad;
-				const pOutX = p1[0] + (v2x / len2) * pad,
-					pOutY = p1[1] + (v2y / len2) * pad;
-				if (i === 0) context.moveTo(pInX, pInY);
-				else context.lineTo(pInX, pInY);
-				context.quadraticCurveTo(p1[0], p1[1], pOutX, pOutY);
-			}
-			context.closePath();
-			context.fill();
-			context.stroke();
-		}
-		context.restore();
-	};
-
-	// Minimap — throttled, simple rendering
-	drawMinimap = () => {
-		if (!this.minimapCanvas || !this.document.nodes.size) return;
-		// Only redraw minimap every N frames
-		if (this.frameCount % PERF.MINIMAP_INTERVAL !== 0) return;
-
-		const mmw = this.minimapCanvas.width;
-		const mmh = this.minimapCanvas.height;
-		const mmctx = this.minimapContext;
-
-		mmctx.clearRect(0, 0, mmw, mmh);
-
-		mmctx.fillStyle = "rgba(20, 22, 30, 0.85)";
-		roundRect(mmctx, 0, 0, mmw, mmh, 6);
-		mmctx.fill();
-
-		let minX = Infinity,
-			minY = Infinity,
-			maxX = -Infinity,
-			maxY = -Infinity;
-		this.document.nodes.forEach((n) => {
-			if (n.x < minX) minX = n.x;
-			if (n.y < minY) minY = n.y;
-			if (n.x > maxX) maxX = n.x;
-			if (n.y > maxY) maxY = n.y;
-		});
-
-		const pad = 10;
-		const gw = maxX - minX || 1;
-		const gh = maxY - minY || 1;
-		const sx = (mmw - pad * 2) / gw;
-		const sy = (mmh - pad * 2) / gh;
-		const s = Math.min(sx, sy);
-		const ox = (mmw - s * gw) / 2;
-		const oy = (mmh - s * gh) / 2;
-
-		mmctx.save();
-		mmctx.translate(ox - minX * s, oy - minY * s);
-		mmctx.scale(s, s);
-
-		// Skip edges in minimap for large graphs
-		if (this.document.edges.size < 500) {
-			mmctx.strokeStyle = "rgba(255,255,255,0.1)";
-			mmctx.lineWidth = 1 / s;
-			mmctx.beginPath();
-			this.document.edges.forEach((edge) => {
-				if (!edge.source.x) return;
-				mmctx.moveTo(edge.source.x, edge.source.y);
-				mmctx.lineTo(edge.target.x, edge.target.y);
-			});
-			mmctx.stroke();
-		}
-
-		// Batch node drawing by color for fewer state changes
-		const dotSize = Math.max(1.5, 2 / s);
-		mmctx.globalAlpha = 0.8;
-		// Simple single-pass: just draw all nodes as one color for speed
-		mmctx.fillStyle = "rgba(180,190,200,0.9)";
-		mmctx.beginPath();
-		this.document.nodes.forEach((n) => {
-			mmctx.moveTo(n.x + dotSize, n.y);
-			mmctx.arc(n.x, n.y, dotSize, 0, Math.PI * 2);
-		});
-		mmctx.fill();
-		mmctx.globalAlpha = 1;
-
-		// Viewport rectangle
-		const vp = this.getWorldViewport();
-		mmctx.strokeStyle = "rgba(80,166,255,0.9)";
-		mmctx.lineWidth = 2 / s;
-		mmctx.fillStyle = "rgba(80,166,255,0.08)";
-		mmctx.strokeRect(vp.x0, vp.y0, vp.x1 - vp.x0, vp.y1 - vp.y0);
-		mmctx.fillRect(vp.x0, vp.y0, vp.x1 - vp.x0, vp.y1 - vp.y0);
-
-		mmctx.restore();
-	};
-
-	labelEdge = (context, edge) => {
-		const zoom = this.state.transform.k * this.devicePixelRatio;
-		if (this.document.edges.size > 200 && zoom < 1.5) return;
-		if (this.document.edges.size > 40 && zoom < 1.0) return;
-		if (zoom < 0.6) return;
-
-		const srcR = this.getNodeRadius(edge.source);
-		const tgtR = this.getNodeRadius(edge.target);
-		if (edge.arc.distance < srcR + tgtR + 40) return;
-
-		const fontSize = 11;
-		context.font = `500 ${fontSize}px ${THEME.labelFont}`;
-		context.textAlign = "center";
-		context.textBaseline = "middle";
-
-		const maxWidth = 120;
-		const bgPadding = 4;
-		let { width } = context.measureText(edge.label);
-		width = Math.min(width, maxWidth);
-
-		const { centerX: cx, centerY: cy } = edge.arc;
-		const rw = width + 2 * bgPadding;
-		const rh = fontSize + bgPadding;
-
-		context.globalAlpha = 0.88;
-		context.fillStyle = "#ffffff";
-		roundRect(context, cx - rw / 2, cy - rh / 2, rw, rh, 3);
-		context.fill();
-		context.globalAlpha = 1;
-
-		context.fillStyle = "#333333";
-		context.fillText(edge.label, cx, cy, maxWidth);
-	};
-
-	labelNode = (context, node) => {
-		const zoom = this.state.transform.k * this.devicePixelRatio;
-		const nodeCount = this.document.nodes.size;
-		const cached = this.nodeRenderCache.get(node.id);
-		const degree = cached ? cached.degree : 0;
-		const radius = cached ? cached.radius : DEFAULT_NODE_RADIUS;
-
-		if (nodeCount > 500 && zoom < 2.0 && degree < 3) return;
-		if (nodeCount > 200 && zoom < 1.2 && degree < 2) return;
-		if (nodeCount > 50 && zoom < 0.8) return;
-		if (zoom < 0.4) return;
-		if (nodeCount > 100 && degree < 2 && zoom < 1.5) return;
-
-		const label = node.label || "";
-		if (!label) return;
-
-		const fontSize = Math.max(10, Math.min(14, radius * 0.9));
-		context.font = `600 ${fontSize}px ${THEME.labelFont}`;
-		context.textAlign = "center";
-		context.textBaseline = "middle";
-
-		const maxWidth = radius * 4;
-		let { width: textWidth } = context.measureText(label);
-		textWidth = Math.min(textWidth, maxWidth);
-
-		const bgPadding = 3;
-		const textY = node.y + radius + fontSize / 2 + 4;
-		const rw = textWidth + 2 * bgPadding;
-		const rh = fontSize + bgPadding;
-
-		context.globalAlpha = 0.88;
-		context.fillStyle = "#2A2C34";
-		roundRect(context, node.x - rw / 2, textY - rh / 2, rw, rh, rh / 2);
-		context.fill();
-		context.globalAlpha = 1;
-
-		context.fillStyle = "#FFFFFF";
-		context.fillText(label, node.x, textY, maxWidth);
-	};
-
-	_drawAll = () => {
-		const context = this.canvasContext;
-		if (!context) return;
-
-		const { highlightPredicate } = this.props;
-		this._isHovering = !!this.props.hoveredNode;
-		this.frameCount++;
-
-		context.save();
-		const { devicePixelRatio: dpr } = this;
-		context.clearRect(0, 0, this.width * dpr, this.height * dpr);
-		context.translate(
-			this.state.transform.x * dpr,
-			this.state.transform.y * dpr,
-		);
-		context.scale(this.state.transform.k * dpr, this.state.transform.k * dpr);
-
-		this._viewport = this.getWorldViewport();
-
-		const zoom = this.state.transform.k * dpr;
-		const isZoomedOut = zoom < 0.3;
-		const nodeCount = this.document.nodes.size;
-		const isLargeGraph = nodeCount > PERF.LARGE_GRAPH;
-		const isHugeGraph = nodeCount > PERF.HUGE_GRAPH;
-
-		// --- Hulls (throttled) ---
-		if (!isZoomedOut && !isHugeGraph) {
-			if (this.frameCount % PERF.HULL_INTERVAL === 0 || !this.cachedHulls) {
-				this.computeHulls();
-			}
-			this.drawHulls(context);
-		}
-
-		// --- Arc helpers (defined once, not per-edge) ---
-		const addArrow = (arc, target, vx, vy, nodeRadius) => {
-			const baseOffset = nodeRadius + ARROW_LENGTH;
-			arc.arrowBase0 = target.x - vx * baseOffset;
-			arc.arrowBase1 = target.y - vy * baseOffset;
-			arc.arrowEnd0 = target.x - nodeRadius * vx;
-			arc.arrowEnd1 = target.y - nodeRadius * vy;
-			arc.arrowPt10 = arc.arrowBase0 + ARROW_WIDTH * vy;
-			arc.arrowPt11 = arc.arrowBase1 - ARROW_WIDTH * vx;
-			arc.arrowPt20 = arc.arrowBase0 - ARROW_WIDTH * vy;
-			arc.arrowPt21 = arc.arrowBase1 + ARROW_WIDTH * vx;
-			arc.hasArrow = true;
-		};
-
-		const getArc = (edge) => {
-			const dx = edge.target.x - edge.source.x;
-			const dy = edge.target.y - edge.source.y;
-			const l = Math.sqrt(dx * dx + dy * dy);
-
-			const srcR = this.getNodeRadius(edge.source);
-			const tgtR = this.getNodeRadius(edge.target);
-
-			const arc = {
-				radius: -1,
-				distance: l,
-				centerX: edge.source.x + dx / 2,
-				centerY: edge.source.y + dy / 2,
-				hasArrow: false,
-			};
-
-			if (
-				!edge.siblingCount ||
-				edge.siblingCount < 2 ||
-				(edge.siblingCount % 2 && edge.siblingIndex === 0) ||
-				l < srcR + tgtR
-			) {
-				if (l > srcR + tgtR + 2 * ARROW_LENGTH) {
-					addArrow(arc, edge.target, dx / l, dy / l, tgtR);
-				}
-				return arc;
-			}
-
-			const LR = 4;
-			let offset;
-			if (edge.siblingCount % 2) {
-				offset = LR * (1 + Math.ceil(edge.siblingIndex / 2) * 2);
-			} else {
-				offset = LR * (1 + Math.floor(edge.siblingIndex / 2) * 2);
-			}
-			if (edge.siblingCount * LR > (0.9 * l) / 2) {
-				offset = (offset * 0.9 * l) / 2 / edge.siblingCount / LR;
-			}
-
-			const norm0 = edge.siblingIndex % 2 ? dy / l : -dy / l;
-			const norm1 = edge.siblingIndex % 2 ? -dx / l : dx / l;
-			const R = (offset * offset + (l * l) / 4) / 2 / offset;
-			const h2 = (R * offset) / (R - offset);
-
-			arc.radius = R;
-			arc.centerX = edge.source.x + dx / 2 + norm0 * offset;
-			arc.centerY = edge.source.y + dy / 2 + norm1 * offset;
-			arc.controlX = edge.source.x + dx / 2 + norm0 * (offset + h2);
-			arc.controlY = edge.source.y + dy / 2 + norm1 * (offset + h2);
-
-			if (l > srcR + tgtR + 2 * ARROW_LENGTH) {
-				const rotateDir = edge.siblingIndex % 2 ? +1 : -1;
-				const alpha = Math.asin(Math.min(1, l / 2 / R));
-				const theta = Math.asin(Math.min(1, tgtR / 2 / R));
-				const ra = rotateDir * (alpha - theta);
-				const cosA = Math.cos(ra),
-					sinA = Math.sin(ra);
-				const ndx = dx / l,
-					ndy = dy / l;
-				addArrow(
-					arc,
-					edge.target,
-					ndx * cosA - ndy * sinA,
-					ndx * sinA + ndy * cosA,
-					tgtR,
-				);
-			}
-
-			return arc;
-		};
-
-		// --- Edges ---
-		context.lineCap = "round";
-		let edgesDrawn = 0;
-		this.document.edges.forEach((edge) => {
-			// Hard cap on visible edges for huge graphs
-			if (isHugeGraph && edgesDrawn >= PERF.MAX_VISIBLE_EDGES) return;
-
-			// Viewport culling
-			if (
-				!this.isInViewport(edge.source.x, edge.source.y, 100) &&
-				!this.isInViewport(edge.target.x, edge.target.y, 100)
-			)
-				return;
-
-			edgesDrawn++;
-			const arc = (edge.arc = getArc(edge));
-
-			const isHighlighted = edge.predicate === highlightPredicate;
-			const isActive = edge === this.props.activeEdge;
-			const inNeighborhood = this.isEdgeInNeighborhood(edge);
-
-			context.strokeStyle = edge.color;
-			if (this._isHovering && !inNeighborhood) {
-				context.globalAlpha = THEME.edgeAlphaDimmed;
-				context.lineWidth = 0.5;
-			} else if (isActive) {
-				context.globalAlpha = THEME.edgeAlphaHighlight;
-				context.lineWidth = THEME.edgeWidthActive;
-			} else if (isHighlighted || (this._isHovering && inNeighborhood)) {
-				context.globalAlpha = THEME.edgeAlphaHighlight;
-				context.lineWidth = THEME.edgeWidthHighlight;
-			} else {
-				context.globalAlpha = THEME.edgeAlphaDefault;
-				context.lineWidth = THEME.edgeWidthDefault;
-			}
-
-			context.beginPath();
-			context.moveTo(edge.source.x, edge.source.y);
-			if (arc.radius <= 0) {
-				context.lineTo(edge.target.x, edge.target.y);
-			} else {
-				context.arcTo(
-					arc.controlX,
-					arc.controlY,
-					edge.target.x,
-					edge.target.y,
-					arc.radius,
-				);
-			}
-			context.stroke();
-
-			// Arrowhead — skip for huge graphs when zoomed out
-			if (arc.hasArrow && !(isHugeGraph && isZoomedOut)) {
-				context.fillStyle = edge.color;
-				context.beginPath();
-				context.moveTo(arc.arrowEnd0, arc.arrowEnd1);
-				context.lineTo(arc.arrowPt10, arc.arrowPt11);
-				context.lineTo(arc.arrowPt20, arc.arrowPt21);
-				context.closePath();
-				context.fill();
-			}
-
-			context.globalAlpha = 1;
-			if (!isLargeGraph && (!this._isHovering || inNeighborhood)) {
-				this.labelEdge(context, edge);
-			}
-		});
-
-		// --- Nodes ---
-		this.document.nodes.forEach((d) => {
-			if (!this.isInViewport(d.x, d.y, 50)) return;
-
-			const cached = this.nodeRenderCache.get(d.id);
-			const radius = cached ? cached.radius : DEFAULT_NODE_RADIUS;
-			const color = cached ? cached.color : "#848484";
-			const isActive = d === this.props.activeNode;
-			const inNeighborhood = this.isInNeighborhood(d.id);
-			const dimmed = this._isHovering && !inNeighborhood;
-
-			if (dimmed) context.globalAlpha = THEME.nodeDimmedAlpha;
-
-			// LOD: dots at very low zoom
-			if (isZoomedOut) {
-				context.fillStyle = color;
-				context.beginPath();
-				context.arc(d.x, d.y, Math.max(2, radius * 0.3), 0, 2 * Math.PI);
-				context.fill();
-				context.globalAlpha = 1;
-				return;
-			}
-
-			// Solid fill
-			context.fillStyle = color;
-			context.beginPath();
-			context.arc(d.x, d.y, radius, 0, 2 * Math.PI, true);
-			context.fill();
-
-			// Border
-			context.strokeStyle = cached
-				? cached.colorDark
-				: darkenColor(color, 0.25);
-			context.lineWidth = isActive
-				? THEME.nodeBorderActive
-				: THEME.nodeBorderDefault;
-			context.stroke();
-
-			// Active glow
-			if (isActive && !dimmed) {
-				context.strokeStyle = color;
-				context.globalAlpha = 0.4;
-				context.lineWidth = 4;
-				context.beginPath();
-				context.arc(d.x, d.y, radius + 4, 0, 2 * Math.PI, true);
-				context.stroke();
-				context.globalAlpha = dimmed ? THEME.nodeDimmedAlpha : 1;
-			}
-
-			// Search pulse
-			const pulse = this.pulsingNodes.get(d.id);
-			if (pulse && pulse > 0) {
-				context.strokeStyle = "#50A6FF";
-				context.globalAlpha = 0.6 * pulse;
-				context.lineWidth = 8 * pulse;
-				context.beginPath();
-				context.arc(d.x, d.y, radius + 10 * (1 - pulse), 0, 2 * Math.PI);
-				context.stroke();
-				context.globalAlpha = 1;
-			}
-
-			// Expanded dot
-			if (d.expanded) {
-				context.fillStyle = "#ffffff";
-				context.beginPath();
-				context.arc(
-					d.x + radius * 0.55,
-					d.y - radius * 0.55,
-					3,
-					0,
-					2 * Math.PI,
-				);
-				context.fill();
-			}
-
-			context.globalAlpha = 1;
-			if (!dimmed) this.labelNode(context, d);
-		});
-
-		context.restore();
-		this.drawMinimap();
-	};
-
-	startAnimationLoop = () => {
-		const animate = (timestamp) => {
-			const delta = timestamp - (this.lastFrameTime || timestamp);
-			this.lastFrameTime = timestamp;
-
-			let hasPulse = false;
-			this.pulsingNodes.forEach((val, key) => {
-				const newVal = val - delta * 0.002;
-				if (newVal <= 0) this.pulsingNodes.delete(key);
-				else {
-					this.pulsingNodes.set(key, newVal);
-					hasPulse = true;
-				}
-			});
-
-			if (hasPulse) this._drawAll();
-
-			this.animationFrameId = requestAnimationFrame(animate);
-		};
-		this.animationFrameId = requestAnimationFrame(animate);
-	};
-
-	drawGraph = debounce(this._drawAll, 5, { leading: true, trailing: true });
-
-	createForces = () => {
-		this.d3simulation
-			.alphaTarget(0)
-			.alphaMin(0.005)
-			.alphaDecay(0.05)
-			.velocityDecay(0.5)
-			.force(
-				"link",
-				d3
-					.forceLink()
-					.distance((d) => {
-						const srcDeg =
-							this.nodeDegrees.get(
-								typeof d.source === "object" ? d.source.id : d.source,
-							) || 1;
-						const tgtDeg =
-							this.nodeDegrees.get(
-								typeof d.target === "object" ? d.target.id : d.target,
-							) || 1;
-						const srcG = typeof d.source === "object" ? d.source.group : null;
-						const tgtG = typeof d.target === "object" ? d.target.group : null;
-						const cross = srcG && tgtG && srcG !== tgtG;
-						return (cross ? 100 : 60) + Math.sqrt(srcDeg + tgtDeg) * 15;
-					})
-					.strength((d) => {
-						const srcG = typeof d.source === "object" ? d.source.group : null;
-						const tgtG = typeof d.target === "object" ? d.target.group : null;
-						return srcG === tgtG ? 0.4 : 0.15;
-					})
-					.id((d) => d.id),
-			)
-			.force(
-				"charge",
-				d3
-					.forceManyBody()
-					.strength((d) => {
-						const degree = this.nodeDegrees.get(d.id) || 0;
-						return -200 - degree * 30;
-					})
-					.distanceMax(500)
-					.theta(0.9),
-			)
-			.force(
-				"collision",
-				d3
-					.forceCollide()
-					.radius((d) => this.getNodeRadius(d) + 8)
-					.strength(0.8),
-			)
-			.force("cluster", forceCluster(0.35))
-			.force("fixedPosForce", fixedPosForce());
-
-		this.fixedPosForce = this.d3simulation.force("fixedPosForce");
-		this.edgesForce = this.d3simulation.force("link");
-	};
-
-	componentDidMount() {
-		this.d3simulation = d3.forceSimulation().on("tick", this.drawGraph);
-		this.createForces();
-
-		this.graphCanvas = d3
-			.select(this.outer.current)
-			.append("canvas")
-			.attr("width", this.width)
-			.attr("height", this.height)
-			.node();
-
-		this.minimapCanvas = document.createElement("canvas");
-		this.minimapCanvas.className = "graph-minimap";
-		this.minimapCanvas.width = 180;
-		this.minimapCanvas.height = 120;
-		this.outer.current.appendChild(this.minimapCanvas);
-		this.minimapContext = this.minimapCanvas.getContext("2d");
-		this.minimapCanvas.addEventListener("click", this.onMinimapClick);
-
-		this.zoomBehavior = d3
-			.zoom()
-			.scaleExtent([(1 / 8) * this.devicePixelRatio, 6 * this.devicePixelRatio])
-			.on("zoom", this.onZoom);
-
-		d3.select(this.graphCanvas)
-			.on("click", this.onClick)
-			.on("dblclick", this.onDoubleClick)
-			.on("mousemove", this.onMouseMove)
-			.call(
-				d3
-					.drag()
-					.subject(this.dragsubject)
-					.on("start", this.dragstarted)
-					.on("drag", this.dragged),
-			)
-			.call(this.zoomBehavior);
-
-		this.onResize();
-		this.updateDocument(this.props.nodes, this.props.edges);
-		this.startAnimationLoop();
-		this.resizeObserver = window.setInterval(this.onResize, 1000);
-	}
-
-	componentWillUnmount() {
-		clearInterval(this.resizeObserver);
-		if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId);
-		if (this.minimapCanvas)
-			this.minimapCanvas.removeEventListener("click", this.onMinimapClick);
-	}
-
-	onMinimapClick = (e) => {
-		if (!this.document.nodes.size) return;
-		const rect = this.minimapCanvas.getBoundingClientRect();
-		const px = e.clientX - rect.left,
-			py = e.clientY - rect.top;
-		const mmw = this.minimapCanvas.width,
-			mmh = this.minimapCanvas.height;
-
-		let minX = Infinity,
-			minY = Infinity,
-			maxX = -Infinity,
-			maxY = -Infinity;
-		this.document.nodes.forEach((n) => {
-			if (n.x < minX) minX = n.x;
-			if (n.y < minY) minY = n.y;
-			if (n.x > maxX) maxX = n.x;
-			if (n.y > maxY) maxY = n.y;
-		});
-
-		const pad = 10,
-			gw = maxX - minX || 1,
-			gh = maxY - minY || 1;
-		const s = Math.min((mmw - pad * 2) / gw, (mmh - pad * 2) / gh);
-		const ox = (mmw - s * gw) / 2,
-			oy = (mmh - s * gh) / 2;
-		const wx = (px - ox + minX * s) / s,
-			wy = (py - oy + minY * s) / s;
-
-		const k = this.state.transform.k;
-		d3.select(this.graphCanvas)
-			.transition()
-			.duration(300)
-			.call(
-				this.zoomBehavior.transform,
-				d3.zoomIdentity
-					.translate(this.width / 2 - wx * k, this.height / 2 - wy * k)
-					.scale(k),
-			);
-	};
-
-	getD3EventCoords = (event) => this.state.transform.invert([event.x, event.y]);
-
-	findNodeAtPos = (x, y) => {
-		let minNode,
-			minD = 1e10;
-		this.document.nodes.forEach((n) => {
-			const r = this.getNodeRadius(n);
-			const d = (n.x - x) * (n.x - x) + (n.y - y) * (n.y - y);
-			if (d < r * r && d < minD) {
-				minNode = n;
-				minD = d;
-			}
-		});
-		return minNode;
-	};
-
-	findEdgeAtPos = (x, y) => {
-		let minEdge,
-			minD = 1e10;
-		this.document.edges.forEach((edge) => {
-			if (!edge.arc) return;
-			const { centerX: cx, centerY: cy } = edge.arc;
-			const d = (cx - x) * (cx - x) + (cy - y) * (cy - y);
-			if (d < minD) {
-				minEdge = edge;
-				minD = d;
-			}
-		});
-		return minD > 225 ? undefined : minEdge;
-	};
-
-	onMouseMove = () => {
-		const { offsetX: x, offsetY: y } = currentEvent;
-		const pt = this.getD3EventCoords({ x, y });
-		const node = this.findNodeAtPos(...pt);
-		this.props.onNodeHovered(node);
-		if (this.graphCanvas)
-			this.graphCanvas.style.cursor = node ? "pointer" : "default";
-		if (!node) this.props.onEdgeHovered(this.findEdgeAtPos(...pt));
-		this.drawGraph();
-	};
-
-	onClick = () => {
-		const { offsetX: x, offsetY: y } = currentEvent;
-		const pt = this.getD3EventCoords({ x, y });
-		const node = this.findNodeAtPos(...pt);
-		if (node) {
-			currentEvent.stopImmediatePropagation();
-			return this.props.onNodeSelected(node);
-		}
-		const edge = this.findEdgeAtPos(...pt);
-		if (edge) {
-			currentEvent.stopImmediatePropagation();
-			return this.props.onEdgeSelected(edge);
-		}
-	};
-
-	onDoubleClick = () => {
-		const { offsetX: x, offsetY: y } = currentEvent;
-		const pt = this.getD3EventCoords({ x, y });
-		const node = this.findNodeAtPos(...pt);
-		if (node) {
-			currentEvent.stopImmediatePropagation();
-			return this.props.onNodeDoubleClicked(node);
-		}
-	};
-
-	dragsubject = () => {
-		const { offsetX: x, offsetY: y } = currentEvent.sourceEvent;
-		const pt = this.getD3EventCoords({ x, y });
-		const node = this.findNodeAtPos(...pt);
-		this.props.onNodeSelected(node);
-		return node;
-	};
-
-	dragstarted = () => {
-		if (!currentEvent.active)
-			setTimeout(() => this.d3simulation.alpha(0.5).restart(), DOUBLE_CLICK_MS);
-	};
-
-	dragged = () => {
-		const { offsetX: x, offsetY: y } = currentEvent.sourceEvent;
-		const pt = this.getD3EventCoords({ x, y });
-		this.fixedPosForce.setNodeCoords(currentEvent.subject, ...pt);
-		this.drawGraph();
-		this.d3simulation.alpha(Math.max(0.12, this.d3simulation.alpha()));
-	};
-
-	_updateZoom = (transform) => {
-		if (this.state.transform.toString() !== transform.toString())
-			this.setState({ transform });
-	};
-	updateZoom = debounce(this._updateZoom, 2, { leading: true, trailing: true });
-	onZoom = () => this.updateZoom(currentEvent.transform);
-
-	zoomToFit = () => {
-		if (!this.graphCanvas || !this.document.nodes.size) return;
-		let minX = Infinity,
-			minY = Infinity,
-			maxX = -Infinity,
-			maxY = -Infinity;
-		this.document.nodes.forEach((n) => {
-			const r = this.getNodeRadius(n) + 20;
-			if (n.x - r < minX) minX = n.x - r;
-			if (n.y - r < minY) minY = n.y - r;
-			if (n.x + r > maxX) maxX = n.x + r;
-			if (n.y + r > maxY) maxY = n.y + r;
-		});
-		const p = 40,
-			gw = maxX - minX + p * 2,
-			gh = maxY - minY + p * 2;
-		const scale = Math.min(this.width / gw, this.height / gh, 2) * 0.9;
-		const transform = d3.zoomIdentity
-			.translate(this.width / 2, this.height / 2)
-			.scale(scale)
-			.translate(-(minX + maxX) / 2, -(minY + maxY) / 2);
-		d3.select(this.graphCanvas)
-			.transition()
-			.duration(500)
-			.call(this.zoomBehavior.transform, transform);
-	};
-
-	focusNode = (node) => {
-		if (!this.graphCanvas || !node) return;
-		const k = 2.2;
-		d3.select(this.graphCanvas)
-			.transition()
-			.duration(500)
-			.ease(d3.easeCubicOut)
-			.call(
-				this.zoomBehavior.transform,
-				d3.zoomIdentity
-					.translate(this.width / 2 - node.x * k, this.height / 2 - node.y * k)
-					.scale(k),
-			);
-		this.pulsingNodes.set(node.id, 1.0);
-	};
-
-	searchNode = (query) => {
-		if (!query) return null;
-		const q = query.toLowerCase().trim();
-		let found = null;
-		this.document.nodes.forEach((n) => {
-			if (found) return;
-			const name = (n.name || n.label || "").toLowerCase();
-			const uid = (n.uid || n.id || "").toLowerCase();
-			if (name.includes(q) || uid === q) found = n;
-		});
-		return found;
-	};
-
-	onResize = () => {
-		let resized = false;
-		if (this.outer.current) {
-			const el = this.outer.current;
-			resized |= this.width !== el.offsetWidth;
-			resized |= this.height !== el.offsetHeight;
-			this.width = el.offsetWidth;
-			this.height = el.offsetHeight;
-		}
-		if (!resized) return;
-
-		this.zoomBehavior.scaleTo(d3.select(this.graphCanvas), 1);
-		this.zoomBehavior.translateTo(d3.select(this.graphCanvas), 0, 0);
-
-		const { width, height } = this;
-		this.d3simulation
-			.force("x", d3.forceX(0).strength((0.02 * height) / width))
-			.force("y", d3.forceY(0).strength((0.02 * width) / height));
-
-		d3.select(this.graphCanvas)
-			.attr("width", this.width * this.devicePixelRatio)
-			.attr("height", this.height * this.devicePixelRatio);
-
-		this.canvasContext = this.graphCanvas.getContext("2d");
-		this._drawAll();
-	};
-
-	updateDocument = (nodes, edges) => {
-		if (!this.d3simulation || !nodes || !edges) return;
-
-		const newNodesReceived =
-			this.document.nodesLength !== nodes.size ||
-			this.document.edgesLength !== edges.size;
-
-		this.document = {
-			edges,
-			edgesLength: edges.size,
-			nodes,
-			nodesLength: nodes.size,
-		};
-		this.computeNodeDegrees();
-
-		if (newNodesReceived) {
-			this.d3simulation
-				.force(
-					"link",
-					d3
-						.forceLink()
-						.distance((d) => {
-							const srcDeg =
-								this.nodeDegrees.get(
-									typeof d.source === "object" ? d.source.id : d.source,
-								) || 1;
-							const tgtDeg =
-								this.nodeDegrees.get(
-									typeof d.target === "object" ? d.target.id : d.target,
-								) || 1;
-							const srcG = typeof d.source === "object" ? d.source.group : null;
-							const tgtG = typeof d.target === "object" ? d.target.group : null;
-							return (
-								(srcG && tgtG && srcG !== tgtG ? 100 : 60) +
-								Math.sqrt(srcDeg + tgtDeg) * 15
-							);
-						})
-						.strength((d) => {
-							const srcG = typeof d.source === "object" ? d.source.group : null;
-							const tgtG = typeof d.target === "object" ? d.target.group : null;
-							return srcG === tgtG ? 0.4 : 0.15;
-						})
-						.id((d) => d.id),
-				)
-				.force(
-					"charge",
-					d3
-						.forceManyBody()
-						.strength((d) => -200 - (this.nodeDegrees.get(d.id) || 0) * 30)
-						.distanceMax(500)
-						.theta(0.9),
-				)
-				.force(
-					"collision",
-					d3
-						.forceCollide()
-						.radius((d) => this.getNodeRadius(d) + 8)
-						.strength(0.8),
-				)
-				.force("cluster", forceCluster(0.35));
-
-			this.edgesForce = this.d3simulation.force("link");
-			this.d3simulation.alpha(0.5).restart();
-		}
-
-		this.d3simulation.nodes(Array.from(nodes.values()));
-		this.edgesForce.links(Array.from(edges.values()));
-	};
-
-	render() {
-		this.updateDocument(this.props.nodes, this.props.edges);
-		this.onResize();
-		this.drawGraph();
-		return <div ref={this.outer} className="graph-outer" />;
-	}
+  width = 100
+  height = 100
+  outer = React.createRef()
+  devicePixelRatio = window.devicePixelRatio || 1
+
+  state = {
+    transform: d3.zoomTransform({}),
+  }
+
+  document = {
+    nodes: new Map(),
+    edges: new Map(),
+  }
+
+  nodeDegrees = new Map()
+  adjacencyMap = new Map()
+  groupColors = new Map()
+  animationFrameId = null
+  lastFrameTime = 0
+  frameCount = 0
+
+  // Pre-cached per-node render data (avoids per-frame allocation)
+  nodeRenderCache = new Map()
+
+  // Cached hull paths (recomputed every HULL_INTERVAL frames)
+  cachedHulls = null
+
+  // Pulse animation state
+  pulsingNodes = new Map()
+
+  computeNodeDegrees = () => {
+    this.nodeDegrees.clear()
+    this.adjacencyMap.clear()
+
+    this.document.nodes.forEach((n) => {
+      this.nodeDegrees.set(n.id, 0)
+      this.adjacencyMap.set(n.id, new Set())
+    })
+
+    this.document.edges.forEach((edge) => {
+      const srcId =
+        typeof edge.source === 'object' ? edge.source.id : edge.source
+      const tgtId =
+        typeof edge.target === 'object' ? edge.target.id : edge.target
+      this.nodeDegrees.set(srcId, (this.nodeDegrees.get(srcId) || 0) + 1)
+      this.nodeDegrees.set(tgtId, (this.nodeDegrees.get(tgtId) || 0) + 1)
+      if (this.adjacencyMap.has(srcId)) this.adjacencyMap.get(srcId).add(tgtId)
+      if (this.adjacencyMap.has(tgtId)) this.adjacencyMap.get(tgtId).add(srcId)
+    })
+
+    this.maxDegree = 1
+    this.nodeDegrees.forEach((deg) => {
+      if (deg > this.maxDegree) this.maxDegree = deg
+    })
+
+    this.groupColors.clear()
+    this.document.nodes.forEach((n) => {
+      if (n.group && n.color && !this.groupColors.has(n.group)) {
+        this.groupColors.set(n.group, n.color)
+      }
+    })
+
+    // Pre-cache radius and colors per node (avoids recalc every frame)
+    this.nodeRenderCache.clear()
+    this.document.nodes.forEach((n) => {
+      const degree = this.nodeDegrees.get(n.id) || 0
+      let radius = DEFAULT_NODE_RADIUS
+      if (this.maxDegree > 1) {
+        const t = Math.sqrt(degree / this.maxDegree)
+        radius = MIN_NODE_RADIUS + t * (MAX_NODE_RADIUS - MIN_NODE_RADIUS)
+      }
+      const color = n.color || '#848484'
+      this.nodeRenderCache.set(n.id, {
+        radius,
+        degree,
+        color,
+        colorDark: darkenColor(color, 0.25),
+      })
+    })
+
+    this.cachedHulls = null // invalidate hull cache
+  }
+
+  getNodeRadius = (node) => {
+    const cached = this.nodeRenderCache.get(node.id)
+    return cached ? cached.radius : DEFAULT_NODE_RADIUS
+  }
+
+  isInNeighborhood = (nodeId) => {
+    const hoveredNode = this.props.activeNode
+    if (!hoveredNode || !this._isHovering) return true
+    if (nodeId === hoveredNode.id) return true
+    const neighbors = this.adjacencyMap.get(hoveredNode.id)
+    return neighbors && neighbors.has(nodeId)
+  }
+
+  isEdgeInNeighborhood = (edge) => {
+    const hoveredNode = this.props.activeNode
+    if (!hoveredNode || !this._isHovering) return true
+    const srcId = typeof edge.source === 'object' ? edge.source.id : edge.source
+    const tgtId = typeof edge.target === 'object' ? edge.target.id : edge.target
+    return srcId === hoveredNode.id || tgtId === hoveredNode.id
+  }
+
+  getWorldViewport = () => {
+    const k = this.state.transform.k
+    const tx = this.state.transform.x
+    const ty = this.state.transform.y
+    return {
+      x0: -tx / k,
+      y0: -ty / k,
+      x1: (this.width - tx) / k,
+      y1: (this.height - ty) / k,
+    }
+  }
+
+  isInViewport = (x, y, pad = 60) => {
+    const vp = this._viewport
+    if (!vp) return true
+    return (
+      x >= vp.x0 - pad &&
+      x <= vp.x1 + pad &&
+      y >= vp.y0 - pad &&
+      y <= vp.y1 + pad
+    )
+  }
+
+  // Hull computation — cached and throttled
+  computeHulls = () => {
+    const nodeCount = this.document.nodes.size
+    if (nodeCount > PERF.HUGE_GRAPH || nodeCount < 4) {
+      this.cachedHulls = []
+      return
+    }
+
+    const byGroup = new Map()
+    this.document.nodes.forEach((n) => {
+      if (!n.group) return
+      if (!byGroup.has(n.group)) byGroup.set(n.group, [])
+      byGroup.get(n.group).push([n.x, n.y])
+    })
+
+    const hulls = []
+    byGroup.forEach((points, group) => {
+      if (points.length < 3) return
+      const hull = d3.polygonHull(points)
+      if (!hull) return
+      hulls.push({ hull, color: this.groupColors.get(group) || '#888888' })
+    })
+    this.cachedHulls = hulls
+  }
+
+  drawHulls = (context) => {
+    if (!this.cachedHulls || !this.cachedHulls.length) return
+
+    context.save()
+    context.lineJoin = 'round'
+    context.lineWidth = 1.5
+
+    for (let h = 0; h < this.cachedHulls.length; h++) {
+      const { hull, color } = this.cachedHulls[h]
+      context.fillStyle = hexToRgba(color, THEME.hullAlpha)
+      context.strokeStyle = hexToRgba(color, THEME.hullStrokeAlpha)
+
+      const pad = THEME.hullPadding
+      context.beginPath()
+      for (let i = 0; i < hull.length; i++) {
+        const p0 = hull[(i - 1 + hull.length) % hull.length]
+        const p1 = hull[i]
+        const p2 = hull[(i + 1) % hull.length]
+        const v1x = p1[0] - p0[0],
+          v1y = p1[1] - p0[1]
+        const v2x = p2[0] - p1[0],
+          v2y = p2[1] - p1[1]
+        const len1 = Math.hypot(v1x, v1y) || 1
+        const len2 = Math.hypot(v2x, v2y) || 1
+        const pInX = p1[0] - (v1x / len1) * pad,
+          pInY = p1[1] - (v1y / len1) * pad
+        const pOutX = p1[0] + (v2x / len2) * pad,
+          pOutY = p1[1] + (v2y / len2) * pad
+        if (i === 0) context.moveTo(pInX, pInY)
+        else context.lineTo(pInX, pInY)
+        context.quadraticCurveTo(p1[0], p1[1], pOutX, pOutY)
+      }
+      context.closePath()
+      context.fill()
+      context.stroke()
+    }
+    context.restore()
+  }
+
+  // Minimap — throttled, simple rendering
+  drawMinimap = () => {
+    if (!this.minimapCanvas || !this.document.nodes.size) return
+    // Only redraw minimap every N frames
+    if (this.frameCount % PERF.MINIMAP_INTERVAL !== 0) return
+
+    const mmw = this.minimapCanvas.width
+    const mmh = this.minimapCanvas.height
+    const mmctx = this.minimapContext
+
+    mmctx.clearRect(0, 0, mmw, mmh)
+
+    mmctx.fillStyle = 'rgba(20, 22, 30, 0.85)'
+    roundRect(mmctx, 0, 0, mmw, mmh, 6)
+    mmctx.fill()
+
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity
+    this.document.nodes.forEach((n) => {
+      if (n.x < minX) minX = n.x
+      if (n.y < minY) minY = n.y
+      if (n.x > maxX) maxX = n.x
+      if (n.y > maxY) maxY = n.y
+    })
+
+    const pad = 10
+    const gw = maxX - minX || 1
+    const gh = maxY - minY || 1
+    const sx = (mmw - pad * 2) / gw
+    const sy = (mmh - pad * 2) / gh
+    const s = Math.min(sx, sy)
+    const ox = (mmw - s * gw) / 2
+    const oy = (mmh - s * gh) / 2
+
+    mmctx.save()
+    mmctx.translate(ox - minX * s, oy - minY * s)
+    mmctx.scale(s, s)
+
+    // Skip edges in minimap for large graphs
+    if (this.document.edges.size < 500) {
+      mmctx.strokeStyle = 'rgba(255,255,255,0.1)'
+      mmctx.lineWidth = 1 / s
+      mmctx.beginPath()
+      this.document.edges.forEach((edge) => {
+        if (!edge.source.x) return
+        mmctx.moveTo(edge.source.x, edge.source.y)
+        mmctx.lineTo(edge.target.x, edge.target.y)
+      })
+      mmctx.stroke()
+    }
+
+    // Batch node drawing by color for fewer state changes
+    const dotSize = Math.max(1.5, 2 / s)
+    mmctx.globalAlpha = 0.8
+    // Simple single-pass: just draw all nodes as one color for speed
+    mmctx.fillStyle = 'rgba(180,190,200,0.9)'
+    mmctx.beginPath()
+    this.document.nodes.forEach((n) => {
+      mmctx.moveTo(n.x + dotSize, n.y)
+      mmctx.arc(n.x, n.y, dotSize, 0, Math.PI * 2)
+    })
+    mmctx.fill()
+    mmctx.globalAlpha = 1
+
+    // Viewport rectangle
+    const vp = this.getWorldViewport()
+    mmctx.strokeStyle = 'rgba(80,166,255,0.9)'
+    mmctx.lineWidth = 2 / s
+    mmctx.fillStyle = 'rgba(80,166,255,0.08)'
+    mmctx.strokeRect(vp.x0, vp.y0, vp.x1 - vp.x0, vp.y1 - vp.y0)
+    mmctx.fillRect(vp.x0, vp.y0, vp.x1 - vp.x0, vp.y1 - vp.y0)
+
+    mmctx.restore()
+  }
+
+  labelEdge = (context, edge) => {
+    const zoom = this.state.transform.k * this.devicePixelRatio
+    if (this.document.edges.size > 200 && zoom < 1.5) return
+    if (this.document.edges.size > 40 && zoom < 1.0) return
+    if (zoom < 0.6) return
+
+    const srcR = this.getNodeRadius(edge.source)
+    const tgtR = this.getNodeRadius(edge.target)
+    if (edge.arc.distance < srcR + tgtR + 40) return
+
+    const fontSize = 11
+    context.font = `500 ${fontSize}px ${THEME.labelFont}`
+    context.textAlign = 'center'
+    context.textBaseline = 'middle'
+
+    const maxWidth = 120
+    const bgPadding = 4
+    let { width } = context.measureText(edge.label)
+    width = Math.min(width, maxWidth)
+
+    const { centerX: cx, centerY: cy } = edge.arc
+    const rw = width + 2 * bgPadding
+    const rh = fontSize + bgPadding
+
+    context.globalAlpha = 0.88
+    context.fillStyle = '#ffffff'
+    roundRect(context, cx - rw / 2, cy - rh / 2, rw, rh, 3)
+    context.fill()
+    context.globalAlpha = 1
+
+    context.fillStyle = '#333333'
+    context.fillText(edge.label, cx, cy, maxWidth)
+  }
+
+  labelNode = (context, node) => {
+    const zoom = this.state.transform.k * this.devicePixelRatio
+    const nodeCount = this.document.nodes.size
+    const cached = this.nodeRenderCache.get(node.id)
+    const degree = cached ? cached.degree : 0
+    const radius = cached ? cached.radius : DEFAULT_NODE_RADIUS
+
+    if (nodeCount > 500 && zoom < 2.0 && degree < 3) return
+    if (nodeCount > 200 && zoom < 1.2 && degree < 2) return
+    if (nodeCount > 50 && zoom < 0.8) return
+    if (zoom < 0.4) return
+    if (nodeCount > 100 && degree < 2 && zoom < 1.5) return
+
+    const label = node.label || ''
+    if (!label) return
+
+    const fontSize = Math.max(10, Math.min(14, radius * 0.9))
+    context.font = `600 ${fontSize}px ${THEME.labelFont}`
+    context.textAlign = 'center'
+    context.textBaseline = 'middle'
+
+    const maxWidth = radius * 4
+    let { width: textWidth } = context.measureText(label)
+    textWidth = Math.min(textWidth, maxWidth)
+
+    const bgPadding = 3
+    const textY = node.y + radius + fontSize / 2 + 4
+    const rw = textWidth + 2 * bgPadding
+    const rh = fontSize + bgPadding
+
+    context.globalAlpha = 0.88
+    context.fillStyle = '#2A2C34'
+    roundRect(context, node.x - rw / 2, textY - rh / 2, rw, rh, rh / 2)
+    context.fill()
+    context.globalAlpha = 1
+
+    context.fillStyle = '#FFFFFF'
+    context.fillText(label, node.x, textY, maxWidth)
+  }
+
+  _drawAll = () => {
+    const context = this.canvasContext
+    if (!context) return
+
+    const { highlightPredicate } = this.props
+    this._isHovering = !!this.props.hoveredNode
+    this.frameCount++
+
+    context.save()
+    const { devicePixelRatio: dpr } = this
+    context.clearRect(0, 0, this.width * dpr, this.height * dpr)
+    context.translate(
+      this.state.transform.x * dpr,
+      this.state.transform.y * dpr,
+    )
+    context.scale(this.state.transform.k * dpr, this.state.transform.k * dpr)
+
+    this._viewport = this.getWorldViewport()
+
+    const zoom = this.state.transform.k * dpr
+    const isZoomedOut = zoom < 0.3
+    const nodeCount = this.document.nodes.size
+    const isLargeGraph = nodeCount > PERF.LARGE_GRAPH
+    const isHugeGraph = nodeCount > PERF.HUGE_GRAPH
+
+    // --- Hulls (throttled) ---
+    if (!isZoomedOut && !isHugeGraph) {
+      if (this.frameCount % PERF.HULL_INTERVAL === 0 || !this.cachedHulls) {
+        this.computeHulls()
+      }
+      this.drawHulls(context)
+    }
+
+    // --- Arc helpers (defined once, not per-edge) ---
+    const addArrow = (arc, target, vx, vy, nodeRadius) => {
+      const baseOffset = nodeRadius + ARROW_LENGTH
+      arc.arrowBase0 = target.x - vx * baseOffset
+      arc.arrowBase1 = target.y - vy * baseOffset
+      arc.arrowEnd0 = target.x - nodeRadius * vx
+      arc.arrowEnd1 = target.y - nodeRadius * vy
+      arc.arrowPt10 = arc.arrowBase0 + ARROW_WIDTH * vy
+      arc.arrowPt11 = arc.arrowBase1 - ARROW_WIDTH * vx
+      arc.arrowPt20 = arc.arrowBase0 - ARROW_WIDTH * vy
+      arc.arrowPt21 = arc.arrowBase1 + ARROW_WIDTH * vx
+      arc.hasArrow = true
+    }
+
+    const getArc = (edge) => {
+      const dx = edge.target.x - edge.source.x
+      const dy = edge.target.y - edge.source.y
+      const l = Math.sqrt(dx * dx + dy * dy)
+
+      const srcR = this.getNodeRadius(edge.source)
+      const tgtR = this.getNodeRadius(edge.target)
+
+      const arc = {
+        radius: -1,
+        distance: l,
+        centerX: edge.source.x + dx / 2,
+        centerY: edge.source.y + dy / 2,
+        hasArrow: false,
+      }
+
+      if (
+        !edge.siblingCount ||
+        edge.siblingCount < 2 ||
+        (edge.siblingCount % 2 && edge.siblingIndex === 0) ||
+        l < srcR + tgtR
+      ) {
+        if (l > srcR + tgtR + 2 * ARROW_LENGTH) {
+          addArrow(arc, edge.target, dx / l, dy / l, tgtR)
+        }
+        return arc
+      }
+
+      const LR = 4
+      let offset
+      if (edge.siblingCount % 2) {
+        offset = LR * (1 + Math.ceil(edge.siblingIndex / 2) * 2)
+      } else {
+        offset = LR * (1 + Math.floor(edge.siblingIndex / 2) * 2)
+      }
+      if (edge.siblingCount * LR > (0.9 * l) / 2) {
+        offset = (offset * 0.9 * l) / 2 / edge.siblingCount / LR
+      }
+
+      const norm0 = edge.siblingIndex % 2 ? dy / l : -dy / l
+      const norm1 = edge.siblingIndex % 2 ? -dx / l : dx / l
+      const R = (offset * offset + (l * l) / 4) / 2 / offset
+      const h2 = (R * offset) / (R - offset)
+
+      arc.radius = R
+      arc.centerX = edge.source.x + dx / 2 + norm0 * offset
+      arc.centerY = edge.source.y + dy / 2 + norm1 * offset
+      arc.controlX = edge.source.x + dx / 2 + norm0 * (offset + h2)
+      arc.controlY = edge.source.y + dy / 2 + norm1 * (offset + h2)
+
+      if (l > srcR + tgtR + 2 * ARROW_LENGTH) {
+        const rotateDir = edge.siblingIndex % 2 ? +1 : -1
+        const alpha = Math.asin(Math.min(1, l / 2 / R))
+        const theta = Math.asin(Math.min(1, tgtR / 2 / R))
+        const ra = rotateDir * (alpha - theta)
+        const cosA = Math.cos(ra),
+          sinA = Math.sin(ra)
+        const ndx = dx / l,
+          ndy = dy / l
+        addArrow(
+          arc,
+          edge.target,
+          ndx * cosA - ndy * sinA,
+          ndx * sinA + ndy * cosA,
+          tgtR,
+        )
+      }
+
+      return arc
+    }
+
+    // --- Edges ---
+    context.lineCap = 'round'
+    let edgesDrawn = 0
+    this.document.edges.forEach((edge) => {
+      // Hard cap on visible edges for huge graphs
+      if (isHugeGraph && edgesDrawn >= PERF.MAX_VISIBLE_EDGES) return
+
+      // Viewport culling
+      if (
+        !this.isInViewport(edge.source.x, edge.source.y, 100) &&
+        !this.isInViewport(edge.target.x, edge.target.y, 100)
+      )
+        return
+
+      edgesDrawn++
+      const arc = (edge.arc = getArc(edge))
+
+      const isHighlighted = edge.predicate === highlightPredicate
+      const isActive = edge === this.props.activeEdge
+      const inNeighborhood = this.isEdgeInNeighborhood(edge)
+
+      context.strokeStyle = edge.color
+      if (this._isHovering && !inNeighborhood) {
+        context.globalAlpha = THEME.edgeAlphaDimmed
+        context.lineWidth = 0.5
+      } else if (isActive) {
+        context.globalAlpha = THEME.edgeAlphaHighlight
+        context.lineWidth = THEME.edgeWidthActive
+      } else if (isHighlighted || (this._isHovering && inNeighborhood)) {
+        context.globalAlpha = THEME.edgeAlphaHighlight
+        context.lineWidth = THEME.edgeWidthHighlight
+      } else {
+        context.globalAlpha = THEME.edgeAlphaDefault
+        context.lineWidth = THEME.edgeWidthDefault
+      }
+
+      context.beginPath()
+      context.moveTo(edge.source.x, edge.source.y)
+      if (arc.radius <= 0) {
+        context.lineTo(edge.target.x, edge.target.y)
+      } else {
+        context.arcTo(
+          arc.controlX,
+          arc.controlY,
+          edge.target.x,
+          edge.target.y,
+          arc.radius,
+        )
+      }
+      context.stroke()
+
+      // Arrowhead — skip for huge graphs when zoomed out
+      if (arc.hasArrow && !(isHugeGraph && isZoomedOut)) {
+        context.fillStyle = edge.color
+        context.beginPath()
+        context.moveTo(arc.arrowEnd0, arc.arrowEnd1)
+        context.lineTo(arc.arrowPt10, arc.arrowPt11)
+        context.lineTo(arc.arrowPt20, arc.arrowPt21)
+        context.closePath()
+        context.fill()
+      }
+
+      context.globalAlpha = 1
+      if (!isLargeGraph && (!this._isHovering || inNeighborhood)) {
+        this.labelEdge(context, edge)
+      }
+    })
+
+    // --- Nodes ---
+    this.document.nodes.forEach((d) => {
+      if (!this.isInViewport(d.x, d.y, 50)) return
+
+      const cached = this.nodeRenderCache.get(d.id)
+      const radius = cached ? cached.radius : DEFAULT_NODE_RADIUS
+      const color = cached ? cached.color : '#848484'
+      const isActive = d === this.props.activeNode
+      const inNeighborhood = this.isInNeighborhood(d.id)
+      const dimmed = this._isHovering && !inNeighborhood
+
+      if (dimmed) context.globalAlpha = THEME.nodeDimmedAlpha
+
+      // LOD: dots at very low zoom
+      if (isZoomedOut) {
+        context.fillStyle = color
+        context.beginPath()
+        context.arc(d.x, d.y, Math.max(2, radius * 0.3), 0, 2 * Math.PI)
+        context.fill()
+        context.globalAlpha = 1
+        return
+      }
+
+      // Solid fill
+      context.fillStyle = color
+      context.beginPath()
+      context.arc(d.x, d.y, radius, 0, 2 * Math.PI, true)
+      context.fill()
+
+      // Border
+      context.strokeStyle = cached ? cached.colorDark : darkenColor(color, 0.25)
+      context.lineWidth = isActive
+        ? THEME.nodeBorderActive
+        : THEME.nodeBorderDefault
+      context.stroke()
+
+      // Active glow
+      if (isActive && !dimmed) {
+        context.strokeStyle = color
+        context.globalAlpha = 0.4
+        context.lineWidth = 4
+        context.beginPath()
+        context.arc(d.x, d.y, radius + 4, 0, 2 * Math.PI, true)
+        context.stroke()
+        context.globalAlpha = dimmed ? THEME.nodeDimmedAlpha : 1
+      }
+
+      // Search pulse
+      const pulse = this.pulsingNodes.get(d.id)
+      if (pulse && pulse > 0) {
+        context.strokeStyle = '#50A6FF'
+        context.globalAlpha = 0.6 * pulse
+        context.lineWidth = 8 * pulse
+        context.beginPath()
+        context.arc(d.x, d.y, radius + 10 * (1 - pulse), 0, 2 * Math.PI)
+        context.stroke()
+        context.globalAlpha = 1
+      }
+
+      // Expanded dot
+      if (d.expanded) {
+        context.fillStyle = '#ffffff'
+        context.beginPath()
+        context.arc(d.x + radius * 0.55, d.y - radius * 0.55, 3, 0, 2 * Math.PI)
+        context.fill()
+      }
+
+      context.globalAlpha = 1
+      if (!dimmed) this.labelNode(context, d)
+    })
+
+    context.restore()
+    this.drawMinimap()
+  }
+
+  startAnimationLoop = () => {
+    const animate = (timestamp) => {
+      const delta = timestamp - (this.lastFrameTime || timestamp)
+      this.lastFrameTime = timestamp
+
+      let hasPulse = false
+      this.pulsingNodes.forEach((val, key) => {
+        const newVal = val - delta * 0.002
+        if (newVal <= 0) this.pulsingNodes.delete(key)
+        else {
+          this.pulsingNodes.set(key, newVal)
+          hasPulse = true
+        }
+      })
+
+      if (hasPulse) this._drawAll()
+
+      this.animationFrameId = requestAnimationFrame(animate)
+    }
+    this.animationFrameId = requestAnimationFrame(animate)
+  }
+
+  drawGraph = debounce(this._drawAll, 5, { leading: true, trailing: true })
+
+  createForces = () => {
+    this.d3simulation
+      .alphaTarget(0)
+      .alphaMin(0.005)
+      .alphaDecay(0.05)
+      .velocityDecay(0.5)
+      .force(
+        'link',
+        d3
+          .forceLink()
+          .distance((d) => {
+            const srcDeg =
+              this.nodeDegrees.get(
+                typeof d.source === 'object' ? d.source.id : d.source,
+              ) || 1
+            const tgtDeg =
+              this.nodeDegrees.get(
+                typeof d.target === 'object' ? d.target.id : d.target,
+              ) || 1
+            const srcG = typeof d.source === 'object' ? d.source.group : null
+            const tgtG = typeof d.target === 'object' ? d.target.group : null
+            const cross = srcG && tgtG && srcG !== tgtG
+            return (cross ? 100 : 60) + Math.sqrt(srcDeg + tgtDeg) * 15
+          })
+          .strength((d) => {
+            const srcG = typeof d.source === 'object' ? d.source.group : null
+            const tgtG = typeof d.target === 'object' ? d.target.group : null
+            return srcG === tgtG ? 0.4 : 0.15
+          })
+          .id((d) => d.id),
+      )
+      .force(
+        'charge',
+        d3
+          .forceManyBody()
+          .strength((d) => {
+            const degree = this.nodeDegrees.get(d.id) || 0
+            return -200 - degree * 30
+          })
+          .distanceMax(500)
+          .theta(0.9),
+      )
+      .force(
+        'collision',
+        d3
+          .forceCollide()
+          .radius((d) => this.getNodeRadius(d) + 8)
+          .strength(0.8),
+      )
+      .force('cluster', forceCluster(0.35))
+      .force('fixedPosForce', fixedPosForce())
+
+    this.fixedPosForce = this.d3simulation.force('fixedPosForce')
+    this.edgesForce = this.d3simulation.force('link')
+  }
+
+  componentDidMount() {
+    this.d3simulation = d3.forceSimulation().on('tick', this.drawGraph)
+    this.createForces()
+
+    this.graphCanvas = d3
+      .select(this.outer.current)
+      .append('canvas')
+      .attr('width', this.width)
+      .attr('height', this.height)
+      .node()
+
+    this.minimapCanvas = document.createElement('canvas')
+    this.minimapCanvas.className = 'graph-minimap'
+    this.minimapCanvas.width = 180
+    this.minimapCanvas.height = 120
+    this.outer.current.appendChild(this.minimapCanvas)
+    this.minimapContext = this.minimapCanvas.getContext('2d')
+    this.minimapCanvas.addEventListener('click', this.onMinimapClick)
+
+    this.zoomBehavior = d3
+      .zoom()
+      .scaleExtent([(1 / 8) * this.devicePixelRatio, 6 * this.devicePixelRatio])
+      .on('zoom', this.onZoom)
+
+    d3.select(this.graphCanvas)
+      .on('click', this.onClick)
+      .on('dblclick', this.onDoubleClick)
+      .on('mousemove', this.onMouseMove)
+      .call(
+        d3
+          .drag()
+          .subject(this.dragsubject)
+          .on('start', this.dragstarted)
+          .on('drag', this.dragged),
+      )
+      .call(this.zoomBehavior)
+
+    this.onResize()
+    this.updateDocument(this.props.nodes, this.props.edges)
+    this.startAnimationLoop()
+    this.resizeObserver = window.setInterval(this.onResize, 1000)
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.resizeObserver)
+    if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId)
+    if (this.minimapCanvas)
+      this.minimapCanvas.removeEventListener('click', this.onMinimapClick)
+  }
+
+  onMinimapClick = (e) => {
+    if (!this.document.nodes.size) return
+    const rect = this.minimapCanvas.getBoundingClientRect()
+    const px = e.clientX - rect.left,
+      py = e.clientY - rect.top
+    const mmw = this.minimapCanvas.width,
+      mmh = this.minimapCanvas.height
+
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity
+    this.document.nodes.forEach((n) => {
+      if (n.x < minX) minX = n.x
+      if (n.y < minY) minY = n.y
+      if (n.x > maxX) maxX = n.x
+      if (n.y > maxY) maxY = n.y
+    })
+
+    const pad = 10,
+      gw = maxX - minX || 1,
+      gh = maxY - minY || 1
+    const s = Math.min((mmw - pad * 2) / gw, (mmh - pad * 2) / gh)
+    const ox = (mmw - s * gw) / 2,
+      oy = (mmh - s * gh) / 2
+    const wx = (px - ox + minX * s) / s,
+      wy = (py - oy + minY * s) / s
+
+    const k = this.state.transform.k
+    d3.select(this.graphCanvas)
+      .transition()
+      .duration(300)
+      .call(
+        this.zoomBehavior.transform,
+        d3.zoomIdentity
+          .translate(this.width / 2 - wx * k, this.height / 2 - wy * k)
+          .scale(k),
+      )
+  }
+
+  getD3EventCoords = (event) => this.state.transform.invert([event.x, event.y])
+
+  findNodeAtPos = (x, y) => {
+    let minNode,
+      minD = 1e10
+    this.document.nodes.forEach((n) => {
+      const r = this.getNodeRadius(n)
+      const d = (n.x - x) * (n.x - x) + (n.y - y) * (n.y - y)
+      if (d < r * r && d < minD) {
+        minNode = n
+        minD = d
+      }
+    })
+    return minNode
+  }
+
+  findEdgeAtPos = (x, y) => {
+    let minEdge,
+      minD = 1e10
+    this.document.edges.forEach((edge) => {
+      if (!edge.arc) return
+      const { centerX: cx, centerY: cy } = edge.arc
+      const d = (cx - x) * (cx - x) + (cy - y) * (cy - y)
+      if (d < minD) {
+        minEdge = edge
+        minD = d
+      }
+    })
+    return minD > 225 ? undefined : minEdge
+  }
+
+  onMouseMove = () => {
+    const { offsetX: x, offsetY: y } = currentEvent
+    const pt = this.getD3EventCoords({ x, y })
+    const node = this.findNodeAtPos(...pt)
+    this.props.onNodeHovered(node)
+    if (this.graphCanvas)
+      this.graphCanvas.style.cursor = node ? 'pointer' : 'default'
+    if (!node) this.props.onEdgeHovered(this.findEdgeAtPos(...pt))
+    this.drawGraph()
+  }
+
+  onClick = () => {
+    const { offsetX: x, offsetY: y } = currentEvent
+    const pt = this.getD3EventCoords({ x, y })
+    const node = this.findNodeAtPos(...pt)
+    if (node) {
+      currentEvent.stopImmediatePropagation()
+      return this.props.onNodeSelected(node)
+    }
+    const edge = this.findEdgeAtPos(...pt)
+    if (edge) {
+      currentEvent.stopImmediatePropagation()
+      return this.props.onEdgeSelected(edge)
+    }
+  }
+
+  onDoubleClick = () => {
+    const { offsetX: x, offsetY: y } = currentEvent
+    const pt = this.getD3EventCoords({ x, y })
+    const node = this.findNodeAtPos(...pt)
+    if (node) {
+      currentEvent.stopImmediatePropagation()
+      return this.props.onNodeDoubleClicked(node)
+    }
+  }
+
+  dragsubject = () => {
+    const { offsetX: x, offsetY: y } = currentEvent.sourceEvent
+    const pt = this.getD3EventCoords({ x, y })
+    const node = this.findNodeAtPos(...pt)
+    this.props.onNodeSelected(node)
+    return node
+  }
+
+  dragstarted = () => {
+    if (!currentEvent.active)
+      setTimeout(() => this.d3simulation.alpha(0.5).restart(), DOUBLE_CLICK_MS)
+  }
+
+  dragged = () => {
+    const { offsetX: x, offsetY: y } = currentEvent.sourceEvent
+    const pt = this.getD3EventCoords({ x, y })
+    this.fixedPosForce.setNodeCoords(currentEvent.subject, ...pt)
+    this.drawGraph()
+    this.d3simulation.alpha(Math.max(0.12, this.d3simulation.alpha()))
+  }
+
+  _updateZoom = (transform) => {
+    if (this.state.transform.toString() !== transform.toString())
+      this.setState({ transform })
+  }
+  updateZoom = debounce(this._updateZoom, 2, { leading: true, trailing: true })
+  onZoom = () => this.updateZoom(currentEvent.transform)
+
+  zoomToFit = () => {
+    if (!this.graphCanvas || !this.document.nodes.size) return
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity
+    this.document.nodes.forEach((n) => {
+      const r = this.getNodeRadius(n) + 20
+      if (n.x - r < minX) minX = n.x - r
+      if (n.y - r < minY) minY = n.y - r
+      if (n.x + r > maxX) maxX = n.x + r
+      if (n.y + r > maxY) maxY = n.y + r
+    })
+    const p = 40,
+      gw = maxX - minX + p * 2,
+      gh = maxY - minY + p * 2
+    const scale = Math.min(this.width / gw, this.height / gh, 2) * 0.9
+    const transform = d3.zoomIdentity
+      .translate(this.width / 2, this.height / 2)
+      .scale(scale)
+      .translate(-(minX + maxX) / 2, -(minY + maxY) / 2)
+    d3.select(this.graphCanvas)
+      .transition()
+      .duration(500)
+      .call(this.zoomBehavior.transform, transform)
+  }
+
+  focusNode = (node) => {
+    if (!this.graphCanvas || !node) return
+    const k = 2.2
+    d3.select(this.graphCanvas)
+      .transition()
+      .duration(500)
+      .ease(d3.easeCubicOut)
+      .call(
+        this.zoomBehavior.transform,
+        d3.zoomIdentity
+          .translate(this.width / 2 - node.x * k, this.height / 2 - node.y * k)
+          .scale(k),
+      )
+    this.pulsingNodes.set(node.id, 1.0)
+  }
+
+  searchNode = (query) => {
+    if (!query) return null
+    const q = query.toLowerCase().trim()
+    let found = null
+    this.document.nodes.forEach((n) => {
+      if (found) return
+      const name = (n.name || n.label || '').toLowerCase()
+      const uid = (n.uid || n.id || '').toLowerCase()
+      if (name.includes(q) || uid === q) found = n
+    })
+    return found
+  }
+
+  onResize = () => {
+    let resized = false
+    if (this.outer.current) {
+      const el = this.outer.current
+      resized |= this.width !== el.offsetWidth
+      resized |= this.height !== el.offsetHeight
+      this.width = el.offsetWidth
+      this.height = el.offsetHeight
+    }
+    if (!resized) return
+
+    this.zoomBehavior.scaleTo(d3.select(this.graphCanvas), 1)
+    this.zoomBehavior.translateTo(d3.select(this.graphCanvas), 0, 0)
+
+    const { width, height } = this
+    this.d3simulation
+      .force('x', d3.forceX(0).strength((0.02 * height) / width))
+      .force('y', d3.forceY(0).strength((0.02 * width) / height))
+
+    d3.select(this.graphCanvas)
+      .attr('width', this.width * this.devicePixelRatio)
+      .attr('height', this.height * this.devicePixelRatio)
+
+    this.canvasContext = this.graphCanvas.getContext('2d')
+    this._drawAll()
+  }
+
+  updateDocument = (nodes, edges) => {
+    if (!this.d3simulation || !nodes || !edges) return
+
+    const newNodesReceived =
+      this.document.nodesLength !== nodes.size ||
+      this.document.edgesLength !== edges.size
+
+    this.document = {
+      edges,
+      edgesLength: edges.size,
+      nodes,
+      nodesLength: nodes.size,
+    }
+    this.computeNodeDegrees()
+
+    if (newNodesReceived) {
+      this.d3simulation
+        .force(
+          'link',
+          d3
+            .forceLink()
+            .distance((d) => {
+              const srcDeg =
+                this.nodeDegrees.get(
+                  typeof d.source === 'object' ? d.source.id : d.source,
+                ) || 1
+              const tgtDeg =
+                this.nodeDegrees.get(
+                  typeof d.target === 'object' ? d.target.id : d.target,
+                ) || 1
+              const srcG = typeof d.source === 'object' ? d.source.group : null
+              const tgtG = typeof d.target === 'object' ? d.target.group : null
+              return (
+                (srcG && tgtG && srcG !== tgtG ? 100 : 60) +
+                Math.sqrt(srcDeg + tgtDeg) * 15
+              )
+            })
+            .strength((d) => {
+              const srcG = typeof d.source === 'object' ? d.source.group : null
+              const tgtG = typeof d.target === 'object' ? d.target.group : null
+              return srcG === tgtG ? 0.4 : 0.15
+            })
+            .id((d) => d.id),
+        )
+        .force(
+          'charge',
+          d3
+            .forceManyBody()
+            .strength((d) => -200 - (this.nodeDegrees.get(d.id) || 0) * 30)
+            .distanceMax(500)
+            .theta(0.9),
+        )
+        .force(
+          'collision',
+          d3
+            .forceCollide()
+            .radius((d) => this.getNodeRadius(d) + 8)
+            .strength(0.8),
+        )
+        .force('cluster', forceCluster(0.35))
+
+      this.edgesForce = this.d3simulation.force('link')
+      this.d3simulation.alpha(0.5).restart()
+    }
+
+    this.d3simulation.nodes(Array.from(nodes.values()))
+    this.edgesForce.links(Array.from(edges.values()))
+  }
+
+  render() {
+    this.updateDocument(this.props.nodes, this.props.edges)
+    this.onResize()
+    this.drawGraph()
+    return <div ref={this.outer} className='graph-outer' />
+  }
 }

--- a/client/src/components/GraphContainer.js
+++ b/client/src/components/GraphContainer.js
@@ -35,6 +35,11 @@ export default ({
   const [hoveredEdge, setHoveredEdge] = React.useState(null)
   const [selectedEdge, setSelectedEdge] = React.useState(null)
 
+  const [searchQuery, setSearchQuery] = React.useState('')
+  const [searchFocused, setSearchFocused] = React.useState(false)
+
+  const graphRef = React.useRef(null)
+
   const onEdgeSelected = (edge) => {
     setSelectedNode(null)
     setSelectedEdge(edge)
@@ -46,6 +51,19 @@ export default ({
 
   const activeNode = hoveredNode || selectedNode
   const activeEdge = !hoveredNode ? hoveredEdge || selectedEdge : null
+
+  const handleSearch = (e) => {
+    if (e.key !== 'Enter' || !graphRef.current) return
+    const node = graphRef.current.searchNode(searchQuery)
+    if (node) {
+      graphRef.current.focusNode(node)
+      onNodeSelected(node)
+    }
+  }
+
+  const handleZoomToFit = () => {
+    if (graphRef.current) graphRef.current.zoomToFit()
+  }
 
   const nodeProps = () => (
     <NodeProperties
@@ -64,18 +82,10 @@ export default ({
   )
 
   const renderPanelContent = () => {
-    if (hoveredNode) {
-      return nodeProps()
-    }
-    if (hoveredEdge) {
-      return edgeProps()
-    }
-    if (selectedNode) {
-      return nodeProps()
-    }
-    if (selectedEdge) {
-      return edgeProps()
-    }
+    if (hoveredNode) return nodeProps()
+    if (hoveredEdge) return edgeProps()
+    if (selectedNode) return nodeProps()
+    if (selectedEdge) return edgeProps()
     return null
   }
 
@@ -84,6 +94,7 @@ export default ({
   return (
     <div className='graph-container'>
       <D3Graph
+        ref={graphRef}
         edges={edgesDataset}
         highlightPredicate={highlightPredicate}
         nodes={nodesDataset}
@@ -97,7 +108,42 @@ export default ({
         onNodeSelected={onNodeSelected}
         activeNode={activeNode}
         activeEdge={activeEdge}
+        hoveredNode={hoveredNode}
       />
+
+      {/* Graph toolbar: search + controls */}
+      <div className='graph-toolbar'>
+        <div className={`graph-search ${searchFocused ? 'focused' : ''}`}>
+          <svg width='14' height='14' viewBox='0 0 16 16' fill='currentColor' className='search-icon'>
+            <path d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z'/>
+          </svg>
+          <input
+            type='text'
+            placeholder='Search nodes...'
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={handleSearch}
+            onFocus={() => setSearchFocused(true)}
+            onBlur={() => setSearchFocused(false)}
+          />
+        </div>
+        <button
+          className='graph-control-btn'
+          onClick={handleZoomToFit}
+          title='Fit to screen'
+        >
+          <svg width='16' height='16' viewBox='0 0 16 16' fill='currentColor'>
+            <path d='M1 1h5v1.5H2.5V5H1V1zm9 0h5v4h-1.5V2.5H10V1zM1 11h1.5v2.5H5V15H1v-4zm12.5 2.5V11H15v4h-4v-1.5h2.5z'/>
+          </svg>
+        </button>
+      </div>
+
+      {/* Node/edge count indicator */}
+      <div className='graph-stats'>
+        {nodesDataset.size} nodes &middot; {edgesDataset.size} edges
+        {remainingNodes > 0 && ` · ${remainingNodes} hidden`}
+      </div>
+
       {!remainingNodes ? null : (
         <PartialRenderInfo
           remainingNodes={remainingNodes}

--- a/client/src/components/GraphContainer.js
+++ b/client/src/components/GraphContainer.js
@@ -3,175 +3,181 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react'
+import React from "react";
 
-import EdgeProperties from 'components/EdgeProperties'
-import NodeProperties from 'components/NodeProperties'
-import PartialRenderInfo from 'components/PartialRenderInfo'
+import EdgeProperties from "components/EdgeProperties";
+import NodeProperties from "components/NodeProperties";
+import PartialRenderInfo from "components/PartialRenderInfo";
 
-import D3Graph from 'components/D3Graph'
-import MovablePanel from 'components/MovablePanel'
+import D3Graph from "components/D3Graph";
+import MovablePanel from "components/MovablePanel";
 
-import '../assets/css/Graph.scss'
+import "../assets/css/Graph.scss";
 
 export default ({
-  graphUpdateHack,
-  edgesDataset,
-  highlightPredicate,
-  nodesDataset,
-  onCollapseNode,
-  onExpandNode,
-  onSetPanelMinimized,
-  onShowMoreNodes,
-  onPanelResize,
-  panelMinimized,
-  panelHeight,
-  panelWidth,
-  remainingNodes,
+	graphUpdateHack,
+	edgesDataset,
+	highlightPredicate,
+	nodesDataset,
+	onCollapseNode,
+	onExpandNode,
+	onSetPanelMinimized,
+	onShowMoreNodes,
+	onPanelResize,
+	panelMinimized,
+	panelHeight,
+	panelWidth,
+	remainingNodes,
 }) => {
-  const [selectedNode, setSelectedNode] = React.useState(null)
-  const [hoveredNode, setHoveredNode] = React.useState(null)
+	const [selectedNode, setSelectedNode] = React.useState(null);
+	const [hoveredNode, setHoveredNode] = React.useState(null);
 
-  const [hoveredEdge, setHoveredEdge] = React.useState(null)
-  const [selectedEdge, setSelectedEdge] = React.useState(null)
+	const [hoveredEdge, setHoveredEdge] = React.useState(null);
+	const [selectedEdge, setSelectedEdge] = React.useState(null);
 
-  const [searchQuery, setSearchQuery] = React.useState('')
-  const [searchFocused, setSearchFocused] = React.useState(false)
+	const [searchQuery, setSearchQuery] = React.useState("");
+	const [searchFocused, setSearchFocused] = React.useState(false);
 
-  const graphRef = React.useRef(null)
+	const graphRef = React.useRef(null);
 
-  const onEdgeSelected = (edge) => {
-    setSelectedNode(null)
-    setSelectedEdge(edge)
-  }
-  const onNodeSelected = (node) => {
-    setSelectedEdge(null)
-    setSelectedNode(node)
-  }
+	const onEdgeSelected = (edge) => {
+		setSelectedNode(null);
+		setSelectedEdge(edge);
+	};
+	const onNodeSelected = (node) => {
+		setSelectedEdge(null);
+		setSelectedNode(node);
+	};
 
-  const activeNode = hoveredNode || selectedNode
-  const activeEdge = !hoveredNode ? hoveredEdge || selectedEdge : null
+	const activeNode = hoveredNode || selectedNode;
+	const activeEdge = !hoveredNode ? hoveredEdge || selectedEdge : null;
 
-  const handleSearch = (e) => {
-    if (e.key !== 'Enter' || !graphRef.current) return
-    const node = graphRef.current.searchNode(searchQuery)
-    if (node) {
-      graphRef.current.focusNode(node)
-      onNodeSelected(node)
-    }
-  }
+	const handleSearch = (e) => {
+		if (e.key !== "Enter" || !graphRef.current) return;
+		const node = graphRef.current.searchNode(searchQuery);
+		if (node) {
+			graphRef.current.focusNode(node);
+			onNodeSelected(node);
+		}
+	};
 
-  const handleZoomToFit = () => {
-    if (graphRef.current) graphRef.current.zoomToFit()
-  }
+	const handleZoomToFit = () => {
+		if (graphRef.current) graphRef.current.zoomToFit();
+	};
 
-  const nodeProps = () => (
-    <NodeProperties
-      node={activeNode}
-      onCollapseNode={onCollapseNode}
-      onExpandNode={onExpandNode}
-    />
-  )
+	const nodeProps = () => (
+		<NodeProperties
+			node={activeNode}
+			onCollapseNode={onCollapseNode}
+			onExpandNode={onExpandNode}
+		/>
+	);
 
-  const edgeProps = () => (
-    <EdgeProperties
-      edge={activeEdge}
-      onSelectSource={() => onNodeSelected(activeEdge.source)}
-      onSelectTarget={() => onNodeSelected(activeEdge.target)}
-    />
-  )
+	const edgeProps = () => (
+		<EdgeProperties
+			edge={activeEdge}
+			onSelectSource={() => onNodeSelected(activeEdge.source)}
+			onSelectTarget={() => onNodeSelected(activeEdge.target)}
+		/>
+	);
 
-  const renderPanelContent = () => {
-    if (hoveredNode) return nodeProps()
-    if (hoveredEdge) return edgeProps()
-    if (selectedNode) return nodeProps()
-    if (selectedEdge) return edgeProps()
-    return null
-  }
+	const renderPanelContent = () => {
+		if (hoveredNode) return nodeProps();
+		if (hoveredEdge) return edgeProps();
+		if (selectedNode) return nodeProps();
+		if (selectedEdge) return edgeProps();
+		return null;
+	};
 
-  const panelContent = renderPanelContent()
+	const panelContent = renderPanelContent();
 
-  return (
-    <div className='graph-container'>
-      <D3Graph
-        ref={graphRef}
-        edges={edgesDataset}
-        highlightPredicate={highlightPredicate}
-        nodes={nodesDataset}
-        graphUpdateHack={graphUpdateHack}
-        onEdgeHovered={setHoveredEdge}
-        onEdgeSelected={onEdgeSelected}
-        onNodeDoubleClicked={(node) =>
-          !node.expanded ? onExpandNode(node.uid) : onCollapseNode(node.uid)
-        }
-        onNodeHovered={setHoveredNode}
-        onNodeSelected={onNodeSelected}
-        activeNode={activeNode}
-        activeEdge={activeEdge}
-        hoveredNode={hoveredNode}
-      />
+	return (
+		<div className="graph-container">
+			<D3Graph
+				ref={graphRef}
+				edges={edgesDataset}
+				highlightPredicate={highlightPredicate}
+				nodes={nodesDataset}
+				graphUpdateHack={graphUpdateHack}
+				onEdgeHovered={setHoveredEdge}
+				onEdgeSelected={onEdgeSelected}
+				onNodeDoubleClicked={(node) =>
+					!node.expanded ? onExpandNode(node.uid) : onCollapseNode(node.uid)
+				}
+				onNodeHovered={setHoveredNode}
+				onNodeSelected={onNodeSelected}
+				activeNode={activeNode}
+				activeEdge={activeEdge}
+				hoveredNode={hoveredNode}
+			/>
 
-      {/* Graph toolbar: search + controls */}
-      <div className='graph-toolbar'>
-        <div className={`graph-search ${searchFocused ? 'focused' : ''}`}>
-          <svg width='14' height='14' viewBox='0 0 16 16' fill='currentColor' className='search-icon'>
-            <path d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z'/>
-          </svg>
-          <input
-            type='text'
-            placeholder='Search nodes...'
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            onKeyDown={handleSearch}
-            onFocus={() => setSearchFocused(true)}
-            onBlur={() => setSearchFocused(false)}
-          />
-        </div>
-        <button
-          className='graph-control-btn'
-          onClick={handleZoomToFit}
-          title='Fit to screen'
-        >
-          <svg width='16' height='16' viewBox='0 0 16 16' fill='currentColor'>
-            <path d='M1 1h5v1.5H2.5V5H1V1zm9 0h5v4h-1.5V2.5H10V1zM1 11h1.5v2.5H5V15H1v-4zm12.5 2.5V11H15v4h-4v-1.5h2.5z'/>
-          </svg>
-        </button>
-      </div>
+			{/* Graph toolbar: search + controls */}
+			<div className="graph-toolbar">
+				<div className={`graph-search ${searchFocused ? "focused" : ""}`}>
+					<svg
+						width="14"
+						height="14"
+						viewBox="0 0 16 16"
+						fill="currentColor"
+						className="search-icon"
+					>
+						<path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z" />
+					</svg>
+					<input
+						type="text"
+						placeholder="Search nodes..."
+						value={searchQuery}
+						onChange={(e) => setSearchQuery(e.target.value)}
+						onKeyDown={handleSearch}
+						onFocus={() => setSearchFocused(true)}
+						onBlur={() => setSearchFocused(false)}
+					/>
+				</div>
+				<button
+					className="graph-control-btn"
+					onClick={handleZoomToFit}
+					title="Fit to screen"
+				>
+					<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+						<path d="M1 1h5v1.5H2.5V5H1V1zm9 0h5v4h-1.5V2.5H10V1zM1 11h1.5v2.5H5V15H1v-4zm12.5 2.5V11H15v4h-4v-1.5h2.5z" />
+					</svg>
+				</button>
+			</div>
 
-      {/* Node/edge count indicator */}
-      <div className='graph-stats'>
-        {nodesDataset.size} nodes &middot; {edgesDataset.size} edges
-        {remainingNodes > 0 && ` · ${remainingNodes} hidden`}
-      </div>
+			{/* Node/edge count indicator */}
+			<div className="graph-stats">
+				{nodesDataset.size} nodes &middot; {edgesDataset.size} edges
+				{remainingNodes > 0 && ` · ${remainingNodes} hidden`}
+			</div>
 
-      {!remainingNodes ? null : (
-        <PartialRenderInfo
-          remainingNodes={remainingNodes}
-          onShowMoreNodes={onShowMoreNodes}
-        />
-      )}
-      <MovablePanel
-        boundingSelector='.graph-container'
-        collapsed={!selectedNode && !selectedEdge}
-        minimized={panelMinimized}
-        title={
-          panelContent
-            ? null
-            : remainingNodes > 0
-              ? `Showing ${
-                  nodesDataset.size + remainingNodes
-                } nodes (${remainingNodes} hidden) and ${
-                  edgesDataset.size
-                } edges`
-              : `Showing ${nodesDataset.size} nodes and ${edgesDataset.size} edges`
-        }
-        height={panelHeight}
-        width={panelWidth}
-        onSetPanelMinimized={onSetPanelMinimized}
-        onResize={onPanelResize}
-      >
-        {renderPanelContent()}
-      </MovablePanel>
-    </div>
-  )
-}
+			{!remainingNodes ? null : (
+				<PartialRenderInfo
+					remainingNodes={remainingNodes}
+					onShowMoreNodes={onShowMoreNodes}
+				/>
+			)}
+			<MovablePanel
+				boundingSelector=".graph-container"
+				collapsed={!selectedNode && !selectedEdge}
+				minimized={panelMinimized}
+				title={
+					panelContent
+						? null
+						: remainingNodes > 0
+							? `Showing ${
+									nodesDataset.size + remainingNodes
+								} nodes (${remainingNodes} hidden) and ${
+									edgesDataset.size
+								} edges`
+							: `Showing ${nodesDataset.size} nodes and ${edgesDataset.size} edges`
+				}
+				height={panelHeight}
+				width={panelWidth}
+				onSetPanelMinimized={onSetPanelMinimized}
+				onResize={onPanelResize}
+			>
+				{renderPanelContent()}
+			</MovablePanel>
+		</div>
+	);
+};

--- a/client/src/components/GraphContainer.js
+++ b/client/src/components/GraphContainer.js
@@ -3,173 +3,171 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from "react";
+import React from 'react'
 
-import EdgeProperties from "components/EdgeProperties";
-import NodeProperties from "components/NodeProperties";
-import PartialRenderInfo from "components/PartialRenderInfo";
+import EdgeProperties from 'components/EdgeProperties'
+import NodeProperties from 'components/NodeProperties'
+import PartialRenderInfo from 'components/PartialRenderInfo'
 
-import D3Graph from "components/D3Graph";
-import MovablePanel from "components/MovablePanel";
+import D3Graph from 'components/D3Graph'
+import MovablePanel from 'components/MovablePanel'
 
-import "../assets/css/Graph.scss";
+import '../assets/css/Graph.scss'
 
 export default ({
-	graphUpdateHack,
-	edgesDataset,
-	highlightPredicate,
-	nodesDataset,
-	onCollapseNode,
-	onExpandNode,
-	onSetPanelMinimized,
-	onShowMoreNodes,
-	onPanelResize,
-	panelMinimized,
-	panelHeight,
-	panelWidth,
-	remainingNodes,
+  graphUpdateHack,
+  edgesDataset,
+  highlightPredicate,
+  nodesDataset,
+  onCollapseNode,
+  onExpandNode,
+  onSetPanelMinimized,
+  onShowMoreNodes,
+  onPanelResize,
+  panelMinimized,
+  panelHeight,
+  panelWidth,
+  remainingNodes,
 }) => {
-	const [selectedNode, setSelectedNode] = React.useState(null);
-	const [hoveredNode, setHoveredNode] = React.useState(null);
+  const [selectedNode, setSelectedNode] = React.useState(null)
+  const [hoveredNode, setHoveredNode] = React.useState(null)
 
-	const [hoveredEdge, setHoveredEdge] = React.useState(null);
-	const [selectedEdge, setSelectedEdge] = React.useState(null);
+  const [hoveredEdge, setHoveredEdge] = React.useState(null)
+  const [selectedEdge, setSelectedEdge] = React.useState(null)
 
-	const [searchQuery, setSearchQuery] = React.useState("");
-	const [searchFocused, setSearchFocused] = React.useState(false);
+  const [searchQuery, setSearchQuery] = React.useState('')
+  const [searchFocused, setSearchFocused] = React.useState(false)
 
-	const graphRef = React.useRef(null);
+  const graphRef = React.useRef(null)
 
-	const onEdgeSelected = (edge) => {
-		setSelectedNode(null);
-		setSelectedEdge(edge);
-	};
-	const onNodeSelected = (node) => {
-		setSelectedEdge(null);
-		setSelectedNode(node);
-	};
+  const onEdgeSelected = (edge) => {
+    setSelectedNode(null)
+    setSelectedEdge(edge)
+  }
+  const onNodeSelected = (node) => {
+    setSelectedEdge(null)
+    setSelectedNode(node)
+  }
 
-	const activeNode = hoveredNode || selectedNode;
-	const activeEdge = !hoveredNode ? hoveredEdge || selectedEdge : null;
+  const activeNode = hoveredNode || selectedNode
+  const activeEdge = !hoveredNode ? hoveredEdge || selectedEdge : null
 
-	const handleSearch = (e) => {
-		if (e.key !== "Enter" || !graphRef.current) return;
-		const node = graphRef.current.searchNode(searchQuery);
-		if (node) {
-			graphRef.current.focusNode(node);
-			onNodeSelected(node);
-		}
-	};
+  const handleSearch = (e) => {
+    if (e.key !== 'Enter' || !graphRef.current) return
+    const node = graphRef.current.searchNode(searchQuery)
+    if (node) {
+      graphRef.current.focusNode(node)
+      onNodeSelected(node)
+    }
+  }
 
-	const handleZoomToFit = () => {
-		if (graphRef.current) graphRef.current.zoomToFit();
-	};
+  const handleZoomToFit = () => {
+    if (graphRef.current) graphRef.current.zoomToFit()
+  }
 
-	const nodeProps = () => (
-		<NodeProperties
-			node={activeNode}
-			onCollapseNode={onCollapseNode}
-			onExpandNode={onExpandNode}
-		/>
-	);
+  const nodeProps = () => (
+    <NodeProperties
+      node={activeNode}
+      onCollapseNode={onCollapseNode}
+      onExpandNode={onExpandNode}
+    />
+  )
 
-	const edgeProps = () => (
-		<EdgeProperties
-			edge={activeEdge}
-			onSelectSource={() => onNodeSelected(activeEdge.source)}
-			onSelectTarget={() => onNodeSelected(activeEdge.target)}
-		/>
-	);
+  const edgeProps = () => (
+    <EdgeProperties
+      edge={activeEdge}
+      onSelectSource={() => onNodeSelected(activeEdge.source)}
+      onSelectTarget={() => onNodeSelected(activeEdge.target)}
+    />
+  )
 
-	const renderPanelContent = () => {
-		if (hoveredNode) return nodeProps();
-		if (hoveredEdge) return edgeProps();
-		if (selectedNode) return nodeProps();
-		if (selectedEdge) return edgeProps();
-		return null;
-	};
+  const renderPanelContent = () => {
+    if (hoveredNode) return nodeProps()
+    if (hoveredEdge) return edgeProps()
+    if (selectedNode) return nodeProps()
+    if (selectedEdge) return edgeProps()
+    return null
+  }
 
-	const panelContent = renderPanelContent();
+  return (
+    <div className='graph-container'>
+      <D3Graph
+        ref={graphRef}
+        edges={edgesDataset}
+        highlightPredicate={highlightPredicate}
+        nodes={nodesDataset}
+        graphUpdateHack={graphUpdateHack}
+        onEdgeHovered={setHoveredEdge}
+        onEdgeSelected={onEdgeSelected}
+        onNodeDoubleClicked={(node) =>
+          !node.expanded ? onExpandNode(node.uid) : onCollapseNode(node.uid)
+        }
+        onNodeHovered={setHoveredNode}
+        onNodeSelected={onNodeSelected}
+        activeNode={activeNode}
+        activeEdge={activeEdge}
+        hoveredNode={hoveredNode}
+      />
 
-	return (
-		<div className="graph-container">
-			<D3Graph
-				ref={graphRef}
-				edges={edgesDataset}
-				highlightPredicate={highlightPredicate}
-				nodes={nodesDataset}
-				graphUpdateHack={graphUpdateHack}
-				onEdgeHovered={setHoveredEdge}
-				onEdgeSelected={onEdgeSelected}
-				onNodeDoubleClicked={(node) =>
-					!node.expanded ? onExpandNode(node.uid) : onCollapseNode(node.uid)
-				}
-				onNodeHovered={setHoveredNode}
-				onNodeSelected={onNodeSelected}
-				activeNode={activeNode}
-				activeEdge={activeEdge}
-				hoveredNode={hoveredNode}
-			/>
+      {/* Graph toolbar: search + controls */}
+      <div className='graph-toolbar'>
+        <div className={`graph-search ${searchFocused ? 'focused' : ''}`}>
+          <svg
+            width='14'
+            height='14'
+            viewBox='0 0 16 16'
+            fill='currentColor'
+            className='search-icon'
+          >
+            <path d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z' />
+          </svg>
+          <input
+            type='text'
+            placeholder='Search nodes...'
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={handleSearch}
+            onFocus={() => setSearchFocused(true)}
+            onBlur={() => setSearchFocused(false)}
+          />
+        </div>
+        <button
+          className='graph-control-btn'
+          onClick={handleZoomToFit}
+          title='Fit to screen'
+        >
+          <svg width='16' height='16' viewBox='0 0 16 16' fill='currentColor'>
+            <path d='M1 1h5v1.5H2.5V5H1V1zm9 0h5v4h-1.5V2.5H10V1zM1 11h1.5v2.5H5V15H1v-4zm12.5 2.5V11H15v4h-4v-1.5h2.5z' />
+          </svg>
+        </button>
+      </div>
 
-			{/* Graph toolbar: search + controls */}
-			<div className="graph-toolbar">
-				<div className={`graph-search ${searchFocused ? "focused" : ""}`}>
-					<svg
-						width="14"
-						height="14"
-						viewBox="0 0 16 16"
-						fill="currentColor"
-						className="search-icon"
-					>
-						<path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z" />
-					</svg>
-					<input
-						type="text"
-						placeholder="Search nodes..."
-						value={searchQuery}
-						onChange={(e) => setSearchQuery(e.target.value)}
-						onKeyDown={handleSearch}
-						onFocus={() => setSearchFocused(true)}
-						onBlur={() => setSearchFocused(false)}
-					/>
-				</div>
-				<button
-					className="graph-control-btn"
-					onClick={handleZoomToFit}
-					title="Fit to screen"
-				>
-					<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-						<path d="M1 1h5v1.5H2.5V5H1V1zm9 0h5v4h-1.5V2.5H10V1zM1 11h1.5v2.5H5V15H1v-4zm12.5 2.5V11H15v4h-4v-1.5h2.5z" />
-					</svg>
-				</button>
-			</div>
+      {/* Node/edge count indicator */}
+      <div className='graph-stats'>
+        {nodesDataset.size} nodes &middot; {edgesDataset.size} edges
+        {remainingNodes > 0 && ` · ${remainingNodes} hidden`}
+      </div>
 
-			{/* Node/edge count indicator */}
-			<div className="graph-stats">
-				{nodesDataset.size} nodes &middot; {edgesDataset.size} edges
-				{remainingNodes > 0 && ` · ${remainingNodes} hidden`}
-			</div>
-
-			{!remainingNodes ? null : (
-				<PartialRenderInfo
-					remainingNodes={remainingNodes}
-					onShowMoreNodes={onShowMoreNodes}
-				/>
-			)}
-			{(selectedNode || selectedEdge) && (
-				<MovablePanel
-					boundingSelector=".graph-container"
-					collapsed={false}
-					minimized={panelMinimized}
-					title={null}
-					height={panelHeight}
-					width={panelWidth}
-					onSetPanelMinimized={onSetPanelMinimized}
-					onResize={onPanelResize}
-				>
-					{renderPanelContent()}
-				</MovablePanel>
-			)}
-		</div>
-	);
-};
+      {!remainingNodes ? null : (
+        <PartialRenderInfo
+          remainingNodes={remainingNodes}
+          onShowMoreNodes={onShowMoreNodes}
+        />
+      )}
+      {(selectedNode || selectedEdge) && (
+        <MovablePanel
+          boundingSelector='.graph-container'
+          collapsed={false}
+          minimized={panelMinimized}
+          title={null}
+          height={panelHeight}
+          width={panelWidth}
+          onSetPanelMinimized={onSetPanelMinimized}
+          onResize={onPanelResize}
+        >
+          {renderPanelContent()}
+        </MovablePanel>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/GraphContainer.js
+++ b/client/src/components/GraphContainer.js
@@ -156,28 +156,20 @@ export default ({
 					onShowMoreNodes={onShowMoreNodes}
 				/>
 			)}
-			<MovablePanel
-				boundingSelector=".graph-container"
-				collapsed={!selectedNode && !selectedEdge}
-				minimized={panelMinimized}
-				title={
-					panelContent
-						? null
-						: remainingNodes > 0
-							? `Showing ${
-									nodesDataset.size + remainingNodes
-								} nodes (${remainingNodes} hidden) and ${
-									edgesDataset.size
-								} edges`
-							: `Showing ${nodesDataset.size} nodes and ${edgesDataset.size} edges`
-				}
-				height={panelHeight}
-				width={panelWidth}
-				onSetPanelMinimized={onSetPanelMinimized}
-				onResize={onPanelResize}
-			>
-				{renderPanelContent()}
-			</MovablePanel>
+			{(selectedNode || selectedEdge) && (
+				<MovablePanel
+					boundingSelector=".graph-container"
+					collapsed={false}
+					minimized={panelMinimized}
+					title={null}
+					height={panelHeight}
+					width={panelWidth}
+					onSetPanelMinimized={onSetPanelMinimized}
+					onResize={onPanelResize}
+				>
+					{renderPanelContent()}
+				</MovablePanel>
+			)}
 		</div>
 	);
 };

--- a/client/src/lib/ColorGenerator.js
+++ b/client/src/lib/ColorGenerator.js
@@ -5,24 +5,32 @@
 
 import randomColor from 'randomcolor'
 
+// Neo4j-inspired color palette: rich, saturated, distinct colors
 export default class ColorGenerator {
-  // Picked up from http://graphicdesign.stackexchange.com/questions/3682/where-can-i-find-a-large-palette-set-of-contrasting-colors-for-coloring-many-d.
   randomColorList = [
-    '#47c0ee',
-    '#8dd593',
-    '#f6c4e1',
-    '#8595e1',
-    '#f0b98d',
-    '#f79cd4',
-    '#bec1d4',
-    '#11c638',
-    '#b5bbe3',
-    '#7d87b9',
-    '#e07b91',
-    '#4a6fe3',
+    '#4C8EDA', // blue
+    '#57C7E3', // cyan
+    '#F79767', // orange
+    '#FFC454', // yellow
+    '#D9C8AE', // tan
+    '#C990C0', // purple/pink
+    '#8DCC93', // green
+    '#ECB5C9', // light pink
+    '#4C8EDA', // blue variant
+    '#DA7194', // rose
+    '#569480', // teal
+    '#848484', // gray
+    '#FFC0CB', // pink
+    '#FFD700', // gold
+    '#00CED1', // dark turquoise
+    '#FF6347', // tomato
+    '#7B68EE', // medium slate blue
+    '#3CB371', // medium sea green
+    '#FF69B4', // hot pink
+    '#1E90FF', // dodger blue
   ]
 
-  get = () => this.randomColorList.shift() || randomColor()
+  get = () => this.randomColorList.shift() || randomColor({ luminosity: 'bright' })
 
   getRGBA = (alpha = 1) => {
     const col = this.get()

--- a/client/src/lib/ColorGenerator.js
+++ b/client/src/lib/ColorGenerator.js
@@ -3,40 +3,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import randomColor from "randomcolor";
+import randomColor from 'randomcolor'
 
 // Neo4j-inspired color palette: rich, saturated, distinct colors
 export default class ColorGenerator {
-	randomColorList = [
-		"#4C8EDA", // blue
-		"#57C7E3", // cyan
-		"#F79767", // orange
-		"#FFC454", // yellow
-		"#D9C8AE", // tan
-		"#C990C0", // purple/pink
-		"#8DCC93", // green
-		"#ECB5C9", // light pink
-		"#4C8EDA", // blue variant
-		"#DA7194", // rose
-		"#569480", // teal
-		"#848484", // gray
-		"#FFC0CB", // pink
-		"#FFD700", // gold
-		"#00CED1", // dark turquoise
-		"#FF6347", // tomato
-		"#7B68EE", // medium slate blue
-		"#3CB371", // medium sea green
-		"#FF69B4", // hot pink
-		"#1E90FF", // dodger blue
-	];
+  randomColorList = [
+    '#4C8EDA', // blue
+    '#57C7E3', // cyan
+    '#F79767', // orange
+    '#FFC454', // yellow
+    '#D9C8AE', // tan
+    '#C990C0', // purple/pink
+    '#8DCC93', // green
+    '#ECB5C9', // light pink
+    '#4C8EDA', // blue variant
+    '#DA7194', // rose
+    '#569480', // teal
+    '#848484', // gray
+    '#FFC0CB', // pink
+    '#FFD700', // gold
+    '#00CED1', // dark turquoise
+    '#FF6347', // tomato
+    '#7B68EE', // medium slate blue
+    '#3CB371', // medium sea green
+    '#FF69B4', // hot pink
+    '#1E90FF', // dodger blue
+  ]
 
-	get = () =>
-		this.randomColorList.shift() || randomColor({ luminosity: "bright" });
+  get = () =>
+    this.randomColorList.shift() || randomColor({ luminosity: 'bright' })
 
-	getRGBA = (alpha = 1) => {
-		const col = this.get();
-		const component = (idx) =>
-			parseInt(col.substring(1 + idx * 2, 3 + idx * 2), 16);
-		return [component(0), component(1), component(2), alpha];
-	};
+  getRGBA = (alpha = 1) => {
+    const col = this.get()
+    const component = (idx) =>
+      parseInt(col.substring(1 + idx * 2, 3 + idx * 2), 16)
+    return [component(0), component(1), component(2), alpha]
+  }
 }

--- a/client/src/lib/ColorGenerator.js
+++ b/client/src/lib/ColorGenerator.js
@@ -3,39 +3,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import randomColor from 'randomcolor'
+import randomColor from "randomcolor";
 
 // Neo4j-inspired color palette: rich, saturated, distinct colors
 export default class ColorGenerator {
-  randomColorList = [
-    '#4C8EDA', // blue
-    '#57C7E3', // cyan
-    '#F79767', // orange
-    '#FFC454', // yellow
-    '#D9C8AE', // tan
-    '#C990C0', // purple/pink
-    '#8DCC93', // green
-    '#ECB5C9', // light pink
-    '#4C8EDA', // blue variant
-    '#DA7194', // rose
-    '#569480', // teal
-    '#848484', // gray
-    '#FFC0CB', // pink
-    '#FFD700', // gold
-    '#00CED1', // dark turquoise
-    '#FF6347', // tomato
-    '#7B68EE', // medium slate blue
-    '#3CB371', // medium sea green
-    '#FF69B4', // hot pink
-    '#1E90FF', // dodger blue
-  ]
+	randomColorList = [
+		"#4C8EDA", // blue
+		"#57C7E3", // cyan
+		"#F79767", // orange
+		"#FFC454", // yellow
+		"#D9C8AE", // tan
+		"#C990C0", // purple/pink
+		"#8DCC93", // green
+		"#ECB5C9", // light pink
+		"#4C8EDA", // blue variant
+		"#DA7194", // rose
+		"#569480", // teal
+		"#848484", // gray
+		"#FFC0CB", // pink
+		"#FFD700", // gold
+		"#00CED1", // dark turquoise
+		"#FF6347", // tomato
+		"#7B68EE", // medium slate blue
+		"#3CB371", // medium sea green
+		"#FF69B4", // hot pink
+		"#1E90FF", // dodger blue
+	];
 
-  get = () => this.randomColorList.shift() || randomColor({ luminosity: 'bright' })
+	get = () =>
+		this.randomColorList.shift() || randomColor({ luminosity: "bright" });
 
-  getRGBA = (alpha = 1) => {
-    const col = this.get()
-    const component = (idx) =>
-      parseInt(col.substring(1 + idx * 2, 3 + idx * 2), 16)
-    return [component(0), component(1), component(2), alpha]
-  }
+	getRGBA = (alpha = 1) => {
+		const col = this.get();
+		const component = (idx) =>
+			parseInt(col.substring(1 + idx * 2, 3 + idx * 2), 16);
+		return [component(0), component(1), component(2), alpha];
+	};
 }

--- a/client/src/lib/graph.js
+++ b/client/src/lib/graph.js
@@ -61,7 +61,12 @@ export function getNodeLabel(properties, regex) {
 }
 
 function getNameKey(properties, regex) {
-  return Object.keys(properties).find((p) => regex.test(p)) || ''
+  const keys = Object.keys(properties)
+  // Prefer exact "name" match before falling back to partial regex match
+  // (e.g. avoid picking "graph_name" over "name")
+  const exact = keys.find((p) => p.toLowerCase() === 'name')
+  if (exact) return exact
+  return keys.find((p) => regex.test(p)) || ''
 }
 
 export class GraphParser {


### PR DESCRIPTION
## Summary
- **ArangoDB-style cluster neighborhoods** via custom `forceCluster` that groups nodes by predicate with tight same-group attraction and convex hull overlays
- **Neighborhood highlighting** — hover a node to dim all non-connected nodes/edges to 6-12% opacity
- **Degree-based node sizing** (8-40px radius), solid flat fills, pre-cached colors/radius for performance
- **Minimap** (bottom-left) with click-to-navigate and viewport rectangle
- **Node search** with zoom-to-focus and pulse animation
- **Performance optimizations** — viewport culling, edge cap (2000), LOD dot rendering, throttled hulls/minimap, no shadows/gradients
- **Neo4j-inspired color palette** with 20 rich colors, fit-to-screen button, dot-grid background

## Test plan
- [ ] Run BSA entity query with 1000+ nodes — verify clusters form and browser stays responsive
- [ ] Hover nodes — verify neighborhood dimming works
- [ ] Use search bar to find "Bank Secrecy Act" — verify zoom + pulse
- [ ] Click minimap to navigate
- [ ] Click fit-to-screen button
- [ ] Double-click nodes to expand/collapse
- [ ] Verify entity selector legend still works with hover highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)