### PR TITLE
feat: searchable run history panel with status and latency

### DIFF
--- a/client/src/assets/css/EditorPanel.scss
+++ b/client/src/assets/css/EditorPanel.scss
@@ -12,12 +12,21 @@
   .header {
     border-bottom: 1px solid #d2d2d2;
     background-color: #fff;
+
+    // Flex (not floats) so a crowded toolbar wraps into clean rows instead
+    // of collapsing the float container and leaving an empty band.
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
   }
 
   .actions {
-    float: left;
+    display: flex;
+    align-items: stretch;
     &.right {
-      float: right;
+      // Push the run/clear/etc. group to the right; on a narrow pane it
+      // wraps to its own row rather than overflowing.
+      margin-left: auto;
     }
   }
 

--- a/client/src/components/EditorPanel.js
+++ b/client/src/components/EditorPanel.js
@@ -19,6 +19,7 @@ import {
 } from 'actions/query'
 
 import QueryVarsEditor from 'components/QueryVarsEditor'
+import RunHistoryPanel from 'components/RunHistoryPanel'
 import Editor from 'containers/Editor'
 
 import '../assets/css/EditorPanel.scss'
@@ -101,6 +102,7 @@ export default function EditorPanel() {
         {queryOptions}
 
         <div className='actions right'>
+          <RunHistoryPanel />
           <button
             className={classnames('action', {
               actionable: isQueryDirty || hasQueryVars,

--- a/client/src/components/RunHistoryPanel.js
+++ b/client/src/components/RunHistoryPanel.js
@@ -1,0 +1,151 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import classnames from 'classnames'
+import React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import TimeAgo from 'react-timeago'
+
+import { setActiveFrame } from 'actions/frames'
+import { updateQueryAndAction, updateQueryVars } from 'actions/query'
+import { filterFrames, summarizeFrame } from 'lib/runHistory'
+
+import './RunHistoryPanel.scss'
+
+const STATUS_TITLES = {
+  ok: 'Completed without errors',
+  error: 'Completed with errors',
+  unknown: 'Not executed in this session',
+}
+
+export default function RunHistoryPanel() {
+  const dispatch = useDispatch()
+  const { items, frameResults, activeFrameId } = useSelector(
+    (store) => store.frames,
+  )
+
+  const [isOpen, setOpen] = React.useState(false)
+  const [search, setSearch] = React.useState('')
+
+  const rootRef = React.useRef(null)
+  const searchRef = React.useRef(null)
+
+  // Close the panel on outside clicks and on Escape.
+  React.useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+    const onMouseDown = (e) => {
+      if (rootRef.current && !rootRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [isOpen])
+
+  // Focus the search input when the panel opens.
+  React.useEffect(() => {
+    if (isOpen && searchRef.current) {
+      searchRef.current.focus()
+    }
+  }, [isOpen])
+
+  const selectFrame = (frame) => {
+    dispatch(updateQueryAndAction(frame.query, frame.action))
+    if (frame.action === 'query') {
+      dispatch(updateQueryVars(frame.queryOptions?.queryVars || []))
+    }
+    dispatch(setActiveFrame(frame.id))
+    setOpen(false)
+  }
+
+  const visibleFrames = filterFrames(items, search)
+
+  const renderRow = (frame) => {
+    const { status, latencyText, snippet } = summarizeFrame(frame, frameResults)
+    const createdAt = frame.createdAt || frame.timestamp
+
+    return (
+      <button
+        key={frame.id}
+        type='button'
+        className={classnames('run-history-row', {
+          active: frame.id === activeFrameId,
+        })}
+        onClick={() => selectFrame(frame)}
+        title={frame.query}
+      >
+        <i
+          className={classnames('action-icon', {
+            'fa fa-search': frame.action === 'query',
+            'far fa-edit': frame.action !== 'query',
+          })}
+        />
+        <span
+          className={`status-dot status-${status}`}
+          title={STATUS_TITLES[status]}
+        />
+        <span className='snippet'>{snippet}</span>
+        <span className='meta'>
+          {latencyText && <span className='latency'>{latencyText}</span>}
+          {createdAt && (
+            <span className='time'>
+              <TimeAgo date={createdAt} minPeriod={10} />
+            </span>
+          )}
+        </span>
+      </button>
+    )
+  }
+
+  return (
+    <div className='run-history' ref={rootRef}>
+      <button
+        type='button'
+        className={classnames('action actionable', { open: isOpen })}
+        onClick={() => setOpen(!isOpen)}
+        title='Show run history'
+      >
+        <i className='fa fa-history' /> History
+      </button>
+
+      {isOpen && (
+        <div className='run-history-panel'>
+          <div className='run-history-search'>
+            <input
+              ref={searchRef}
+              type='text'
+              className='form-control form-control-sm'
+              placeholder='Search past queries...'
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <div className='run-history-list'>
+            {visibleFrames.length ? (
+              visibleFrames.map(renderRow)
+            ) : (
+              <div className='run-history-empty text-muted'>
+                {items.length
+                  ? 'No runs match your search'
+                  : 'No queries have been run yet'}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/RunHistoryPanel.js
+++ b/client/src/components/RunHistoryPanel.js
@@ -28,11 +28,40 @@ export default function RunHistoryPanel() {
 
   const [isOpen, setOpen] = React.useState(false)
   const [search, setSearch] = React.useState('')
+  const [coords, setCoords] = React.useState(null)
 
   const rootRef = React.useRef(null)
+  const buttonRef = React.useRef(null)
   const searchRef = React.useRef(null)
 
-  // Close the panel on outside clicks and on Escape.
+  // Position the panel below the button, right-aligned to it, but clamped
+  // to the viewport so a narrow editor pane never pushes it off-screen
+  // (it is position:fixed, so it also escapes any clipping ancestor).
+  const PANEL_WIDTH = 420
+  const computeCoords = () => {
+    if (!buttonRef.current) {
+      return
+    }
+    const rect = buttonRef.current.getBoundingClientRect()
+    const width = Math.min(PANEL_WIDTH, window.innerWidth - 16)
+    const left = Math.max(
+      8,
+      Math.min(rect.right - width, window.innerWidth - width - 8),
+    )
+    setCoords({ top: rect.bottom + 2, left, width })
+  }
+
+  const toggleOpen = () => {
+    if (isOpen) {
+      setOpen(false)
+    } else {
+      computeCoords()
+      setOpen(true)
+    }
+  }
+
+  // Close the panel on outside clicks and on Escape; keep it anchored to
+  // the button on resize.
   React.useEffect(() => {
     if (!isOpen) {
       return
@@ -49,9 +78,11 @@ export default function RunHistoryPanel() {
     }
     document.addEventListener('mousedown', onMouseDown)
     document.addEventListener('keydown', onKeyDown)
+    window.addEventListener('resize', computeCoords)
     return () => {
       document.removeEventListener('mousedown', onMouseDown)
       document.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('resize', computeCoords)
     }
   }, [isOpen])
 
@@ -113,16 +144,24 @@ export default function RunHistoryPanel() {
   return (
     <div className='run-history' ref={rootRef}>
       <button
+        ref={buttonRef}
         type='button'
         className={classnames('action actionable', { open: isOpen })}
-        onClick={() => setOpen(!isOpen)}
+        onClick={toggleOpen}
         title='Show run history'
       >
         <i className='fa fa-history' /> History
       </button>
 
-      {isOpen && (
-        <div className='run-history-panel'>
+      {isOpen && coords && (
+        <div
+          className='run-history-panel'
+          style={{
+            top: coords.top,
+            left: coords.left,
+            width: coords.width,
+          }}
+        >
           <div className='run-history-search'>
             <input
               ref={searchRef}

--- a/client/src/components/RunHistoryPanel.scss
+++ b/client/src/components/RunHistoryPanel.scss
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.run-history {
+  display: inline-block;
+  position: relative;
+
+  > .action.open {
+    background: #f7f7f7;
+  }
+
+  .run-history-panel {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 1000;
+
+    width: 420px;
+    max-width: 80vw;
+
+    background: #fff;
+    border: 1px solid #d2d2d2;
+    border-radius: 2px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  .run-history-search {
+    padding: 8px;
+    border-bottom: 1px solid #e5e5e5;
+  }
+
+  .run-history-list {
+    max-height: 320px;
+    overflow-y: auto;
+  }
+
+  .run-history-empty {
+    padding: 14px 12px;
+    text-align: center;
+    font-size: 13px;
+  }
+
+  .run-history-row {
+    display: flex;
+    align-items: center;
+    width: 100%;
+
+    padding: 6px 10px;
+    border: none;
+    border-bottom: 1px solid #f0f0f0;
+    background: transparent;
+    text-align: left;
+    font-size: 13px;
+    color: #333;
+    cursor: pointer;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &:hover {
+      background: #f7f7f7;
+    }
+
+    &.active {
+      background: #eef6fb;
+    }
+
+    .action-icon {
+      flex: 0 0 auto;
+      margin-right: 8px;
+      color: #8a8a8a;
+      font-size: 12px;
+    }
+
+    .status-dot {
+      flex: 0 0 auto;
+      width: 8px;
+      height: 8px;
+      margin-right: 8px;
+      border-radius: 50%;
+
+      &.status-ok {
+        background-color: #28a745;
+      }
+      &.status-error {
+        background-color: #dc3545;
+      }
+      &.status-unknown {
+        background-color: #adb5bd;
+      }
+    }
+
+    .snippet {
+      flex: 1 1 auto;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      font-family: monospace;
+      font-size: 12px;
+    }
+
+    .meta {
+      flex: 0 0 auto;
+      margin-left: 10px;
+      color: #8a8a8a;
+      font-size: 11px;
+      white-space: nowrap;
+
+      .latency {
+        margin-right: 8px;
+        color: #5b8c5a;
+      }
+    }
+  }
+}

--- a/client/src/components/RunHistoryPanel.scss
+++ b/client/src/components/RunHistoryPanel.scss
@@ -12,13 +12,11 @@
   }
 
   .run-history-panel {
-    position: absolute;
-    top: 100%;
-    right: 0;
+    // Fixed + JS-computed top/left/width (see RunHistoryPanel.js) so the
+    // panel stays on-screen from a mid-toolbar button and is never clipped
+    // by a narrow editor pane or an overflow:hidden ancestor.
+    position: fixed;
     z-index: 1000;
-
-    width: 420px;
-    max-width: 80vw;
 
     background: #fff;
     border: 1px solid #d2d2d2;

--- a/client/src/lib/runHistory.js
+++ b/client/src/lib/runHistory.js
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TAB_JSON } from 'actions/frames'
+
+export const SNIPPET_MAX_LENGTH = 60
+
+/**
+ * formatLatencyMs renders a latency expressed in nanoseconds as a short
+ * millisecond string, e.g. 1234567 -> "1.2ms". Returns '' when the value
+ * is missing or not a positive number.
+ */
+export function formatLatencyMs(latencyNs) {
+  if (typeof latencyNs !== 'number' || !isFinite(latencyNs) || latencyNs <= 0) {
+    return ''
+  }
+  const ms = latencyNs / 1e6
+  if (ms < 1) {
+    return `${ms.toFixed(2)}ms`
+  }
+  if (ms < 10) {
+    return `${ms.toFixed(1)}ms`
+  }
+  return `${Math.round(ms)}ms`
+}
+
+// Collapses all whitespace runs (including newlines) into single spaces
+// and truncates to SNIPPET_MAX_LENGTH characters, appending an ellipsis.
+function makeSnippet(query) {
+  const oneLine = String(query || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (oneLine.length <= SNIPPET_MAX_LENGTH) {
+    return oneLine
+  }
+  return `${oneLine.slice(0, SNIPPET_MAX_LENGTH)}…`
+}
+
+// Picks the most relevant tab result for a frame: the JSON tab when it has
+// completed (mutations and JSON queries land there), otherwise any other
+// completed tab (e.g. a query only executed on the visual tab).
+function pickTabResult(frameResult) {
+  if (!frameResult) {
+    return null
+  }
+  const jsonResult = frameResult[TAB_JSON]
+  if (jsonResult && jsonResult.completed) {
+    return jsonResult
+  }
+  const completed = Object.values(frameResult).find(
+    (tabResult) => tabResult && tabResult.completed,
+  )
+  return completed || null
+}
+
+/**
+ * summarizeFrame computes display info for one history row.
+ *
+ * @param frame - a frames.items entry ({ id, action, query, ... })
+ * @param frameResults - the frames.frameResults map keyed by frame id,
+ *   holding per-tab results ({ completed, error, serverLatencyNs, ... })
+ * @returns {{status: 'ok'|'error'|'unknown', latencyText: string, snippet: string}}
+ */
+export function summarizeFrame(frame, frameResults) {
+  const snippet = makeSnippet(frame && frame.query)
+  const frameResult = frame && frameResults ? frameResults[frame.id] : undefined
+  const tabResult = pickTabResult(frameResult)
+
+  if (!tabResult) {
+    return { status: 'unknown', latencyText: '', snippet }
+  }
+  return {
+    status: tabResult.error ? 'error' : 'ok',
+    latencyText: formatLatencyMs(tabResult.serverLatencyNs),
+    snippet,
+  }
+}
+
+/**
+ * filterFrames returns the frames whose query text contains the search
+ * string (case-insensitive). A blank search returns all frames.
+ */
+export function filterFrames(items, query) {
+  const frames = items || []
+  const needle = String(query || '')
+    .trim()
+    .toLowerCase()
+  if (!needle) {
+    return frames
+  }
+  return frames.filter(
+    (frame) =>
+      typeof frame?.query === 'string' &&
+      frame.query.toLowerCase().includes(needle),
+  )
+}

--- a/client/src/lib/runHistory.test.js
+++ b/client/src/lib/runHistory.test.js
@@ -1,0 +1,244 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TAB_JSON, TAB_VISUAL } from 'actions/frames'
+
+import {
+  SNIPPET_MAX_LENGTH,
+  filterFrames,
+  formatLatencyMs,
+  summarizeFrame,
+} from './runHistory'
+
+const FRAME_ID = 'frame-1'
+const makeFrame = (overrides = {}) => ({
+  id: FRAME_ID,
+  action: 'query',
+  query: '{ q(func: has(name)) { name } }',
+  ...overrides,
+})
+
+describe('summarizeFrame', () => {
+  describe('status', () => {
+    it('is unknown when there are no results for the frame', () => {
+      const { status } = summarizeFrame(makeFrame(), {})
+      expect(status).toBe('unknown')
+    })
+
+    it('is unknown when frameResults is undefined', () => {
+      const { status } = summarizeFrame(makeFrame(), undefined)
+      expect(status).toBe('unknown')
+    })
+
+    it('is unknown when no tab has completed yet', () => {
+      const frameResults = {
+        [FRAME_ID]: {
+          [TAB_JSON]: { canExecute: true },
+          [TAB_VISUAL]: { canExecute: false, executionStart: 123 },
+        },
+      }
+      expect(summarizeFrame(makeFrame(), frameResults).status).toBe('unknown')
+    })
+
+    it('is ok when the JSON tab completed without error', () => {
+      const frameResults = {
+        [FRAME_ID]: {
+          [TAB_JSON]: { completed: true, response: { data: {} } },
+        },
+      }
+      expect(summarizeFrame(makeFrame(), frameResults).status).toBe('ok')
+    })
+
+    it('is error when the JSON tab completed with an error', () => {
+      const frameResults = {
+        [FRAME_ID]: {
+          [TAB_JSON]: { completed: true, error: new Error('boom') },
+        },
+      }
+      expect(summarizeFrame(makeFrame(), frameResults).status).toBe('error')
+    })
+
+    it('falls back to another completed tab when JSON tab never ran', () => {
+      const frameResults = {
+        [FRAME_ID]: {
+          [TAB_JSON]: { canExecute: true },
+          [TAB_VISUAL]: { completed: true, response: { data: {} } },
+        },
+      }
+      expect(summarizeFrame(makeFrame(), frameResults).status).toBe('ok')
+    })
+
+    it('reports an error from a fallback tab', () => {
+      const frameResults = {
+        [FRAME_ID]: {
+          [TAB_JSON]: { canExecute: true },
+          [TAB_VISUAL]: { completed: true, error: { message: 'bad' } },
+        },
+      }
+      expect(summarizeFrame(makeFrame(), frameResults).status).toBe('error')
+    })
+
+    it('prefers the JSON tab result over other completed tabs', () => {
+      const frameResults = {
+        [FRAME_ID]: {
+          [TAB_JSON]: { completed: true, error: { message: 'bad json' } },
+          [TAB_VISUAL]: { completed: true, response: { data: {} } },
+        },
+      }
+      expect(summarizeFrame(makeFrame(), frameResults).status).toBe('error')
+    })
+
+    it('ignores results belonging to other frames', () => {
+      const frameResults = {
+        'other-frame': {
+          [TAB_JSON]: { completed: true, response: { data: {} } },
+        },
+      }
+      expect(summarizeFrame(makeFrame(), frameResults).status).toBe('unknown')
+    })
+  })
+
+  describe('latencyText', () => {
+    it('formats server latency from the completed tab as milliseconds', () => {
+      const frameResults = {
+        [FRAME_ID]: {
+          [TAB_JSON]: { completed: true, serverLatencyNs: 42e6 },
+        },
+      }
+      expect(summarizeFrame(makeFrame(), frameResults).latencyText).toBe('42ms')
+    })
+
+    it('is empty when the frame never executed', () => {
+      expect(summarizeFrame(makeFrame(), {}).latencyText).toBe('')
+    })
+
+    it('is empty when server latency is missing on a completed tab', () => {
+      const frameResults = {
+        [FRAME_ID]: { [TAB_JSON]: { completed: true } },
+      }
+      expect(summarizeFrame(makeFrame(), frameResults).latencyText).toBe('')
+    })
+
+    it('is empty when server latency is zero (unknown)', () => {
+      const frameResults = {
+        [FRAME_ID]: {
+          [TAB_JSON]: { completed: true, serverLatencyNs: 0 },
+        },
+      }
+      expect(summarizeFrame(makeFrame(), frameResults).latencyText).toBe('')
+    })
+  })
+
+  describe('snippet', () => {
+    it('returns short queries unchanged', () => {
+      const frame = makeFrame({ query: '{ me { name } }' })
+      expect(summarizeFrame(frame, {}).snippet).toBe('{ me { name } }')
+    })
+
+    it('collapses newlines and extra whitespace into single spaces', () => {
+      const frame = makeFrame({ query: '{\n  me {\n    name\t }\n}' })
+      expect(summarizeFrame(frame, {}).snippet).toBe('{ me { name } }')
+    })
+
+    it('trims leading and trailing whitespace', () => {
+      const frame = makeFrame({ query: '   { me { name } }  \n' })
+      expect(summarizeFrame(frame, {}).snippet).toBe('{ me { name } }')
+    })
+
+    it('truncates long queries to the limit with an ellipsis', () => {
+      const frame = makeFrame({ query: 'x'.repeat(200) })
+      const { snippet } = summarizeFrame(frame, {})
+      expect(snippet).toBe(`${'x'.repeat(SNIPPET_MAX_LENGTH)}…`)
+      expect(snippet.length).toBe(SNIPPET_MAX_LENGTH + 1)
+    })
+
+    it('does not truncate a query exactly at the limit', () => {
+      const frame = makeFrame({ query: 'y'.repeat(SNIPPET_MAX_LENGTH) })
+      expect(summarizeFrame(frame, {}).snippet).toBe(
+        'y'.repeat(SNIPPET_MAX_LENGTH),
+      )
+    })
+
+    it('handles frames without a query', () => {
+      const frame = makeFrame({ query: undefined })
+      expect(summarizeFrame(frame, {}).snippet).toBe('')
+    })
+  })
+})
+
+describe('formatLatencyMs', () => {
+  it('formats sub-millisecond latencies with two decimals', () => {
+    expect(formatLatencyMs(450000)).toBe('0.45ms')
+  })
+
+  it('formats single-digit milliseconds with one decimal', () => {
+    expect(formatLatencyMs(1234567)).toBe('1.2ms')
+  })
+
+  it('rounds latencies of 10ms and above to whole milliseconds', () => {
+    expect(formatLatencyMs(15.6e6)).toBe('16ms')
+    expect(formatLatencyMs(1234e6)).toBe('1234ms')
+  })
+
+  it('returns empty string for missing or invalid values', () => {
+    expect(formatLatencyMs(undefined)).toBe('')
+    expect(formatLatencyMs(null)).toBe('')
+    expect(formatLatencyMs(0)).toBe('')
+    expect(formatLatencyMs(-5)).toBe('')
+    expect(formatLatencyMs(NaN)).toBe('')
+    expect(formatLatencyMs('100')).toBe('')
+  })
+})
+
+describe('filterFrames', () => {
+  const items = [
+    makeFrame({ id: 'a', query: '{ people(func: has(Name)) { name } }' }),
+    makeFrame({ id: 'b', query: 'schema {}' }),
+    makeFrame({
+      id: 'c',
+      action: 'mutate',
+      query: '{ set { _:x <name> "Alice" . } }',
+    }),
+  ]
+
+  it('returns all items for an empty search', () => {
+    expect(filterFrames(items, '')).toEqual(items)
+  })
+
+  it('returns all items for a whitespace-only search', () => {
+    expect(filterFrames(items, '   ')).toEqual(items)
+  })
+
+  it('returns all items when search is undefined', () => {
+    expect(filterFrames(items, undefined)).toEqual(items)
+  })
+
+  it('matches by case-insensitive substring', () => {
+    expect(filterFrames(items, 'NAME').map((f) => f.id)).toEqual(['a', 'c'])
+    expect(filterFrames(items, 'alice').map((f) => f.id)).toEqual(['c'])
+    expect(filterFrames(items, 'SCHEMA').map((f) => f.id)).toEqual(['b'])
+  })
+
+  it('trims the search string before matching', () => {
+    expect(filterFrames(items, '  alice  ').map((f) => f.id)).toEqual(['c'])
+  })
+
+  it('returns no items when nothing matches', () => {
+    expect(filterFrames(items, 'does-not-exist')).toEqual([])
+  })
+
+  it('skips frames without a query string', () => {
+    const withBroken = [...items, { id: 'd' }, { id: 'e', query: 42 }]
+    expect(filterFrames(withBroken, 'name').map((f) => f.id)).toEqual([
+      'a',
+      'c',
+    ])
+  })
+
+  it('handles a missing items list', () => {
+    expect(filterFrames(undefined, 'name')).toEqual([])
+    expect(filterFrames(null, '')).toEqual([])
+  })
+})

--- a/client/src/reducers/frames.js
+++ b/client/src/reducers/frames.js
@@ -53,7 +53,9 @@ export default (state = defaultState, action) =>
             draft.items.shift()
           }
         }
-        draft.items.unshift(frame)
+        // Stamp arrival time so run history can show relative times.
+        // Legacy frames (restored from older persisted state) may lack it.
+        draft.items.unshift({ createdAt: Date.now(), ...frame })
         draft.frameResults[frame.id] = {
           [TAB_JSON]: { canExecute: true },
           [TAB_VISUAL]: { canExecute: true },


### PR DESCRIPTION
## What

A **History** button in the editor toolbar opens a searchable panel of past runs (like Memgraph Lab's Run History), newest first. Each row shows:

- action icon (query vs mutate, matching the existing QueryPreview icons),
- a status dot — green (completed without error), red (error), gray (never executed this session),
- a one-line monospace query snippet (whitespace-collapsed, 60-char ellipsis),
- server latency (formatted as ms) and relative time (`react-timeago`, already a dependency).

A search input filters rows by case-insensitive substring; clicking a row loads that query into the editor and activates the frame (same dispatches the existing history strip uses). Closes on outside click and Escape; the active frame's row is highlighted.

## Implementation notes

- Pure helpers in `lib/runHistory.js` (`summarizeFrame`, `filterFrames`, `formatLatencyMs`) — status prefers the JSON tab result and falls back to any completed tab, so a query run only on the Visual tab still shows green/red.
- `RECEIVE_FRAME` now stamps `createdAt` (preserved if already present); legacy persisted frames without it fall back to the existing `timestamp` field or omit the time.
- The existing minimal history strip under the editor is left in place; this panel augments it.

## Testing

31 unit tests on the helpers (status across tab results, latency formatting, snippet truncation, filtering). `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added run history access to the editor, including searchable runs, execution status, latency, timestamps, and query previews.
  * Select a previous run to restore its query and actions.
  * Run history panels reposition automatically and can be closed with outside clicks or Escape.

* **UI Improvements**
  * Improved editor header layout with responsive wrapping and alignment for action controls.

* **Bug Fixes**
  * Preserved compatibility with restored runs that do not include timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->