### PR TITLE
feat: support Zero --security auth token for moveTablet and removeNode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apk update && apk upgrade --no-cache && apk --no-cache --virtual build-depen
 # build package manifest layer
 RUN mkdir -p /ratel/client
 WORKDIR /ratel/client
-COPY ./client/package.json /ratel/client
-RUN npm install --legacy-peer-deps
+COPY ./client/package.json ./client/package-lock.json /ratel/client/
+RUN npm ci --legacy-peer-deps
 
 # copy all assets and build
 COPY . /ratel

--- a/client/src/actions/connection.js
+++ b/client/src/actions/connection.js
@@ -32,6 +32,7 @@ export const UPDATE_NETWORK_HEALTH = 'connection/UPDATE_NETWORK_HEALTH'
 export const UPDATE_SERVER_HEALTH = 'connection/UPDATE_SERVER_HEALTH'
 export const UPDATE_SERVER_VERSION = 'connection/UPDATE_SERVER_VERSION'
 export const UPDATE_ZERO_URL = 'connection/UPDATE_ZERO_URL'
+export const UPDATE_ZERO_AUTH_TOKEN = 'connection/UPDATE_ZERO_AUTH_TOKEN'
 
 export const DISMISS_LICENSE_WARNING = 'connection/DISMISS_LICENSE_WARNING'
 
@@ -131,6 +132,11 @@ export const removeUrl = (url) => async (dispatch, getState) => {
 export const updateZeroUrl = (zeroUrl) => ({
   type: UPDATE_ZERO_URL,
   zeroUrl,
+})
+
+export const updateZeroAuthToken = (zeroAuthToken) => ({
+  type: UPDATE_ZERO_AUTH_TOKEN,
+  zeroAuthToken,
 })
 
 export const checkNetworkHealth = async (dispatch, getState) => {

--- a/client/src/components/Cluster/MoveTabletModal.js
+++ b/client/src/components/Cluster/MoveTabletModal.js
@@ -9,7 +9,7 @@ import Form from 'react-bootstrap/Form'
 import Modal from 'react-bootstrap/Modal'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { updateZeroAuthToken, updateZeroUrl } from 'actions/connection'
+import { updateZeroUrl } from 'actions/connection'
 import { humanizeBytes, sanitizeUrl } from 'lib/helpers'
 import { getSpace } from 'lib/utils'
 
@@ -22,9 +22,6 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
 
   const [zeroUrlInput, setZeroUrl] = useState(
     currentServer.zeroUrl || 'http://localhost:6080',
-  )
-  const [zeroAuthTokenInput, setZeroAuthToken] = useState(
-    currentServer.zeroAuthToken || '',
   )
 
   const [targetGroup, setTargetGroup] = useState(
@@ -42,10 +39,6 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
     dispatch(updateZeroUrl(saneZeroUrl))
   }, [saneZeroUrl, dispatch])
 
-  useEffect(() => {
-    dispatch(updateZeroAuthToken(zeroAuthTokenInput))
-  }, [zeroAuthTokenInput, dispatch])
-
   // /moveTablet?tablet=name&group=2
   // tablet keys are in format "namespace-predicate", strip the namespace prefix
   const tabletName = tablet.replace(/^\d+-/, '')
@@ -57,7 +50,9 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
   const executeRequest = async () => {
     setActionStarted(true)
     setRequestResult({ pending: true })
-    setRequestResult(await fetchZeroEndpoint(getUrl(), zeroAuthTokenInput))
+    setRequestResult(
+      await fetchZeroEndpoint(getUrl(), currentServer.zeroAuthToken),
+    )
   }
 
   const humanizeGroupSize = (group) => {
@@ -108,21 +103,6 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
             value={zeroUrlInput}
             onChange={(e) => setZeroUrl(e.target.value)}
           />
-        </Form.Group>
-        <Form.Group controlId='zeroAuthTokenInput'>
-          <Form.Label>Zero Auth Token (optional):</Form.Label>
-          <Form.Control
-            type='password'
-            autoComplete='off'
-            placeholder='Token from Zero --security flag'
-            value={zeroAuthTokenInput}
-            onChange={(e) => setZeroAuthToken(e.target.value)}
-          />
-          <Form.Text className='text-muted'>
-            Sent as the X-Dgraph-AuthToken header. Required when Zero is running
-            with a --security token and this browser&apos;s machine is not in
-            its IP whitelist.
-          </Form.Text>
         </Form.Group>
         <Form.Label>
           <br />

--- a/client/src/components/Cluster/MoveTabletModal.js
+++ b/client/src/components/Cluster/MoveTabletModal.js
@@ -9,9 +9,11 @@ import Form from 'react-bootstrap/Form'
 import Modal from 'react-bootstrap/Modal'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { updateZeroUrl } from 'actions/connection'
+import { updateZeroAuthToken, updateZeroUrl } from 'actions/connection'
 import { humanizeBytes, sanitizeUrl } from 'lib/helpers'
 import { getSpace } from 'lib/utils'
+
+import ZeroRequestResult, { fetchZeroEndpoint } from './ZeroRequestResult'
 
 export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
   const currentServer = useSelector(
@@ -21,6 +23,9 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
   const [zeroUrlInput, setZeroUrl] = useState(
     currentServer.zeroUrl || 'http://localhost:6080',
   )
+  const [zeroAuthTokenInput, setZeroAuthToken] = useState(
+    currentServer.zeroAuthToken || '',
+  )
 
   const [targetGroup, setTargetGroup] = useState(
     Object.keys(groups)[0] !== fromGroup
@@ -28,6 +33,7 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
       : Object.keys(groups)[1],
   )
   const [actionStarted, setActionStarted] = useState(false)
+  const [requestResult, setRequestResult] = useState(undefined)
 
   const dispatch = useDispatch()
   const saneZeroUrl = sanitizeUrl(zeroUrlInput)
@@ -35,6 +41,10 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
   useEffect(() => {
     dispatch(updateZeroUrl(saneZeroUrl))
   }, [saneZeroUrl, dispatch])
+
+  useEffect(() => {
+    dispatch(updateZeroAuthToken(zeroAuthTokenInput))
+  }, [zeroAuthTokenInput, dispatch])
 
   // /moveTablet?tablet=name&group=2
   // tablet keys are in format "namespace-predicate", strip the namespace prefix
@@ -44,6 +54,12 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
       tabletName,
     )}&group=${targetGroup}`
 
+  const executeRequest = async () => {
+    setActionStarted(true)
+    setRequestResult({ pending: true })
+    setRequestResult(await fetchZeroEndpoint(getUrl(), zeroAuthTokenInput))
+  }
+
   const humanizeGroupSize = (group) => {
     const space = Object.values(group.tablets || {}).reduce(
       (acc, t) => acc + parseInt(getSpace(t) || 0),
@@ -51,6 +67,10 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
     )
     return space ? ` (${humanizeBytes(space)})` : ''
   }
+
+  const canRetry =
+    !actionStarted ||
+    (requestResult && !requestResult.pending && !requestResult.ok)
 
   return (
     <Modal centered show={true} size='md' onHide={onHide}>
@@ -89,28 +109,30 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
             onChange={(e) => setZeroUrl(e.target.value)}
           />
         </Form.Group>
+        <Form.Group controlId='zeroAuthTokenInput'>
+          <Form.Label>Zero Auth Token (optional):</Form.Label>
+          <Form.Control
+            type='password'
+            autoComplete='off'
+            placeholder='Token from Zero --security flag'
+            value={zeroAuthTokenInput}
+            onChange={(e) => setZeroAuthToken(e.target.value)}
+          />
+          <Form.Text className='text-muted'>
+            Sent as the X-Dgraph-AuthToken header. Required when Zero is running
+            with a --security token and this machine is not in its IP whitelist.
+          </Form.Text>
+        </Form.Group>
         <Form.Label>
           <br />
           Command URL:
           <br />
-          <strong>
-            <a href={getUrl()} target='_blank' rel='noopener noreferrer'>
-              {getUrl()}
-            </a>
-          </strong>
+          <strong>{getUrl()}</strong>
         </Form.Label>
-        {actionStarted && (
-          <iframe
-            title={getUrl()}
-            src={getUrl()}
-            width='100%'
-            height='90px'
-            style={{ backgroundColor: 'rgba(30, 96, 119, 0.25)' }}
-          ></iframe>
-        )}
+        {actionStarted && <ZeroRequestResult result={requestResult} />}
       </Modal.Body>
       <Modal.Footer>
-        {!actionStarted ? (
+        {canRetry && (
           <Button
             onClick={() => {
               if (
@@ -121,15 +143,16 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
                 return
               }
 
-              setActionStarted(true)
+              executeRequest()
             }}
             variant='secondary'
             className='pull-right'
             disabled={!targetGroup || fromGroup === targetGroup}
           >
-            Move Tablet
+            {actionStarted ? 'Retry' : 'Move Tablet'}
           </Button>
-        ) : (
+        )}
+        {actionStarted && (
           <Button onClick={onHide} variant='primary' className='pull-right'>
             Close
           </Button>

--- a/client/src/components/Cluster/MoveTabletModal.js
+++ b/client/src/components/Cluster/MoveTabletModal.js
@@ -120,7 +120,8 @@ export default function MoveTabletModal({ fromGroup, tablet, groups, onHide }) {
           />
           <Form.Text className='text-muted'>
             Sent as the X-Dgraph-AuthToken header. Required when Zero is running
-            with a --security token and this machine is not in its IP whitelist.
+            with a --security token and this browser&apos;s machine is not in
+            its IP whitelist.
           </Form.Text>
         </Form.Group>
         <Form.Label>

--- a/client/src/components/Cluster/RemoveNodeModal.js
+++ b/client/src/components/Cluster/RemoveNodeModal.js
@@ -9,7 +9,7 @@ import Form from 'react-bootstrap/Form'
 import Modal from 'react-bootstrap/Modal'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { updateZeroAuthToken, updateZeroUrl } from 'actions/connection'
+import { updateZeroUrl } from 'actions/connection'
 import { sanitizeUrl } from 'lib/helpers'
 
 import ZeroRequestResult, { fetchZeroEndpoint } from './ZeroRequestResult'
@@ -22,9 +22,6 @@ export default function RemoveNodeModal({ groupId, nodeId, onHide }) {
   const [zeroUrlInput, setZeroUrl] = useState(
     currentServer.zeroUrl || 'http://localhost:6080',
   )
-  const [zeroAuthTokenInput, setZeroAuthToken] = useState(
-    currentServer.zeroAuthToken || '',
-  )
 
   const dispatch = useDispatch()
   const saneZeroUrl = sanitizeUrl(zeroUrlInput)
@@ -32,10 +29,6 @@ export default function RemoveNodeModal({ groupId, nodeId, onHide }) {
   useEffect(() => {
     dispatch(updateZeroUrl(saneZeroUrl))
   }, [saneZeroUrl, dispatch])
-
-  useEffect(() => {
-    dispatch(updateZeroAuthToken(zeroAuthTokenInput))
-  }, [zeroAuthTokenInput, dispatch])
 
   const [removalStarted, setRemovalStarted] = useState(false)
   const [requestResult, setRequestResult] = useState(undefined)
@@ -46,7 +39,9 @@ export default function RemoveNodeModal({ groupId, nodeId, onHide }) {
   const executeRequest = async () => {
     setRemovalStarted(true)
     setRequestResult({ pending: true })
-    setRequestResult(await fetchZeroEndpoint(getUrl(), zeroAuthTokenInput))
+    setRequestResult(
+      await fetchZeroEndpoint(getUrl(), currentServer.zeroAuthToken),
+    )
   }
 
   const canRetry =
@@ -71,21 +66,6 @@ export default function RemoveNodeModal({ groupId, nodeId, onHide }) {
             value={zeroUrlInput}
             onChange={(e) => setZeroUrl(e.target.value)}
           />
-        </Form.Group>
-        <Form.Group controlId='zeroAuthTokenInput'>
-          <Form.Label>Zero Auth Token (optional):</Form.Label>
-          <Form.Control
-            type='password'
-            autoComplete='off'
-            placeholder='Token from Zero --security flag'
-            value={zeroAuthTokenInput}
-            onChange={(e) => setZeroAuthToken(e.target.value)}
-          />
-          <Form.Text className='text-muted'>
-            Sent as the X-Dgraph-AuthToken header. Required when Zero is running
-            with a --security token and this browser&apos;s machine is not in
-            its IP whitelist.
-          </Form.Text>
         </Form.Group>
         <Form.Label>
           <br />

--- a/client/src/components/Cluster/RemoveNodeModal.js
+++ b/client/src/components/Cluster/RemoveNodeModal.js
@@ -83,7 +83,8 @@ export default function RemoveNodeModal({ groupId, nodeId, onHide }) {
           />
           <Form.Text className='text-muted'>
             Sent as the X-Dgraph-AuthToken header. Required when Zero is running
-            with a --security token and this machine is not in its IP whitelist.
+            with a --security token and this browser&apos;s machine is not in
+            its IP whitelist.
           </Form.Text>
         </Form.Group>
         <Form.Label>

--- a/client/src/components/Cluster/RemoveNodeModal.js
+++ b/client/src/components/Cluster/RemoveNodeModal.js
@@ -9,8 +9,10 @@ import Form from 'react-bootstrap/Form'
 import Modal from 'react-bootstrap/Modal'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { updateZeroUrl } from 'actions/connection'
+import { updateZeroAuthToken, updateZeroUrl } from 'actions/connection'
 import { sanitizeUrl } from 'lib/helpers'
+
+import ZeroRequestResult, { fetchZeroEndpoint } from './ZeroRequestResult'
 
 export default function RemoveNodeModal({ groupId, nodeId, onHide }) {
   const currentServer = useSelector(
@@ -20,6 +22,9 @@ export default function RemoveNodeModal({ groupId, nodeId, onHide }) {
   const [zeroUrlInput, setZeroUrl] = useState(
     currentServer.zeroUrl || 'http://localhost:6080',
   )
+  const [zeroAuthTokenInput, setZeroAuthToken] = useState(
+    currentServer.zeroAuthToken || '',
+  )
 
   const dispatch = useDispatch()
   const saneZeroUrl = sanitizeUrl(zeroUrlInput)
@@ -28,10 +33,25 @@ export default function RemoveNodeModal({ groupId, nodeId, onHide }) {
     dispatch(updateZeroUrl(saneZeroUrl))
   }, [saneZeroUrl, dispatch])
 
+  useEffect(() => {
+    dispatch(updateZeroAuthToken(zeroAuthTokenInput))
+  }, [zeroAuthTokenInput, dispatch])
+
   const [removalStarted, setRemovalStarted] = useState(false)
+  const [requestResult, setRequestResult] = useState(undefined)
 
   const getUrl = () =>
     `${sanitizeUrl(zeroUrlInput)}/removeNode?id=${nodeId}&group=${groupId}`
+
+  const executeRequest = async () => {
+    setRemovalStarted(true)
+    setRequestResult({ pending: true })
+    setRequestResult(await fetchZeroEndpoint(getUrl(), zeroAuthTokenInput))
+  }
+
+  const canRetry =
+    !removalStarted ||
+    (requestResult && !requestResult.pending && !requestResult.ok)
 
   return (
     <Modal centered show={true} size='md' onHide={onHide}>
@@ -52,28 +72,30 @@ export default function RemoveNodeModal({ groupId, nodeId, onHide }) {
             onChange={(e) => setZeroUrl(e.target.value)}
           />
         </Form.Group>
+        <Form.Group controlId='zeroAuthTokenInput'>
+          <Form.Label>Zero Auth Token (optional):</Form.Label>
+          <Form.Control
+            type='password'
+            autoComplete='off'
+            placeholder='Token from Zero --security flag'
+            value={zeroAuthTokenInput}
+            onChange={(e) => setZeroAuthToken(e.target.value)}
+          />
+          <Form.Text className='text-muted'>
+            Sent as the X-Dgraph-AuthToken header. Required when Zero is running
+            with a --security token and this machine is not in its IP whitelist.
+          </Form.Text>
+        </Form.Group>
         <Form.Label>
           <br />
           Removal URL:
           <br />
-          <strong>
-            <a href={getUrl()} target='_blank' rel='noopener noreferrer'>
-              {getUrl()}
-            </a>
-          </strong>
+          <strong>{getUrl()}</strong>
         </Form.Label>
-        {removalStarted && (
-          <iframe
-            title={getUrl()}
-            src={getUrl()}
-            width='100%'
-            height='90px'
-            style={{ backgroundColor: 'rgba(30, 96, 119, 0.25)' }}
-          ></iframe>
-        )}
+        {removalStarted && <ZeroRequestResult result={requestResult} />}
       </Modal.Body>
       <Modal.Footer>
-        {!removalStarted ? (
+        {canRetry && (
           <Button
             onClick={() => {
               if (
@@ -90,14 +112,15 @@ export default function RemoveNodeModal({ groupId, nodeId, onHide }) {
               ) {
                 return
               }
-              setRemovalStarted(true)
+              executeRequest()
             }}
             variant='danger'
             className='pull-right'
           >
-            Remove Node
+            {removalStarted ? 'Retry' : 'Remove Node'}
           </Button>
-        ) : (
+        )}
+        {removalStarted && (
           <Button onClick={onHide} variant='primary' className='pull-right'>
             Close
           </Button>

--- a/client/src/components/Cluster/ZeroRequestResult.js
+++ b/client/src/components/Cluster/ZeroRequestResult.js
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react'
+
+// Calls a Dgraph Zero admin endpoint (e.g. /moveTablet, /removeNode),
+// attaching the X-Dgraph-AuthToken header when a token is configured.
+// Returns a result object for <ZeroRequestResult />.
+export async function fetchZeroEndpoint(url, authToken) {
+  const headers = {}
+  if (authToken) {
+    headers['X-Dgraph-AuthToken'] = authToken
+  }
+  try {
+    const res = await fetch(url, { headers })
+    const text = await res.text()
+    return { ok: res.ok, status: res.status, text }
+  } catch (err) {
+    return { ok: false, text: err.message || String(err) }
+  }
+}
+
+export default function ZeroRequestResult({ result }) {
+  if (!result) {
+    return null
+  }
+
+  const backgroundColor = result.pending
+    ? 'rgba(30, 96, 119, 0.25)'
+    : result.ok
+      ? 'rgba(30, 119, 60, 0.25)'
+      : 'rgba(119, 30, 30, 0.25)'
+
+  return (
+    <div style={{ backgroundColor, borderRadius: '4px', padding: '8px' }}>
+      {result.pending ? (
+        'Sending request...'
+      ) : (
+        <>
+          <strong>
+            {result.status ? `HTTP ${result.status}` : 'Request failed'}
+          </strong>
+          <pre
+            style={{
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              marginBottom: 0,
+            }}
+          >
+            {result.text}
+          </pre>
+        </>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/ZeroUrlWidget.js
+++ b/client/src/components/ZeroUrlWidget.js
@@ -20,13 +20,16 @@ export default function ZeroUrlWidget() {
     currentServer.zeroAuthToken || '',
   )
 
+  // Reset the inputs when the active server changes while this tab stays
+  // mounted — otherwise the previous server's values linger and typing
+  // would write them onto the new server's record. Keyed on url alone:
+  // syncing on the value fields would clobber in-progress typing, since
+  // the reducer stores a sanitized form of the url.
   useEffect(() => {
-    dispatch(updateZeroUrl(zeroUrl))
-  }, [zeroUrl, dispatch])
-
-  useEffect(() => {
-    dispatch(updateZeroAuthToken(zeroAuthToken))
-  }, [zeroAuthToken, dispatch])
+    setZeroUrl(currentServer.zeroUrl)
+    setZeroAuthToken(currentServer.zeroAuthToken || '')
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentServer.url])
 
   return (
     <Form onSubmit={(e) => e.preventDefault()}>
@@ -36,7 +39,10 @@ export default function ZeroUrlWidget() {
           type='text'
           placeholder='http://myzero:6080'
           value={zeroUrl}
-          onChange={(e) => setZeroUrl(e.target.value)}
+          onChange={(e) => {
+            setZeroUrl(e.target.value)
+            dispatch(updateZeroUrl(e.target.value))
+          }}
           style={{
             width: '100%',
           }}
@@ -49,7 +55,10 @@ export default function ZeroUrlWidget() {
           autoComplete='off'
           placeholder='Token from Zero --security flag'
           value={zeroAuthToken}
-          onChange={(e) => setZeroAuthToken(e.target.value)}
+          onChange={(e) => {
+            setZeroAuthToken(e.target.value)
+            dispatch(updateZeroAuthToken(e.target.value))
+          }}
           style={{
             width: '100%',
           }}

--- a/client/src/components/ZeroUrlWidget.js
+++ b/client/src/components/ZeroUrlWidget.js
@@ -57,7 +57,7 @@ export default function ZeroUrlWidget() {
         <Form.Text className='text-muted'>
           Sent as the X-Dgraph-AuthToken header on Zero admin requests (move
           tablet, remove node). Required when Zero is running with a --security
-          token and this machine is not in its IP whitelist.
+          token and this browser&apos;s machine is not in its IP whitelist.
         </Form.Text>
       </Form.Group>
     </Form>

--- a/client/src/components/ZeroUrlWidget.js
+++ b/client/src/components/ZeroUrlWidget.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Form from 'react-bootstrap/Form'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { updateZeroUrl } from 'actions/connection'
+import { updateZeroAuthToken, updateZeroUrl } from 'actions/connection'
 
 export default function ZeroUrlWidget() {
   const currentServer = useSelector(
@@ -16,6 +16,17 @@ export default function ZeroUrlWidget() {
   const dispatch = useDispatch()
 
   const [zeroUrl, setZeroUrl] = useState(currentServer.zeroUrl)
+  const [zeroAuthToken, setZeroAuthToken] = useState(
+    currentServer.zeroAuthToken || '',
+  )
+
+  useEffect(() => {
+    dispatch(updateZeroUrl(zeroUrl))
+  }, [zeroUrl, dispatch])
+
+  useEffect(() => {
+    dispatch(updateZeroAuthToken(zeroAuthToken))
+  }, [zeroAuthToken, dispatch])
 
   return (
     <Form onSubmit={(e) => e.preventDefault()}>
@@ -25,14 +36,29 @@ export default function ZeroUrlWidget() {
           type='text'
           placeholder='http://myzero:6080'
           value={zeroUrl}
-          onChange={(e) => {
-            dispatch(updateZeroUrl(zeroUrl))
-            setZeroUrl(e.target.value)
-          }}
+          onChange={(e) => setZeroUrl(e.target.value)}
           style={{
             width: '100%',
           }}
         />
+      </Form.Group>
+      <Form.Group controlId='zeroAuthToken'>
+        <Form.Label>Zero Auth Token (optional):</Form.Label>
+        <Form.Control
+          type='password'
+          autoComplete='off'
+          placeholder='Token from Zero --security flag'
+          value={zeroAuthToken}
+          onChange={(e) => setZeroAuthToken(e.target.value)}
+          style={{
+            width: '100%',
+          }}
+        />
+        <Form.Text className='text-muted'>
+          Sent as the X-Dgraph-AuthToken header on Zero admin requests (move
+          tablet, remove node). Required when Zero is running with a --security
+          token and this machine is not in its IP whitelist.
+        </Form.Text>
       </Form.Group>
     </Form>
   )

--- a/client/src/containers/AppProvider.js
+++ b/client/src/containers/AppProvider.js
@@ -16,6 +16,7 @@ import {
   setAuthToken,
   setSlashApiKey,
   updateUrl,
+  updateZeroAuthToken,
 } from 'actions/connection'
 import { runQuery, setResultsTab } from 'actions/frames'
 import {
@@ -116,6 +117,9 @@ export default class AppProvider extends React.Component {
       store.dispatch(
         setAuthToken(hashParams.addr || addrParam, hashParams.authToken),
       )
+    }
+    if (hashParams.zeroAuthToken) {
+      store.dispatch(updateZeroAuthToken(hashParams.zeroAuthToken))
     }
     if (hashParams.query) {
       store.dispatch(updateAction('query'))

--- a/client/src/reducers/connection.js
+++ b/client/src/reducers/connection.js
@@ -25,6 +25,7 @@ import {
   UPDATE_SERVER_HEALTH,
   UPDATE_SERVER_VERSION,
   UPDATE_URL,
+  UPDATE_ZERO_AUTH_TOKEN,
   UPDATE_ZERO_URL,
 } from 'actions/connection'
 import {
@@ -270,6 +271,10 @@ export default (state = defaultState, action) =>
 
       case UPDATE_ZERO_URL:
         currentServer.zeroUrl = sanitizeUrl(action.zeroUrl)
+        break
+
+      case UPDATE_ZERO_AUTH_TOKEN:
+        currentServer.zeroAuthToken = action.zeroAuthToken
         break
 
       case DISMISS_LICENSE_WARNING:


### PR DESCRIPTION
## Summary

Zero is gaining the same `--security` superflag as Alpha (token + IP whitelist gating its admin HTTP endpoints, see GHSA-qj98-gp63-54xj). This PR updates Ratel so the move-tablet and remove-node features can authenticate against a secured Zero.

- Move Tablet and Remove Node now call `/moveTablet` and `/removeNode` with `fetch()`, sending the token in the `X-Dgraph-AuthToken` header, and render the response status and body inline with a Retry button on failure
- New **Zero Auth Token (optional)** field on the Dgraph Zero tab of the Server Connection dialog, persisted per server alongside the Zero URL (also settable via the `zeroAuthToken` URL hash param for embedders)
- Docker client build now copies `package-lock.json` and uses `npm ci`, so image builds install the locked dependency tree

## Why the transport changed

The old modals executed the Zero call by pointing an `<iframe>` at the URL. Browser navigations can't attach custom headers, so there was no way to send `X-Dgraph-AuthToken` with that mechanism. The switch to `fetch()` also means we can show a real HTTP status instead of whatever the iframe loads. Note this makes the call a cross-origin request with a custom header, so it depends on Zero answering `OPTIONS` on these endpoints the same way Alpha does (confirmed in the upcoming release).

The token is optional. When it's blank, requests are sent with no header and behavior against unsecured Zeros is unchanged.

## Included build fix

A fresh `npm install` in the Docker build started pulling react-draggable 4.7.1 (matches `^4.4.5`), which ships a strict-ESM bundler entry that webpack 5 rejects. The client build stage previously ignored the committed lockfile; it now uses `npm ci` so image builds are reproducible. This same commit rides on the `make test` repair branch since both need a working image build; whichever merges second is a no-op.

## Testing

- Manual: ran the built image against a local cluster, verified the token field persists, prefills both modals, and that move-tablet/remove-node succeed with a valid token and show the error response with Retry on a bad one
- `npm run build` and the full Docker `make build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/ratel/pr/426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787948264&installation_model_id=8575&pr_number=426&repository=dgraph-io%2Fratel&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fratel%2Fpull%2F426&signature=a4dc7921f5a6e4ba4144a444730feaad674253f7803cfd0986fdab1180a0eddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->