### PR TITLE
fix: repair broken Jest test suite (16/18 suites failing)

### DIFF
--- a/client/config/jest/babelTransform.js
+++ b/client/config/jest/babelTransform.js
@@ -18,7 +18,10 @@ module.exports = babelJest.createTransformer({
     require.resolve('@babel/preset-react'),
   ],
   plugins: [
-    [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
+    [
+      require.resolve('@babel/plugin-proposal-class-properties'),
+      { loose: true },
+    ],
   ],
   babelrc: false,
   configFile: false,

--- a/client/config/jest/babelTransform.js
+++ b/client/config/jest/babelTransform.js
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Custom babel-jest transformer with an explicit config.
+//
+// The babel config in package.json ("babel" key) is file-relative, so it is
+// never applied to files inside node_modules. ESM-only packages allowed
+// through transformIgnorePatterns (e.g. react-leaflet) therefore reached the
+// test runtime untransformed. This transformer applies the presets to every
+// file Jest transforms, regardless of location.
+const babelJest = require('babel-jest')
+
+module.exports = babelJest.createTransformer({
+  presets: [
+    [require.resolve('@babel/preset-env'), { targets: { node: 'current' } }],
+    require.resolve('@babel/preset-react'),
+  ],
+  plugins: [
+    [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
+  ],
+  babelrc: false,
+  configFile: false,
+})

--- a/client/config/jest/fileTransform.js
+++ b/client/config/jest/fileTransform.js
@@ -4,7 +4,14 @@
  */
 
 const path = require('path')
-const camelcase = require('camelcase')
+
+// camelcase >= 7 is ESM-only and can no longer be require()d here.
+const pascalCase = (str) =>
+  str
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('')
 
 // This is a custom Jest transformer turning file imports into filenames.
 // http://facebook.github.io/jest/docs/en/webpack.html
@@ -16,9 +23,7 @@ module.exports = {
     if (filename.match(/\.svg$/)) {
       // Based on how SVGR generates a component name:
       // https://github.com/smooth-code/svgr/blob/01b194cf967347d43d4cbe6b434404731b87cf27/packages/core/src/state.js#L6
-      const pascalCaseFilename = camelcase(path.parse(filename).name, {
-        pascalCase: true,
-      })
+      const pascalCaseFilename = pascalCase(path.parse(filename).name)
       const componentName = `Svg${pascalCaseFilename}`
       return `const React = require('react');
       module.exports = {

--- a/client/config/jest/nodeShims/assert.js
+++ b/client/config/jest/nodeShims/assert.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('assert')

--- a/client/config/jest/nodeShims/async_hooks.js
+++ b/client/config/jest/nodeShims/async_hooks.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('async_hooks')

--- a/client/config/jest/nodeShims/buffer.js
+++ b/client/config/jest/nodeShims/buffer.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('buffer')

--- a/client/config/jest/nodeShims/console.js
+++ b/client/config/jest/nodeShims/console.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('console')

--- a/client/config/jest/nodeShims/crypto.js
+++ b/client/config/jest/nodeShims/crypto.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('crypto')

--- a/client/config/jest/nodeShims/diagnostics_channel.js
+++ b/client/config/jest/nodeShims/diagnostics_channel.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('diagnostics_channel')

--- a/client/config/jest/nodeShims/dns.js
+++ b/client/config/jest/nodeShims/dns.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('dns')

--- a/client/config/jest/nodeShims/events.js
+++ b/client/config/jest/nodeShims/events.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('events')

--- a/client/config/jest/nodeShims/fs.js
+++ b/client/config/jest/nodeShims/fs.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('fs')

--- a/client/config/jest/nodeShims/fs/promises.js
+++ b/client/config/jest/nodeShims/fs/promises.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('fs/promises')

--- a/client/config/jest/nodeShims/http.js
+++ b/client/config/jest/nodeShims/http.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('http')

--- a/client/config/jest/nodeShims/http2.js
+++ b/client/config/jest/nodeShims/http2.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('http2')

--- a/client/config/jest/nodeShims/https.js
+++ b/client/config/jest/nodeShims/https.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('https')

--- a/client/config/jest/nodeShims/net.js
+++ b/client/config/jest/nodeShims/net.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('net')

--- a/client/config/jest/nodeShims/os.js
+++ b/client/config/jest/nodeShims/os.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('os')

--- a/client/config/jest/nodeShims/path.js
+++ b/client/config/jest/nodeShims/path.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('path')

--- a/client/config/jest/nodeShims/perf_hooks.js
+++ b/client/config/jest/nodeShims/perf_hooks.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('perf_hooks')

--- a/client/config/jest/nodeShims/process.js
+++ b/client/config/jest/nodeShims/process.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('process')

--- a/client/config/jest/nodeShims/querystring.js
+++ b/client/config/jest/nodeShims/querystring.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('querystring')

--- a/client/config/jest/nodeShims/stream.js
+++ b/client/config/jest/nodeShims/stream.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('stream')

--- a/client/config/jest/nodeShims/stream/web.js
+++ b/client/config/jest/nodeShims/stream/web.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('stream/web')

--- a/client/config/jest/nodeShims/string_decoder.js
+++ b/client/config/jest/nodeShims/string_decoder.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('string_decoder')

--- a/client/config/jest/nodeShims/timers.js
+++ b/client/config/jest/nodeShims/timers.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('timers')

--- a/client/config/jest/nodeShims/timers/promises.js
+++ b/client/config/jest/nodeShims/timers/promises.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('timers/promises')

--- a/client/config/jest/nodeShims/tls.js
+++ b/client/config/jest/nodeShims/tls.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('tls')

--- a/client/config/jest/nodeShims/tty.js
+++ b/client/config/jest/nodeShims/tty.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('tty')

--- a/client/config/jest/nodeShims/url.js
+++ b/client/config/jest/nodeShims/url.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('url')

--- a/client/config/jest/nodeShims/util.js
+++ b/client/config/jest/nodeShims/util.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('util')

--- a/client/config/jest/nodeShims/util/types.js
+++ b/client/config/jest/nodeShims/util/types.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('util/types')

--- a/client/config/jest/nodeShims/worker_threads.js
+++ b/client/config/jest/nodeShims/worker_threads.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('worker_threads')

--- a/client/config/jest/nodeShims/zlib.js
+++ b/client/config/jest/nodeShims/zlib.js
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Jest 26 can't resolve `node:`-prefixed core modules (used by newer
+// dependencies such as cheerio); moduleNameMapper points them here.
+module.exports = require('zlib')

--- a/client/config/jest/testPolyfills.js
+++ b/client/config/jest/testPolyfills.js
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Test-only polyfills. jsdom 16 doesn't expose TextEncoder/TextDecoder,
+// web streams, Blob or MessageChannel, which newer dependencies
+// (e.g. undici via cheerio/enzyme) require. This file is referenced only
+// from Jest's setupFiles, never from webpack, so requiring node core
+// modules here is safe.
+
+const util = require('util')
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = util.TextEncoder
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = util.TextDecoder
+}
+
+const streamWeb = require('stream/web')
+for (const name of [
+  'ReadableStream',
+  'WritableStream',
+  'TransformStream',
+  'ByteLengthQueuingStrategy',
+  'CountQueuingStrategy',
+]) {
+  if (typeof global[name] === 'undefined' && streamWeb[name]) {
+    global[name] = streamWeb[name]
+  }
+}
+
+const buffer = require('buffer')
+if (typeof global.Blob === 'undefined' && buffer.Blob) {
+  global.Blob = buffer.Blob
+}
+
+const workerThreads = require('worker_threads')
+for (const name of ['MessageChannel', 'MessagePort']) {
+  if (typeof global[name] === 'undefined' && workerThreads[name]) {
+    global[name] = workerThreads[name]
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "prettier": "prettier --write \"src/**/*.{js,jsx,mjs,json,scss}\"",
     "lint": "trunk fmt",
     "test": "node scripts/test.js",
+    "test:e2e": "node scripts/test.js --testPathIgnorePatterns=never-ignore-anything --testPathPattern=src/e2etests",
     "test:watch": "node scripts/test.js --watch",
     "precommit": "lint-staged",
     "deepClean": "rm -rf yarn-error.log node_modules yarn.lock package-lock.json",
@@ -65,22 +66,30 @@
   "browserslist": [">2%", "last 3 versions", "Firefox ESR", "not ie < 9"],
   "jest": {
     "collectCoverageFrom": ["src/**/*.{js,jsx,mjs}"],
-    "setupFiles": ["<rootDir>/config/polyfills.js"],
+    "setupFiles": [
+      "<rootDir>/config/polyfills.js",
+      "<rootDir>/config/jest/testPolyfills.js"
+    ],
     "testEnvironment": "jsdom",
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}",
       "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}"
     ],
     "testResultsProcessor": "jest-teamcity",
+    "testPathIgnorePatterns": ["<rootDir>/src/e2etests/"],
     "transform": {
-      "^.+\\.(js|jsx|mjs)$": "<rootDir>/node_modules/babel-jest",
+      "^.+\\.(js|jsx|mjs)$": "<rootDir>/config/jest/babelTransform.js",
       "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|mjs|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
-    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"],
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\](?!(react-leaflet|@react-leaflet)[/\\\\]).+\\.(js|jsx|mjs)$"
+    ],
     "modulePaths": ["./src/"],
     "moduleNameMapper": {
-      "^react-native$": "react-native-web"
+      "^react-native$": "react-native-web",
+      "^node:(.*)$": "<rootDir>/config/jest/nodeShims/$1.js",
+      "^cheerio/lib/utils$": "<rootDir>/node_modules/cheerio/dist/commonjs/utils.js"
     },
     "moduleFileExtensions": [
       "web.js",


### PR DESCRIPTION
## Problem

`npm test` currently fails 16 of 18 suites in a clean checkout of main. None of the failures are real test regressions — they are all test-infrastructure breakages:

1. **ESM-only deps are never transpiled.** The babel config lives in `package.json` (file-relative, like `.babelrc`), so it is not applied to files inside `node_modules` even if `transformIgnorePatterns` lets them through. `react-leaflet` 4 is ESM-only → `SyntaxError: Unexpected token 'export'` in every suite that transitively imports the app.
2. **Jest 26 can't resolve `node:`-prefixed core modules** required by newer transitive deps (cheerio → parse5/undici).
3. **enzyme 3 requires `cheerio/lib/utils`**, which no longer exists in cheerio 1.x final (the lockfile resolves enzyme's `^1.0.0-rc.3` range to 1.1.2).
4. **jsdom 16 lacks `TextEncoder`/`TextDecoder`, web streams, `Blob` and `MessageChannel`** globals that undici needs at import time.
5. **e2e suites run in the default `npm test`** but require puppeteer (optional dep) plus a live Dgraph cluster at `localhost:8080`, so 14 suites always fail locally and in CI-less environments.

## Fix

- `config/jest/babelTransform.js`: dedicated babel-jest transformer with explicit presets, so allowed-through node_modules files actually get compiled; `transformIgnorePatterns` now whitelists `react-leaflet`/`@react-leaflet`.
- `config/jest/nodeShims/*`: one-line shims + a `moduleNameMapper` rule mapping `node:<mod>` → the bare core module.
- `moduleNameMapper` entry pointing `cheerio/lib/utils` at its new location (`dist/commonjs/utils.js`); enzyme is test-only so a Jest mapping is sufficient.
- `config/jest/testPolyfills.js` added to `setupFiles` (kept separate from `config/polyfills.js`, which is also a webpack entry and must not require node core modules).
- e2e suites split out: `npm test` runs unit tests, `npm run test:e2e` runs `src/e2etests` (unchanged behavior otherwise).

## Result

| | before | after |
|---|---|---|
| `npm test` | 16/18 suites fail | **4/4 suites pass (13 tests)** |

No production code or dependency changes; `npm run build` verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)