### PR TITLE
fix: pass namespace when submitting login form with Enter

### DIFF
--- a/client/src/components/ServerLoginWidget.js
+++ b/client/src/components/ServerLoginWidget.js
@@ -44,7 +44,7 @@ export default function ServerLoginWidget({ isMultiTenancyEnabled }) {
     <Form
       onSubmit={(e) => {
         e.preventDefault()
-        onLogin(userid, password)
+        onLogin(userid, password, namespace)
       }}
     >
       <Form.Group controlId='useridInput'>


### PR DESCRIPTION
One-line bug fix.

The login form's `onSubmit` handler called `onLogin(userid, password)` without the namespace argument, so submitting with **Enter** on a multi-tenancy cluster dispatched `loginIntoNamespace` with `Number(undefined)` = `NaN` instead of the namespace typed into the form. Clicking the **Login** button already passed it correctly — so the bug only bit keyboard users, which makes it confusing to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)