### PR TITLE
feat: generate DQL from natural language (bring-your-own-key AI)

### DIFF
--- a/client/src/components/AiQueryModal.js
+++ b/client/src/components/AiQueryModal.js
@@ -12,7 +12,8 @@ import { executeQuery } from 'lib/helpers'
 import {
   generateDql,
   loadAiSettings,
-  MODELS,
+  PROVIDER_IDS,
+  PROVIDERS,
   saveAiSettings,
   schemaSummary,
 } from 'lib/nl2dql'
@@ -27,11 +28,18 @@ export default function AiQueryModal({ show, onHide, onInsert }) {
   const [busy, setBusy] = React.useState(false)
   const [error, setError] = React.useState(null)
 
+  const provider = settings.provider
+  const providerDef = PROVIDERS[provider]
+  const current = settings[provider]
+
   const updateSettings = (change) => {
     const next = { ...settings, ...change }
     setSettings(next)
     saveAiSettings(next)
   }
+
+  const updateProviderSettings = (change) =>
+    updateSettings({ [provider]: { ...current, ...change } })
 
   const handleGenerate = async () => {
     setBusy(true)
@@ -49,8 +57,9 @@ export default function AiQueryModal({ show, onHide, onInsert }) {
       }
 
       const dql = await generateDql({
-        apiKey: settings.apiKey,
-        model: settings.model,
+        provider,
+        apiKey: current.apiKey,
+        model: current.model,
         schemaText,
         request,
       })
@@ -74,16 +83,32 @@ export default function AiQueryModal({ show, onHide, onInsert }) {
       </Modal.Header>
       <Modal.Body>
         <Form.Group>
-          <Form.Label>Anthropic API key</Form.Label>
+          <Form.Label>Provider</Form.Label>
+          <Form.Control
+            as='select'
+            value={provider}
+            onChange={(e) => updateSettings({ provider: e.target.value })}
+          >
+            {PROVIDER_IDS.map((id) => (
+              <option key={id} value={id}>
+                {PROVIDERS[id].label}
+              </option>
+            ))}
+          </Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Label>{providerDef.label} API key</Form.Label>
           <Form.Control
             type='password'
-            placeholder='sk-ant-...'
-            value={settings.apiKey}
-            onChange={(e) => updateSettings({ apiKey: e.target.value })}
+            placeholder={providerDef.keyPlaceholder}
+            value={current.apiKey}
+            onChange={(e) => updateProviderSettings({ apiKey: e.target.value })}
           />
           <Form.Text className='text-muted'>
-            Stored only in this browser. Requests go directly to the model
-            API; your data never passes through the Ratel server.
+            Stored only in this browser, per provider. Requests go directly
+            to the model API; your data never passes through the Ratel
+            server.
           </Form.Text>
         </Form.Group>
 
@@ -91,10 +116,10 @@ export default function AiQueryModal({ show, onHide, onInsert }) {
           <Form.Label>Model</Form.Label>
           <Form.Control
             as='select'
-            value={settings.model}
-            onChange={(e) => updateSettings({ model: e.target.value })}
+            value={current.model}
+            onChange={(e) => updateProviderSettings({ model: e.target.value })}
           >
-            {MODELS.map(([value, label]) => (
+            {providerDef.models.map(([value, label]) => (
               <option key={value} value={value}>
                 {label}
               </option>
@@ -139,7 +164,7 @@ export default function AiQueryModal({ show, onHide, onInsert }) {
         <Button
           variant='primary'
           onClick={handleGenerate}
-          disabled={busy || !request.trim() || !settings.apiKey}
+          disabled={busy || !request.trim() || !current.apiKey}
         >
           {busy ? 'Generating…' : 'Generate'}
         </Button>

--- a/client/src/components/AiQueryModal.js
+++ b/client/src/components/AiQueryModal.js
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react'
+import Button from 'react-bootstrap/Button'
+import Form from 'react-bootstrap/Form'
+import Modal from 'react-bootstrap/Modal'
+
+import { executeQuery } from 'lib/helpers'
+import {
+  generateDql,
+  loadAiSettings,
+  MODELS,
+  saveAiSettings,
+  schemaSummary,
+} from 'lib/nl2dql'
+
+// "Generate query with AI": natural language -> DQL, bring-your-own-key.
+// The key is kept in localStorage and requests go straight from the
+// browser to the model API.
+export default function AiQueryModal({ show, onHide, onInsert }) {
+  const [settings, setSettings] = React.useState(loadAiSettings)
+  const [request, setRequest] = React.useState('')
+  const [generated, setGenerated] = React.useState('')
+  const [busy, setBusy] = React.useState(false)
+  const [error, setError] = React.useState(null)
+
+  const updateSettings = (change) => {
+    const next = { ...settings, ...change }
+    setSettings(next)
+    saveAiSettings(next)
+  }
+
+  const handleGenerate = async () => {
+    setBusy(true)
+    setError(null)
+    setGenerated('')
+    try {
+      let schemaText = ''
+      try {
+        const schemaResponse = await executeQuery('schema {}', {
+          action: 'query',
+        })
+        schemaText = schemaSummary(schemaResponse)
+      } catch (e) {
+        // Schema is optional context; generate without it.
+      }
+
+      const dql = await generateDql({
+        apiKey: settings.apiKey,
+        model: settings.model,
+        schemaText,
+        request,
+      })
+      setGenerated(dql)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleInsert = () => {
+    onInsert(generated)
+    onHide()
+  }
+
+  return (
+    <Modal show={show} onHide={onHide} size='lg'>
+      <Modal.Header closeButton>
+        <Modal.Title>Generate query with AI</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form.Group>
+          <Form.Label>Anthropic API key</Form.Label>
+          <Form.Control
+            type='password'
+            placeholder='sk-ant-...'
+            value={settings.apiKey}
+            onChange={(e) => updateSettings({ apiKey: e.target.value })}
+          />
+          <Form.Text className='text-muted'>
+            Stored only in this browser. Requests go directly to the model
+            API; your data never passes through the Ratel server.
+          </Form.Text>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Label>Model</Form.Label>
+          <Form.Control
+            as='select'
+            value={settings.model}
+            onChange={(e) => updateSettings({ model: e.target.value })}
+          >
+            {MODELS.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Label>Describe the query you want</Form.Label>
+          <Form.Control
+            as='textarea'
+            rows={3}
+            placeholder='e.g. the 10 most recently added people and their friends'
+            value={request}
+            onChange={(e) => setRequest(e.target.value)}
+            disabled={busy}
+          />
+          <Form.Text className='text-muted'>
+            The current schema is sent along as context.
+          </Form.Text>
+        </Form.Group>
+
+        {error && <div className='alert alert-danger'>{error}</div>}
+
+        {generated && (
+          <Form.Group>
+            <Form.Label>Generated DQL</Form.Label>
+            <Form.Control
+              as='textarea'
+              rows={8}
+              value={generated}
+              onChange={(e) => setGenerated(e.target.value)}
+              style={{ fontFamily: 'monospace', fontSize: 13 }}
+            />
+          </Form.Group>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant='secondary' onClick={onHide}>
+          Cancel
+        </Button>
+        <Button
+          variant='primary'
+          onClick={handleGenerate}
+          disabled={busy || !request.trim() || !settings.apiKey}
+        >
+          {busy ? 'Generating…' : 'Generate'}
+        </Button>
+        <Button variant='success' onClick={handleInsert} disabled={!generated}>
+          Insert into editor
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/client/src/components/AiQueryModal.js
+++ b/client/src/components/AiQueryModal.js
@@ -10,10 +10,10 @@ import Modal from 'react-bootstrap/Modal'
 
 import { executeQuery } from 'lib/helpers'
 import {
+  PROVIDERS,
+  PROVIDER_IDS,
   generateDql,
   loadAiSettings,
-  PROVIDER_IDS,
-  PROVIDERS,
   saveAiSettings,
   schemaSummary,
 } from 'lib/nl2dql'
@@ -106,9 +106,8 @@ export default function AiQueryModal({ show, onHide, onInsert }) {
             onChange={(e) => updateProviderSettings({ apiKey: e.target.value })}
           />
           <Form.Text className='text-muted'>
-            Stored only in this browser, per provider. Requests go directly
-            to the model API; your data never passes through the Ratel
-            server.
+            Stored only in this browser, per provider. Requests go directly to
+            the model API; your data never passes through the Ratel server.
           </Form.Text>
         </Form.Group>
 

--- a/client/src/components/AiQueryModal.js
+++ b/client/src/components/AiQueryModal.js
@@ -52,7 +52,7 @@ export default function AiQueryModal({ show, onHide, onInsert }) {
           action: 'query',
         })
         schemaText = schemaSummary(schemaResponse)
-      } catch (e) {
+      } catch {
         // Schema is optional context; generate without it.
       }
 

--- a/client/src/components/EditorPanel.js
+++ b/client/src/components/EditorPanel.js
@@ -18,6 +18,7 @@ import {
   updateReadOnly,
 } from 'actions/query'
 
+import AiQueryModal from 'components/AiQueryModal'
 import QueryVarsEditor from 'components/QueryVarsEditor'
 import Editor from 'containers/Editor'
 
@@ -31,6 +32,8 @@ export default function EditorPanel() {
 
   const setReadOnly = (value) => dispatch(updateReadOnly(value))
   const setBestEffort = (value) => dispatch(updateBestEffort(value))
+
+  const [aiModalOpen, setAiModalOpen] = React.useState(false)
 
   const onClearQuery = () => {
     dispatch(updateQuery(''))
@@ -102,6 +105,13 @@ export default function EditorPanel() {
 
         <div className='actions right'>
           <button
+            className='action actionable'
+            title='Generate query with AI'
+            onClick={() => setAiModalOpen(true)}
+          >
+            <i className='fa fa-magic' /> AI
+          </button>
+          <button
             className={classnames('action', {
               actionable: isQueryDirty || hasQueryVars,
             })}
@@ -131,6 +141,15 @@ export default function EditorPanel() {
         onHotkeyRun={onRunCurrentQuery}
         query={query}
         maxHeight='fillParent'
+      />
+
+      <AiQueryModal
+        show={aiModalOpen}
+        onHide={() => setAiModalOpen(false)}
+        onInsert={(dql) => {
+          onUpdateAction('query')
+          onUpdateQuery(dql)
+        }}
       />
       {action === 'query' && <QueryVarsEditor />}
     </div>

--- a/client/src/lib/nl2dql.js
+++ b/client/src/lib/nl2dql.js
@@ -148,7 +148,7 @@ export function loadAiSettings(storage = window.localStorage) {
   let parsed = {}
   try {
     parsed = JSON.parse(storage.getItem(SETTINGS_KEY)) || {}
-  } catch (e) {
+  } catch {
     parsed = {}
   }
 
@@ -179,7 +179,7 @@ export function saveAiSettings(settings, storage = window.localStorage) {
       out[provider] = sanitizeProviderSettings(provider, settings[provider])
     })
     storage.setItem(SETTINGS_KEY, JSON.stringify(out))
-  } catch (e) {
+  } catch {
     // Ignore - the user just re-enters the key next time.
   }
 }
@@ -285,7 +285,7 @@ export async function generateDql({
     let detail = `${res.status}`
     try {
       detail = providerDef.parseError(await res.json()) || detail
-    } catch (e) {
+    } catch {
       // Keep the status code.
     }
     throw new Error(`Model request failed: ${detail}`)

--- a/client/src/lib/nl2dql.js
+++ b/client/src/lib/nl2dql.js
@@ -188,7 +188,6 @@ export function saveAiSettings(settings, storage = window.localStorage) {
 export function schemaSummary(schemaResponse) {
   const data = (schemaResponse && schemaResponse.data) || schemaResponse || {}
   const lines = []
-
   ;(data.schema || []).forEach((p) => {
     if (p.predicate && p.predicate.startsWith('dgraph.')) {
       return

--- a/client/src/lib/nl2dql.js
+++ b/client/src/lib/nl2dql.js
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Natural language -> DQL generation. Bring-your-own-key: the key is
+// stored in localStorage only and requests go directly from the browser
+// to the model API; nothing passes through the Ratel server.
+
+const SETTINGS_KEY = 'ratel-ai-settings'
+
+export const DEFAULT_MODEL = 'claude-haiku-4-5-20251001'
+export const MODELS = [
+  ['claude-haiku-4-5-20251001', 'Claude Haiku 4.5 (fast)'],
+  ['claude-sonnet-4-6', 'Claude Sonnet 4.6 (capable)'],
+]
+
+export function loadAiSettings(storage = window.localStorage) {
+  try {
+    const parsed = JSON.parse(storage.getItem(SETTINGS_KEY)) || {}
+    return {
+      apiKey: typeof parsed.apiKey === 'string' ? parsed.apiKey : '',
+      model: MODELS.some(([m]) => m === parsed.model)
+        ? parsed.model
+        : DEFAULT_MODEL,
+    }
+  } catch (e) {
+    return { apiKey: '', model: DEFAULT_MODEL }
+  }
+}
+
+export function saveAiSettings(settings, storage = window.localStorage) {
+  try {
+    storage.setItem(
+      SETTINGS_KEY,
+      JSON.stringify({
+        apiKey: settings.apiKey || '',
+        model: settings.model || DEFAULT_MODEL,
+      }),
+    )
+  } catch (e) {
+    // Ignore - the user just re-enters the key next time.
+  }
+}
+
+// Compact, prompt-friendly rendering of a `schema {}` response.
+export function schemaSummary(schemaResponse) {
+  const data = (schemaResponse && schemaResponse.data) || schemaResponse || {}
+  const lines = []
+
+  ;(data.schema || []).forEach((p) => {
+    if (p.predicate && p.predicate.startsWith('dgraph.')) {
+      return
+    }
+    const parts = [`${p.predicate}: ${p.type}`]
+    if (p.list) {
+      parts.push('@list')
+    }
+    if (p.index && p.tokenizer) {
+      parts.push(`@index(${p.tokenizer.join(', ')})`)
+    }
+    if (p.reverse) {
+      parts.push('@reverse')
+    }
+    lines.push(parts.join(' '))
+  })
+  ;(data.types || []).forEach((t) => {
+    if (t.name && t.name.startsWith('dgraph.')) {
+      return
+    }
+    const fields = (t.fields || []).map((f) => f.name).join(', ')
+    lines.push(`type ${t.name} { ${fields} }`)
+  })
+
+  return lines.join('\n')
+}
+
+export function buildPrompt(schemaText, request) {
+  const system = [
+    'You translate natural language into Dgraph DQL (GraphQL+-) queries.',
+    'Reply with a single DQL query in a ```dql code block and nothing else.',
+    'Rules:',
+    '- Use only predicates and types that exist in the provided schema.',
+    '- Prefer func: type(...) or indexed predicates for the root function.',
+    '- Include uid and a human-readable name predicate in results when available.',
+    '- Use pagination (first: 100) unless the user asks otherwise.',
+  ].join('\n')
+
+  const user = [
+    'Schema:',
+    '```',
+    schemaText || '(schema unavailable)',
+    '```',
+    '',
+    'Request: ' + request,
+  ].join('\n')
+
+  return { system, user }
+}
+
+// Pulls the DQL out of a model response: prefers fenced code blocks,
+// falls back to the raw text.
+export function extractDql(text) {
+  if (!text) {
+    return ''
+  }
+  const fence = text.match(/```(?:dql|graphql)?\s*\n([\s\S]*?)```/)
+  if (fence) {
+    return fence[1].trim()
+  }
+  return text.trim()
+}
+
+export async function generateDql({
+  apiKey,
+  model,
+  schemaText,
+  request,
+  fetchFn = fetch,
+}) {
+  if (!apiKey) {
+    throw new Error('API key is required')
+  }
+  const { system, user } = buildPrompt(schemaText, request)
+
+  const res = await fetchFn('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      // Explicit opt-in to browser-side calls; the key is the user's own.
+      'anthropic-dangerous-direct-browser-access': 'true',
+    },
+    body: JSON.stringify({
+      model: model || DEFAULT_MODEL,
+      max_tokens: 1024,
+      system,
+      messages: [{ role: 'user', content: user }],
+    }),
+  })
+
+  if (!res.ok) {
+    let detail = `${res.status}`
+    try {
+      const body = await res.json()
+      detail = body.error?.message || detail
+    } catch (e) {
+      // Keep the status code.
+    }
+    throw new Error(`Model request failed: ${detail}`)
+  }
+
+  const body = await res.json()
+  const text = (body.content || [])
+    .filter((block) => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n')
+
+  const dql = extractDql(text)
+  if (!dql) {
+    throw new Error('The model returned no query')
+  }
+  return dql
+}

--- a/client/src/lib/nl2dql.js
+++ b/client/src/lib/nl2dql.js
@@ -3,41 +3,182 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Natural language -> DQL generation. Bring-your-own-key: the key is
+// Natural language -> DQL generation. Bring-your-own-key: keys are
 // stored in localStorage only and requests go directly from the browser
-// to the model API; nothing passes through the Ratel server.
+// to the chosen model API; nothing passes through the Ratel server.
 
 const SETTINGS_KEY = 'ratel-ai-settings'
 
-export const DEFAULT_MODEL = 'claude-haiku-4-5-20251001'
-export const MODELS = [
-  ['claude-haiku-4-5-20251001', 'Claude Haiku 4.5 (fast)'],
-  ['claude-sonnet-4-6', 'Claude Sonnet 4.6 (capable)'],
-]
+export const PROVIDERS = {
+  anthropic: {
+    label: 'Anthropic (Claude)',
+    keyPlaceholder: 'sk-ant-...',
+    defaultModel: 'claude-haiku-4-5-20251001',
+    models: [
+      ['claude-haiku-4-5-20251001', 'Claude Haiku 4.5 (fast)'],
+      ['claude-sonnet-4-6', 'Claude Sonnet 4.6 (capable)'],
+    ],
+    buildRequest({ apiKey, model, system, user }) {
+      return {
+        url: 'https://api.anthropic.com/v1/messages',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          // Explicit opt-in to browser-side calls; the key is the user's own.
+          'anthropic-dangerous-direct-browser-access': 'true',
+        },
+        body: {
+          model,
+          max_tokens: 1024,
+          system,
+          messages: [{ role: 'user', content: user }],
+        },
+      }
+    },
+    parseResponse(body) {
+      return (body.content || [])
+        .filter((block) => block.type === 'text')
+        .map((block) => block.text)
+        .join('\n')
+    },
+    parseError(body) {
+      return body?.error?.message
+    },
+  },
 
-export function loadAiSettings(storage = window.localStorage) {
-  try {
-    const parsed = JSON.parse(storage.getItem(SETTINGS_KEY)) || {}
-    return {
-      apiKey: typeof parsed.apiKey === 'string' ? parsed.apiKey : '',
-      model: MODELS.some(([m]) => m === parsed.model)
-        ? parsed.model
-        : DEFAULT_MODEL,
+  openai: {
+    label: 'OpenAI (ChatGPT)',
+    keyPlaceholder: 'sk-...',
+    defaultModel: 'gpt-5-mini',
+    models: [
+      ['gpt-5-mini', 'GPT-5 mini (fast)'],
+      ['gpt-5.1', 'GPT-5.1 (capable)'],
+    ],
+    buildRequest({ apiKey, model, system, user }) {
+      return {
+        url: 'https://api.openai.com/v1/chat/completions',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: {
+          model,
+          max_completion_tokens: 1024,
+          messages: [
+            { role: 'system', content: system },
+            { role: 'user', content: user },
+          ],
+        },
+      }
+    },
+    parseResponse(body) {
+      return body.choices?.[0]?.message?.content || ''
+    },
+    parseError(body) {
+      return body?.error?.message
+    },
+  },
+
+  gemini: {
+    label: 'Google (Gemini)',
+    keyPlaceholder: 'AIza...',
+    defaultModel: 'gemini-2.5-flash',
+    models: [
+      ['gemini-2.5-flash', 'Gemini 2.5 Flash (fast)'],
+      ['gemini-2.5-pro', 'Gemini 2.5 Pro (capable)'],
+    ],
+    buildRequest({ apiKey, model, system, user }) {
+      return {
+        // The key goes in a header, not the query string, so it never
+        // lands in proxy logs or browser history.
+        url: `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`,
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': apiKey,
+        },
+        body: {
+          system_instruction: { parts: [{ text: system }] },
+          contents: [{ role: 'user', parts: [{ text: user }] }],
+          generationConfig: { maxOutputTokens: 1024 },
+        },
+      }
+    },
+    parseResponse(body) {
+      return (body.candidates?.[0]?.content?.parts || [])
+        .map((part) => part.text || '')
+        .join('\n')
+    },
+    parseError(body) {
+      return body?.error?.message
+    },
+  },
+}
+
+export const PROVIDER_IDS = Object.keys(PROVIDERS)
+export const DEFAULT_PROVIDER = 'anthropic'
+
+const isValidModel = (provider, model) =>
+  PROVIDERS[provider].models.some(([m]) => m === model)
+
+const emptyProviderSettings = (provider) => ({
+  apiKey: '',
+  model: PROVIDERS[provider].defaultModel,
+})
+
+function sanitizeProviderSettings(provider, raw) {
+  const out = emptyProviderSettings(provider)
+  if (raw && typeof raw === 'object') {
+    if (typeof raw.apiKey === 'string') {
+      out.apiKey = raw.apiKey
     }
-  } catch (e) {
-    return { apiKey: '', model: DEFAULT_MODEL }
+    if (isValidModel(provider, raw.model)) {
+      out.model = raw.model
+    }
   }
+  return out
+}
+
+/**
+ * Settings shape: { provider, anthropic: {apiKey, model}, openai: {...},
+ * gemini: {...} }. The pre-multi-provider shape ({apiKey, model}) is
+ * migrated into the anthropic slot.
+ */
+export function loadAiSettings(storage = window.localStorage) {
+  let parsed = {}
+  try {
+    parsed = JSON.parse(storage.getItem(SETTINGS_KEY)) || {}
+  } catch (e) {
+    parsed = {}
+  }
+
+  // Legacy single-provider settings.
+  if (typeof parsed.apiKey === 'string' && !parsed.provider) {
+    parsed = { provider: 'anthropic', anthropic: parsed }
+  }
+
+  const settings = {
+    provider: PROVIDER_IDS.includes(parsed.provider)
+      ? parsed.provider
+      : DEFAULT_PROVIDER,
+  }
+  PROVIDER_IDS.forEach((provider) => {
+    settings[provider] = sanitizeProviderSettings(provider, parsed[provider])
+  })
+  return settings
 }
 
 export function saveAiSettings(settings, storage = window.localStorage) {
   try {
-    storage.setItem(
-      SETTINGS_KEY,
-      JSON.stringify({
-        apiKey: settings.apiKey || '',
-        model: settings.model || DEFAULT_MODEL,
-      }),
-    )
+    const out = {
+      provider: PROVIDER_IDS.includes(settings.provider)
+        ? settings.provider
+        : DEFAULT_PROVIDER,
+    }
+    PROVIDER_IDS.forEach((provider) => {
+      out[provider] = sanitizeProviderSettings(provider, settings[provider])
+    })
+    storage.setItem(SETTINGS_KEY, JSON.stringify(out))
   } catch (e) {
     // Ignore - the user just re-enters the key next time.
   }
@@ -112,51 +253,46 @@ export function extractDql(text) {
 }
 
 export async function generateDql({
+  provider = DEFAULT_PROVIDER,
   apiKey,
   model,
   schemaText,
   request,
   fetchFn = fetch,
 }) {
+  const providerDef = PROVIDERS[provider]
+  if (!providerDef) {
+    throw new Error(`Unknown provider: ${provider}`)
+  }
   if (!apiKey) {
     throw new Error('API key is required')
   }
-  const { system, user } = buildPrompt(schemaText, request)
 
-  const res = await fetchFn('https://api.anthropic.com/v1/messages', {
+  const { system, user } = buildPrompt(schemaText, request)
+  const { url, headers, body } = providerDef.buildRequest({
+    apiKey,
+    model: model || providerDef.defaultModel,
+    system,
+    user,
+  })
+
+  const res = await fetchFn(url, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
-      // Explicit opt-in to browser-side calls; the key is the user's own.
-      'anthropic-dangerous-direct-browser-access': 'true',
-    },
-    body: JSON.stringify({
-      model: model || DEFAULT_MODEL,
-      max_tokens: 1024,
-      system,
-      messages: [{ role: 'user', content: user }],
-    }),
+    headers,
+    body: JSON.stringify(body),
   })
 
   if (!res.ok) {
     let detail = `${res.status}`
     try {
-      const body = await res.json()
-      detail = body.error?.message || detail
+      detail = providerDef.parseError(await res.json()) || detail
     } catch (e) {
       // Keep the status code.
     }
     throw new Error(`Model request failed: ${detail}`)
   }
 
-  const body = await res.json()
-  const text = (body.content || [])
-    .filter((block) => block.type === 'text')
-    .map((block) => block.text)
-    .join('\n')
-
+  const text = providerDef.parseResponse(await res.json())
   const dql = extractDql(text)
   if (!dql) {
     throw new Error('The model returned no query')

--- a/client/src/lib/nl2dql.test.js
+++ b/client/src/lib/nl2dql.test.js
@@ -4,13 +4,13 @@
  */
 
 import {
-  buildPrompt,
   DEFAULT_PROVIDER,
+  PROVIDERS,
+  PROVIDER_IDS,
+  buildPrompt,
   extractDql,
   generateDql,
   loadAiSettings,
-  PROVIDER_IDS,
-  PROVIDERS,
   saveAiSettings,
   schemaSummary,
 } from './nl2dql'

--- a/client/src/lib/nl2dql.test.js
+++ b/client/src/lib/nl2dql.test.js
@@ -1,0 +1,156 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  buildPrompt,
+  DEFAULT_MODEL,
+  extractDql,
+  generateDql,
+  loadAiSettings,
+  saveAiSettings,
+  schemaSummary,
+} from './nl2dql'
+
+const memoryStorage = () => {
+  const data = {}
+  return {
+    getItem: (k) => (k in data ? data[k] : null),
+    setItem: (k, v) => (data[k] = String(v)),
+  }
+}
+
+describe('settings', () => {
+  it('round-trips and defaults the model', () => {
+    const storage = memoryStorage()
+    saveAiSettings({ apiKey: 'sk-test' }, storage)
+    expect(loadAiSettings(storage)).toEqual({
+      apiKey: 'sk-test',
+      model: DEFAULT_MODEL,
+    })
+  })
+
+  it('rejects unknown models and corrupt storage', () => {
+    const storage = memoryStorage()
+    storage.setItem('ratel-ai-settings', '{"model":"gpt-99","apiKey":1}')
+    expect(loadAiSettings(storage)).toEqual({ apiKey: '', model: DEFAULT_MODEL })
+    storage.setItem('ratel-ai-settings', 'not json')
+    expect(loadAiSettings(storage)).toEqual({ apiKey: '', model: DEFAULT_MODEL })
+  })
+})
+
+describe('schemaSummary', () => {
+  it('renders predicates with index/list/reverse and types', () => {
+    const summary = schemaSummary({
+      data: {
+        schema: [
+          {
+            predicate: 'name',
+            type: 'string',
+            index: true,
+            tokenizer: ['term', 'exact'],
+          },
+          { predicate: 'friend', type: 'uid', list: true, reverse: true },
+          { predicate: 'dgraph.type', type: 'string' },
+        ],
+        types: [
+          { name: 'Person', fields: [{ name: 'name' }, { name: 'friend' }] },
+          { name: 'dgraph.graphql', fields: [] },
+        ],
+      },
+    })
+    expect(summary).toContain('name: string @index(term, exact)')
+    expect(summary).toContain('friend: uid @list @reverse')
+    expect(summary).toContain('type Person { name, friend }')
+    expect(summary).not.toContain('dgraph.')
+  })
+
+  it('handles empty responses', () => {
+    expect(schemaSummary(null)).toBe('')
+    expect(schemaSummary({ data: {} })).toBe('')
+  })
+})
+
+describe('buildPrompt', () => {
+  it('includes schema and request', () => {
+    const { system, user } = buildPrompt('name: string', 'find all people')
+    expect(system).toContain('DQL')
+    expect(user).toContain('name: string')
+    expect(user).toContain('Request: find all people')
+  })
+
+  it('notes missing schema', () => {
+    expect(buildPrompt('', 'x').user).toContain('(schema unavailable)')
+  })
+})
+
+describe('extractDql', () => {
+  it('prefers fenced blocks', () => {
+    expect(extractDql('Here:\n```dql\n{ q(func: has(name)) { uid } }\n```')).toBe(
+      '{ q(func: has(name)) { uid } }',
+    )
+    expect(extractDql('```\n{ x }\n```')).toBe('{ x }')
+  })
+
+  it('falls back to raw text', () => {
+    expect(extractDql('  { q { uid } }  ')).toBe('{ q { uid } }')
+    expect(extractDql('')).toBe('')
+  })
+})
+
+describe('generateDql', () => {
+  const okResponse = (text) => ({
+    ok: true,
+    json: async () => ({ content: [{ type: 'text', text }] }),
+  })
+
+  it('calls the API with key, model and prompt; returns extracted DQL', async () => {
+    const fetchFn = jest.fn(async () =>
+      okResponse('```dql\n{ q(func: type(Person)) { uid name } }\n```'),
+    )
+    const dql = await generateDql({
+      apiKey: 'sk-test',
+      model: 'claude-sonnet-4-6',
+      schemaText: 'name: string',
+      request: 'all people',
+      fetchFn,
+    })
+
+    expect(dql).toBe('{ q(func: type(Person)) { uid name } }')
+    const [url, opts] = fetchFn.mock.calls[0]
+    expect(url).toContain('api.anthropic.com')
+    expect(opts.headers['x-api-key']).toBe('sk-test')
+    expect(opts.headers['anthropic-dangerous-direct-browser-access']).toBe(
+      'true',
+    )
+    const body = JSON.parse(opts.body)
+    expect(body.model).toBe('claude-sonnet-4-6')
+    expect(body.messages[0].content).toContain('all people')
+    expect(body.system).toContain('DQL')
+  })
+
+  it('requires an API key', async () => {
+    await expect(generateDql({ apiKey: '', request: 'x' })).rejects.toThrow(
+      'API key',
+    )
+  })
+
+  it('surfaces API error messages', async () => {
+    const fetchFn = jest.fn(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: { message: 'invalid x-api-key' } }),
+    }))
+    await expect(
+      generateDql({ apiKey: 'bad', request: 'x', fetchFn }),
+    ).rejects.toThrow('invalid x-api-key')
+  })
+
+  it('throws when the model returns no query', async () => {
+    const fetchFn = jest.fn(async () => okResponse(''))
+    await expect(
+      generateDql({ apiKey: 'sk', request: 'x', fetchFn }),
+    ).rejects.toThrow('no query')
+  })
+})

--- a/client/src/lib/nl2dql.test.js
+++ b/client/src/lib/nl2dql.test.js
@@ -5,10 +5,12 @@
 
 import {
   buildPrompt,
-  DEFAULT_MODEL,
+  DEFAULT_PROVIDER,
   extractDql,
   generateDql,
   loadAiSettings,
+  PROVIDER_IDS,
+  PROVIDERS,
   saveAiSettings,
   schemaSummary,
 } from './nl2dql'
@@ -22,21 +24,135 @@ const memoryStorage = () => {
 }
 
 describe('settings', () => {
-  it('round-trips and defaults the model', () => {
+  it('round-trips per-provider settings', () => {
     const storage = memoryStorage()
-    saveAiSettings({ apiKey: 'sk-test' }, storage)
-    expect(loadAiSettings(storage)).toEqual({
-      apiKey: 'sk-test',
-      model: DEFAULT_MODEL,
+    saveAiSettings(
+      {
+        provider: 'gemini',
+        gemini: { apiKey: 'AIza-test', model: 'gemini-2.5-pro' },
+        openai: { apiKey: 'sk-oa' },
+      },
+      storage,
+    )
+    const loaded = loadAiSettings(storage)
+    expect(loaded.provider).toBe('gemini')
+    expect(loaded.gemini).toEqual({
+      apiKey: 'AIza-test',
+      model: 'gemini-2.5-pro',
+    })
+    expect(loaded.openai).toEqual({
+      apiKey: 'sk-oa',
+      model: PROVIDERS.openai.defaultModel,
+    })
+    expect(loaded.anthropic).toEqual({
+      apiKey: '',
+      model: PROVIDERS.anthropic.defaultModel,
     })
   })
 
-  it('rejects unknown models and corrupt storage', () => {
+  it('migrates legacy single-provider settings into the anthropic slot', () => {
     const storage = memoryStorage()
-    storage.setItem('ratel-ai-settings', '{"model":"gpt-99","apiKey":1}')
-    expect(loadAiSettings(storage)).toEqual({ apiKey: '', model: DEFAULT_MODEL })
+    storage.setItem(
+      'ratel-ai-settings',
+      JSON.stringify({ apiKey: 'sk-legacy', model: 'claude-sonnet-4-6' }),
+    )
+    const loaded = loadAiSettings(storage)
+    expect(loaded.provider).toBe('anthropic')
+    expect(loaded.anthropic).toEqual({
+      apiKey: 'sk-legacy',
+      model: 'claude-sonnet-4-6',
+    })
+  })
+
+  it('rejects unknown providers/models and corrupt storage', () => {
+    const storage = memoryStorage()
+    storage.setItem(
+      'ratel-ai-settings',
+      JSON.stringify({
+        provider: 'skynet',
+        anthropic: { apiKey: 1, model: 'gpt-99' },
+      }),
+    )
+    const loaded = loadAiSettings(storage)
+    expect(loaded.provider).toBe(DEFAULT_PROVIDER)
+    expect(loaded.anthropic).toEqual({
+      apiKey: '',
+      model: PROVIDERS.anthropic.defaultModel,
+    })
+
     storage.setItem('ratel-ai-settings', 'not json')
-    expect(loadAiSettings(storage)).toEqual({ apiKey: '', model: DEFAULT_MODEL })
+    expect(loadAiSettings(storage).provider).toBe(DEFAULT_PROVIDER)
+  })
+})
+
+describe('provider request shapes', () => {
+  const args = {
+    apiKey: 'test-key',
+    model: 'some-model',
+    system: 'SYS',
+    user: 'USR',
+  }
+
+  it('anthropic: messages API with browser-access header', () => {
+    const { url, headers, body } = PROVIDERS.anthropic.buildRequest(args)
+    expect(url).toContain('api.anthropic.com/v1/messages')
+    expect(headers['x-api-key']).toBe('test-key')
+    expect(headers['anthropic-dangerous-direct-browser-access']).toBe('true')
+    expect(body.system).toBe('SYS')
+    expect(body.messages).toEqual([{ role: 'user', content: 'USR' }])
+  })
+
+  it('openai: chat completions with bearer auth and system message', () => {
+    const { url, headers, body } = PROVIDERS.openai.buildRequest(args)
+    expect(url).toContain('api.openai.com/v1/chat/completions')
+    expect(headers.Authorization).toBe('Bearer test-key')
+    expect(body.model).toBe('some-model')
+    expect(body.max_completion_tokens).toBe(1024)
+    expect(body.messages).toEqual([
+      { role: 'system', content: 'SYS' },
+      { role: 'user', content: 'USR' },
+    ])
+  })
+
+  it('gemini: generateContent with key in header, not URL', () => {
+    const { url, headers, body } = PROVIDERS.gemini.buildRequest(args)
+    expect(url).toContain('models/some-model:generateContent')
+    expect(url).not.toContain('test-key')
+    expect(headers['x-goog-api-key']).toBe('test-key')
+    expect(body.system_instruction.parts[0].text).toBe('SYS')
+    expect(body.contents).toEqual([{ role: 'user', parts: [{ text: 'USR' }] }])
+  })
+})
+
+describe('provider response parsing', () => {
+  it('anthropic: joins text blocks', () => {
+    expect(
+      PROVIDERS.anthropic.parseResponse({
+        content: [
+          { type: 'text', text: 'a' },
+          { type: 'tool_use' },
+          { type: 'text', text: 'b' },
+        ],
+      }),
+    ).toBe('a\nb')
+  })
+
+  it('openai: reads first choice message', () => {
+    expect(
+      PROVIDERS.openai.parseResponse({
+        choices: [{ message: { content: 'hello' } }],
+      }),
+    ).toBe('hello')
+    expect(PROVIDERS.openai.parseResponse({})).toBe('')
+  })
+
+  it('gemini: joins candidate parts', () => {
+    expect(
+      PROVIDERS.gemini.parseResponse({
+        candidates: [{ content: { parts: [{ text: 'x' }, { text: 'y' }] } }],
+      }),
+    ).toBe('x\ny')
+    expect(PROVIDERS.gemini.parseResponse({})).toBe('')
   })
 })
 
@@ -87,9 +203,9 @@ describe('buildPrompt', () => {
 
 describe('extractDql', () => {
   it('prefers fenced blocks', () => {
-    expect(extractDql('Here:\n```dql\n{ q(func: has(name)) { uid } }\n```')).toBe(
-      '{ q(func: has(name)) { uid } }',
-    )
+    expect(
+      extractDql('Here:\n```dql\n{ q(func: has(name)) { uid } }\n```'),
+    ).toBe('{ q(func: has(name)) { uid } }')
     expect(extractDql('```\n{ x }\n```')).toBe('{ x }')
   })
 
@@ -100,57 +216,100 @@ describe('extractDql', () => {
 })
 
 describe('generateDql', () => {
-  const okResponse = (text) => ({
+  const anthropicResponse = (text) => ({
     ok: true,
     json: async () => ({ content: [{ type: 'text', text }] }),
   })
 
-  it('calls the API with key, model and prompt; returns extracted DQL', async () => {
-    const fetchFn = jest.fn(async () =>
-      okResponse('```dql\n{ q(func: type(Person)) { uid name } }\n```'),
-    )
+  it('uses the chosen provider end to end (openai)', async () => {
+    const fetchFn = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        choices: [
+          {
+            message: { content: '```dql\n{ q(func: type(P)) { uid } }\n```' },
+          },
+        ],
+      }),
+    }))
     const dql = await generateDql({
+      provider: 'openai',
       apiKey: 'sk-test',
-      model: 'claude-sonnet-4-6',
+      model: 'gpt-5.1',
       schemaText: 'name: string',
       request: 'all people',
       fetchFn,
     })
-
-    expect(dql).toBe('{ q(func: type(Person)) { uid name } }')
+    expect(dql).toBe('{ q(func: type(P)) { uid } }')
     const [url, opts] = fetchFn.mock.calls[0]
-    expect(url).toContain('api.anthropic.com')
-    expect(opts.headers['x-api-key']).toBe('sk-test')
-    expect(opts.headers['anthropic-dangerous-direct-browser-access']).toBe(
-      'true',
-    )
-    const body = JSON.parse(opts.body)
-    expect(body.model).toBe('claude-sonnet-4-6')
-    expect(body.messages[0].content).toContain('all people')
-    expect(body.system).toContain('DQL')
+    expect(url).toContain('api.openai.com')
+    expect(JSON.parse(opts.body).model).toBe('gpt-5.1')
   })
 
-  it('requires an API key', async () => {
+  it('uses the chosen provider end to end (gemini)', async () => {
+    const fetchFn = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: '{ q { uid } }' }] } }],
+      }),
+    }))
+    const dql = await generateDql({
+      provider: 'gemini',
+      apiKey: 'AIza',
+      request: 'x',
+      fetchFn,
+    })
+    expect(dql).toBe('{ q { uid } }')
+    expect(fetchFn.mock.calls[0][0]).toContain(
+      `models/${PROVIDERS.gemini.defaultModel}:generateContent`,
+    )
+  })
+
+  it('defaults to anthropic and falls back to the default model', async () => {
+    const fetchFn = jest.fn(async () =>
+      anthropicResponse('```dql\n{ q { uid } }\n```'),
+    )
+    await generateDql({ apiKey: 'sk', request: 'x', fetchFn })
+    const [url, opts] = fetchFn.mock.calls[0]
+    expect(url).toContain('api.anthropic.com')
+    expect(JSON.parse(opts.body).model).toBe(PROVIDERS.anthropic.defaultModel)
+  })
+
+  it('rejects unknown providers and missing keys', async () => {
+    await expect(
+      generateDql({ provider: 'skynet', apiKey: 'x', request: 'x' }),
+    ).rejects.toThrow('Unknown provider')
     await expect(generateDql({ apiKey: '', request: 'x' })).rejects.toThrow(
       'API key',
     )
   })
 
-  it('surfaces API error messages', async () => {
+  it('surfaces provider error messages', async () => {
     const fetchFn = jest.fn(async () => ({
       ok: false,
       status: 401,
-      json: async () => ({ error: { message: 'invalid x-api-key' } }),
+      json: async () => ({ error: { message: 'invalid api key' } }),
     }))
     await expect(
-      generateDql({ apiKey: 'bad', request: 'x', fetchFn }),
-    ).rejects.toThrow('invalid x-api-key')
+      generateDql({ provider: 'openai', apiKey: 'bad', request: 'x', fetchFn }),
+    ).rejects.toThrow('invalid api key')
   })
 
   it('throws when the model returns no query', async () => {
-    const fetchFn = jest.fn(async () => okResponse(''))
+    const fetchFn = jest.fn(async () => anthropicResponse(''))
     await expect(
       generateDql({ apiKey: 'sk', request: 'x', fetchFn }),
     ).rejects.toThrow('no query')
+  })
+
+  it('every provider id has a complete definition', () => {
+    PROVIDER_IDS.forEach((id) => {
+      const def = PROVIDERS[id]
+      expect(def.label).toBeTruthy()
+      expect(def.defaultModel).toBeTruthy()
+      expect(def.models.length).toBeGreaterThan(0)
+      expect(typeof def.buildRequest).toBe('function')
+      expect(typeof def.parseResponse).toBe('function')
+    })
   })
 })


### PR DESCRIPTION
## What

Adds an **AI** button to the editor toolbar: describe the query in plain language, get DQL back, review/edit it in the modal, insert into the editor. Comparable tools are shipping this (NebulaGraph Studio's AI assistant, etc.).

## Privacy / key handling

Strictly **bring-your-own-key**: the user pastes their own API key, it's stored in `localStorage` only (per provider), and requests go **directly browser → model API** — nothing passes through the Ratel server and no key ever appears in a URL.

## Providers

A small provider registry (`buildRequest` / `parseResponse` / `parseError` per provider; prompt, schema context and DQL extraction shared):

| Provider | Models | Notes |
|---|---|---|
| Anthropic | Claude Haiku 4.5, Sonnet 4.6 | messages API with the explicit `anthropic-dangerous-direct-browser-access` opt-in |
| OpenAI | GPT-5 mini, GPT-5.1 | chat completions, Bearer auth |
| Google | Gemini 2.5 Flash, Pro | `generateContent`, key in the `x-goog-api-key` header (not the query string) |

## Schema-aware

On generate, the current `schema {}` is summarized compactly (predicates with types/indexes/@reverse, type definitions, `dgraph.*` filtered) and sent as context, so generated queries use real predicates. The system prompt constrains output to a single fenced DQL block; extraction falls back to raw text; the result is editable before inserting.

## Testing

22 unit tests: request shapes for all three providers, response parsing, settings persistence/sanitization/migration, end-to-end mocked generation, error surfacing, missing-key/unknown-provider rejection. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)