### PR TITLE
feat: integrate visual DQL query builder into Console

### DIFF
--- a/client/config/webpack.config.dev.js
+++ b/client/config/webpack.config.dev.js
@@ -313,6 +313,8 @@ module.exports = function (webpackEnv) {
         // Support React Native Web
         // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
         'react-native': 'react-native-web',
+        // Webpack 5 + ESM (.mjs) requires the explicit .js extension.
+        'process/browser': require.resolve('process/browser.js'),
         // Allows for better profiling with ReactDevTools
         ...(isEnvProductionProfile && {
           'react-dom$': 'react-dom/profiling',
@@ -346,6 +348,14 @@ module.exports = function (webpackEnv) {
     module: {
       strictExportPresence: true,
       rules: [
+        // Newer packages (e.g. react-draggable) ship .mjs that request
+        // `process/browser` without an extension; allow webpack to resolve them.
+        {
+          test: /\.m?js$/,
+          resolve: {
+            fullySpecified: false,
+          },
+        },
         {
           // "oneOf" will traverse all following loaders until one will
           // match the requirements. When no loader matches it will fall
@@ -594,7 +604,7 @@ module.exports = function (webpackEnv) {
       new webpack.DefinePlugin(env.stringified),
       // Provide process and Buffer globals for packages that expect them
       new webpack.ProvidePlugin({
-        process: 'process/browser',
+        process: require.resolve('process/browser.js'),
         Buffer: ['buffer', 'Buffer'],
       }),
       // This is necessary to emit hot updates (CSS and Fast Refresh):

--- a/client/config/webpack.config.js
+++ b/client/config/webpack.config.js
@@ -201,6 +201,8 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      // Webpack 5 + ESM (.mjs) requires the explicit .js extension.
+      'process/browser': require.resolve('process/browser.js'),
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).
@@ -228,6 +230,14 @@ module.exports = {
   module: {
     strictExportPresence: true,
     rules: [
+      // Newer packages (e.g. react-draggable) ship .mjs that request
+      // `process/browser` without an extension; allow webpack to resolve them.
+      {
+        test: /\.m?js$/,
+        resolve: {
+          fullySpecified: false,
+        },
+      },
       {
         // "oneOf" will traverse all following loaders until one will
         // match the requirements. When no loader matches it will fall
@@ -425,7 +435,7 @@ module.exports = {
     new webpack.DefinePlugin(env.stringified),
     // Provide process and Buffer globals for packages that expect them
     new webpack.ProvidePlugin({
-      process: 'process/browser',
+      process: require.resolve('process/browser.js'),
       Buffer: ['buffer', 'Buffer'],
     }),
     new MiniCssExtractPlugin({

--- a/client/src/assets/css/EditorPanel.scss
+++ b/client/src/assets/css/EditorPanel.scss
@@ -9,6 +9,57 @@
     flex: 1;
   }
 
+  &.editor-panel-builder {
+    .builder-console-layout {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .builder-canvas-pane {
+      flex: 1 1 58%;
+      min-height: 260px;
+      overflow: hidden;
+      border-bottom: 1px solid #d2d2d2;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .builder-query-pane {
+      flex: 0 0 42%;
+      min-height: 180px;
+      max-height: 45%;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      background: #fff;
+
+      .builder-query-label {
+        flex-shrink: 0;
+        padding: 6px 10px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #666;
+        background: #fff;
+        border-bottom: 1px solid #d2d2d2;
+      }
+
+      .editor-outer {
+        flex: 1;
+        min-height: 0;
+      }
+    }
+
+    .query-builder-view {
+      flex: 1;
+      min-height: 0;
+    }
+  }
+
   .header {
     border-bottom: 1px solid #d2d2d2;
     background-color: #fff;

--- a/client/src/components/EditorPanel.js
+++ b/client/src/components/EditorPanel.js
@@ -4,7 +4,7 @@
  */
 
 import classnames from 'classnames'
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import Dropdown from 'react-bootstrap/Dropdown'
 import DropdownButton from 'react-bootstrap/DropdownButton'
 import { useDispatch, useSelector } from 'react-redux'
@@ -18,28 +18,83 @@ import {
   updateReadOnly,
 } from 'actions/query'
 
+import QueryBuilder from 'components/QueryBuilder'
 import QueryVarsEditor from 'components/QueryVarsEditor'
 import Editor from 'containers/Editor'
 
 import '../assets/css/EditorPanel.scss'
+
+function looksLikeBuilderDql(text) {
+  return /\bquery\s+[A-Za-z_][A-Za-z0-9_]*/i.test(String(text || ''))
+}
 
 export default function EditorPanel() {
   const dispatch = useDispatch()
   const { action, query, queryVars, bestEffort, readOnly } = useSelector(
     (state) => state.query,
   )
+  const [mode, setMode] = useState(action === 'mutate' ? 'mutate' : 'query')
+  const builderRef = useRef(null)
+  const importTimerRef = useRef(null)
+
+  useEffect(
+    () => () => {
+      clearTimeout(importTimerRef.current)
+    },
+    [],
+  )
 
   const setReadOnly = (value) => dispatch(updateReadOnly(value))
   const setBestEffort = (value) => dispatch(updateBestEffort(value))
 
   const onClearQuery = () => {
+    if (mode === 'builder') {
+      builderRef.current?.clear?.()
+      return
+    }
     dispatch(updateQuery(''))
     dispatch(updateQueryVars([]))
   }
-  const onUpdateQuery = (query) => dispatch(updateQuery(query))
-  const onUpdateAction = (action) => dispatch(updateAction(action))
 
-  const onRunCurrentQuery = () =>
+  const onUpdateQuery = (next) => {
+    dispatch(updateQuery(next))
+    if (mode !== 'builder') {
+      return
+    }
+    // Debounce canvas updates so incomplete typing doesn't thrash / fail-parse,
+    // and so a successful re-parse doesn't rewrite the editor mid-keystroke.
+    clearTimeout(importTimerRef.current)
+    importTimerRef.current = setTimeout(() => {
+      const text = String(next || '').trim()
+      if (!text) {
+        builderRef.current?.clear?.()
+        return
+      }
+      if (looksLikeBuilderDql(text)) {
+        builderRef.current?.importQuery?.(next)
+      }
+    }, 400)
+  }
+
+  const selectMode = (nextMode) => {
+    setMode(nextMode)
+    if (nextMode === 'mutate') {
+      dispatch(updateAction('mutate'))
+    } else {
+      dispatch(updateAction('query'))
+    }
+  }
+
+  const onRunCurrentQuery = () => {
+    if (mode === 'builder') {
+      // Flush any pending editor→canvas sync before running.
+      clearTimeout(importTimerRef.current)
+      if (looksLikeBuilderDql(query)) {
+        builderRef.current?.importQuery?.(query)
+      }
+      builderRef.current?.run?.()
+      return
+    }
     dispatch(
       runQuery(query, action, {
         bestEffort,
@@ -47,20 +102,22 @@ export default function EditorPanel() {
         queryVars: action === 'query' ? queryVars : undefined,
       }),
     )
+  }
 
-  const renderRadioBtn = (action, title, selectedAction, onUpdateAction) => (
+  const renderModeBtn = (id, title) => (
     <button
       className='action actionable'
-      onClick={() => onUpdateAction(action)}
+      onClick={() => selectMode(id)}
+      type='button'
     >
       <label className='editor-label'>
         <input
           className='editor-type'
           type='radio'
-          name='action'
-          value={action}
-          checked={selectedAction === action}
-          onChange={() => onUpdateAction(action)}
+          name='editor-mode'
+          value={id}
+          checked={mode === id}
+          onChange={() => selectMode(id)}
         />
         &nbsp;
         {title}
@@ -69,39 +126,44 @@ export default function EditorPanel() {
   )
 
   const isQueryDirty = query.trim() !== ''
-  const hasQueryVars = action === 'query' && queryVars?.length
+  const hasQueryVars = mode !== 'mutate' && queryVars?.length
 
-  // Query options only appear if current mode is query
-  const queryOptions = action === 'query' && (
+  const queryOptions = mode !== 'mutate' && (
     <DropdownButton
       id='query-sliders-dropdown'
       className='action actionable'
       title={<i className='fas fa-sliders-h' />}
     >
       <Dropdown.Item onClick={() => setReadOnly(!readOnly)}>
-        <input type='checkbox' checked={readOnly} /> Read Only
+        <input type='checkbox' checked={readOnly} readOnly /> Read Only
       </Dropdown.Item>
       <Dropdown.Item
         onClick={() => setBestEffort(!bestEffort)}
         disabled={!readOnly}
       >
-        <input type='checkbox' checked={bestEffort} /> Best Effort
+        <input type='checkbox' checked={bestEffort} readOnly /> Best Effort
       </Dropdown.Item>
     </DropdownButton>
   )
 
   return (
-    <div className='editor-panel'>
+    <div
+      className={classnames('editor-panel', {
+        'editor-panel-builder': mode === 'builder',
+      })}
+    >
       <div className='header'>
         <div className='actions'>
-          {renderRadioBtn('query', 'Query', action, onUpdateAction)}
-          {renderRadioBtn('mutate', 'Mutate', action, onUpdateAction)}
+          {renderModeBtn('query', 'Query')}
+          {renderModeBtn('mutate', 'Mutate')}
+          {renderModeBtn('builder', 'Builder')}
         </div>
 
         {queryOptions}
 
         <div className='actions right'>
           <button
+            type='button'
             className={classnames('action', {
               actionable: isQueryDirty || hasQueryVars,
             })}
@@ -110,14 +172,14 @@ export default function EditorPanel() {
             <i className='fa fa-times' /> Clear
           </button>
           <button
+            type='button'
             className={classnames('action', {
               actionable: isQueryDirty,
             })}
             onClick={() => {
-              if (query === '') {
+              if (mode !== 'builder' && query === '') {
                 return
               }
-
               onRunCurrentQuery()
             }}
           >
@@ -126,13 +188,33 @@ export default function EditorPanel() {
         </div>
       </div>
 
-      <Editor
-        onUpdateQuery={onUpdateQuery}
-        onHotkeyRun={onRunCurrentQuery}
-        query={query}
-        maxHeight='fillParent'
-      />
-      {action === 'query' && <QueryVarsEditor />}
+      {mode === 'builder' ? (
+        <div className='builder-console-layout'>
+          <div className='builder-canvas-pane'>
+            <QueryBuilder ref={builderRef} embedded />
+          </div>
+          <div className='builder-query-pane'>
+            <div className='builder-query-label'>Generated DQL</div>
+            <Editor
+              onUpdateQuery={onUpdateQuery}
+              onHotkeyRun={onRunCurrentQuery}
+              query={query}
+              maxHeight='fillParent'
+            />
+            <QueryVarsEditor />
+          </div>
+        </div>
+      ) : (
+        <>
+          <Editor
+            onUpdateQuery={onUpdateQuery}
+            onHotkeyRun={onRunCurrentQuery}
+            query={query}
+            maxHeight='fillParent'
+          />
+          {mode === 'query' && <QueryVarsEditor />}
+        </>
+      )}
     </div>
   )
 }

--- a/client/src/components/QueryBuilder/QueryBuilder.scss
+++ b/client/src/components/QueryBuilder/QueryBuilder.scss
@@ -136,8 +136,8 @@
   --shadow: none;
   --focus-ring: rgba(51, 51, 51, 0.12);
   --mono: Consolas, Monaco, "Courier New", monospace;
-  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
-    Arial, sans-serif;
+  --sans:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 
   height: 100%;
   min-height: 0;
@@ -211,7 +211,9 @@
   border-radius: 1px;
   padding: 4px 9px;
   cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
 }
 
 .dql-builder.ratel-theme .btn-ghost:hover:not(:disabled) {
@@ -237,8 +239,7 @@
   min-height: 240px;
   background:
     linear-gradient(rgba(0, 0, 0, 0.035) 1px, transparent 1px) 0 0 / 24px 24px,
-    linear-gradient(90deg, rgba(0, 0, 0, 0.035) 1px, transparent 1px) 0 0 / 24px
-      24px,
+    linear-gradient(90deg, rgba(0, 0, 0, 0.035) 1px, transparent 1px) 0 0 / 24px 24px,
     #f5f5f5;
   border: none;
   overflow: auto;

--- a/client/src/components/QueryBuilder/QueryBuilder.scss
+++ b/client/src/components/QueryBuilder/QueryBuilder.scss
@@ -1,0 +1,553 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.query-builder-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  background: #fff;
+
+  &.is-embedded {
+    padding: 0;
+  }
+}
+
+.query-builder-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-shrink: 0;
+  padding: 6px 10px;
+  border-bottom: 1px solid #d2d2d2;
+  background: #fff;
+}
+
+.query-builder-toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+
+  h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+}
+
+.query-builder-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+
+  .btn {
+    font-size: 12px;
+    padding: 3px 8px;
+    border-radius: 1px;
+    background: #eee;
+    border: 1px solid #d2d2d2;
+    color: #333;
+
+    &:hover:not(:disabled) {
+      background: #f7f7f7;
+    }
+
+    &:disabled {
+      opacity: 0.45;
+    }
+
+    i {
+      margin-right: 0.3rem;
+    }
+  }
+}
+
+.qb-status {
+  font-size: 12px;
+  color: #8a8a8a;
+  white-space: nowrap;
+
+  &.is-loading {
+    color: #666;
+  }
+
+  &.is-ok {
+    color: #666;
+  }
+
+  &.is-warn {
+    color: #856404;
+  }
+
+  &.is-error {
+    color: #a71d2a;
+  }
+
+  i {
+    margin-right: 0.3rem;
+  }
+}
+
+.qb-link-btn {
+  margin-left: 0.45rem;
+  border: none;
+  background: none;
+  color: #337ab7;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  font-size: inherit;
+}
+
+.query-builder-alert {
+  flex-shrink: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0.45rem 0.75rem;
+}
+
+.query-builder-host {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* ---------- Ratel light theme: canvas + entity cards ---------- */
+
+.dql-builder.ratel-theme {
+  --ink: #333;
+  --ink-soft: #8a8a8a;
+  --paper: #ffffff;
+  --paper-2: #f7f7f7;
+  --line: #d2d2d2;
+  --accent: #333;
+  --accent-dim: #555;
+  --accent-hot: #c45c26;
+  --node: #ffffff;
+  --node-header: #f7f7f7;
+  --input-bg: #ffffff;
+  --danger: #c9302c;
+  --shadow: none;
+  --focus-ring: rgba(51, 51, 51, 0.12);
+  --mono: Consolas, Monaco, "Courier New", monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+
+  height: 100%;
+  min-height: 0;
+  color: var(--ink);
+  background: #fff;
+  overflow: hidden;
+  color-scheme: light;
+  font-family: var(--sans);
+}
+
+.dql-builder.ratel-theme.canvas-only {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.dql-builder.ratel-theme .canvas-wrap {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border: none;
+  background: #fff;
+}
+
+.dql-builder.ratel-theme .panel-label {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 6px 10px;
+  border-bottom: 1px solid #d2d2d2;
+  background: #fff;
+  color: #666;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.dql-builder.ratel-theme .canvas-label-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+
+  .qb-status {
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+}
+
+.dql-builder.ratel-theme .panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dql-builder.ratel-theme .btn-ghost {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: #333;
+  background: #eee;
+  border: 1px solid #d2d2d2;
+  border-radius: 1px;
+  padding: 4px 9px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.dql-builder.ratel-theme .btn-ghost:hover:not(:disabled) {
+  background: #f7f7f7;
+  color: #111;
+  border-color: #c8c8c8;
+}
+
+.dql-builder.ratel-theme .btn-add-entity {
+  color: #333;
+  background: #eee;
+  border-color: #d2d2d2;
+}
+
+.dql-builder.ratel-theme .btn-add-entity:hover:not(:disabled) {
+  background: #f7f7f7;
+  border-color: #c8c8c8;
+  color: #111;
+}
+
+.dql-builder.ratel-theme .canvas {
+  flex: 1;
+  min-height: 240px;
+  background:
+    linear-gradient(rgba(0, 0, 0, 0.035) 1px, transparent 1px) 0 0 / 24px 24px,
+    linear-gradient(90deg, rgba(0, 0, 0, 0.035) 1px, transparent 1px) 0 0 / 24px
+      24px,
+    #f5f5f5;
+  border: none;
+  overflow: auto;
+}
+
+.dql-builder.ratel-theme .canvas-empty {
+  color: #9a9a9a;
+  font-size: 13px;
+}
+
+.dql-builder.ratel-theme .entity-menu-panel {
+  background: #fff;
+  border: 1px solid #d2d2d2;
+  border-radius: 1px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 4px 0;
+  min-width: 160px;
+}
+
+.dql-builder.ratel-theme .entity-menu-item {
+  color: #333;
+  padding: 6px 12px;
+  border-radius: 0;
+  font-size: 13px;
+}
+
+.dql-builder.ratel-theme .entity-menu-item:hover {
+  background: #f0f0f0;
+}
+
+.dql-builder.ratel-theme .entity-menu-hint {
+  color: #aaa;
+}
+
+/* Entity cards — compact, flat, Ratel-like */
+.dql-builder.ratel-theme .entity-node {
+  background: #fff;
+  border: 1px solid #d2d2d2;
+  border-radius: 1px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  color: #333;
+  width: 360px;
+  min-width: 280px;
+  min-height: 200px;
+  animation: none;
+}
+
+.dql-builder.ratel-theme .entity-node.selected {
+  border-color: #999;
+  box-shadow: 0 0 0 1px #999;
+}
+
+.dql-builder.ratel-theme .entity-node.dragging {
+  opacity: 0.95;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+}
+
+.dql-builder.ratel-theme .entity-node-header {
+  background: #f7f7f7;
+  border-bottom: 1px solid #e4e4e4;
+  color: #333;
+  padding: 8px 10px;
+  gap: 8px;
+  align-items: center;
+}
+
+.dql-builder.ratel-theme .entity-node-header .dot {
+  margin-top: 0;
+  width: 8px;
+  height: 8px;
+}
+
+.dql-builder.ratel-theme .entity-type-label {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: #666;
+}
+
+.dql-builder.ratel-theme .entity-node-meta {
+  gap: 4px;
+}
+
+.dql-builder.ratel-theme .query-name-input,
+.dql-builder.ratel-theme .result-name-input {
+  background: #fff;
+  border: 1px solid #d2d2d2;
+  border-radius: 1px;
+  padding: 3px 6px;
+  font-size: 12px;
+  color: #333;
+}
+
+.dql-builder.ratel-theme .result-name-input {
+  color: #666;
+  font-size: 11px;
+}
+
+.dql-builder.ratel-theme .query-name-input:hover,
+.dql-builder.ratel-theme .result-name-input:hover {
+  border-color: #c0c0c0;
+}
+
+.dql-builder.ratel-theme .query-name-input:focus,
+.dql-builder.ratel-theme .result-name-input:focus {
+  border-color: #999;
+  background: #fff;
+  box-shadow: none;
+  color: #333;
+}
+
+.dql-builder.ratel-theme .entity-node-remove {
+  width: 22px;
+  height: 22px;
+  border-radius: 1px;
+  color: #999;
+}
+
+.dql-builder.ratel-theme .entity-node-remove:hover {
+  color: #c9302c;
+  background: #f5f5f5;
+}
+
+/* Sections inside cards */
+.dql-builder.ratel-theme .block-section {
+  padding: 8px 10px;
+  border-bottom: 1px solid #ececec;
+  background: #fafafa;
+}
+
+.dql-builder.ratel-theme .block-section-head {
+  margin-bottom: 6px;
+}
+
+.dql-builder.ratel-theme .block-section-title {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: #888;
+}
+
+.dql-builder.ratel-theme .directive-toggles {
+  gap: 4px;
+}
+
+.dql-builder.ratel-theme .directive-toggle {
+  font-size: 11px;
+  color: #666;
+  background: #fff;
+  border: 1px solid #d2d2d2;
+  border-radius: 1px;
+  padding: 2px 8px;
+}
+
+.dql-builder.ratel-theme .directive-toggle:hover {
+  border-color: #bbb;
+  color: #333;
+  background: #fff;
+}
+
+.dql-builder.ratel-theme .directive-toggle.active {
+  color: #fff;
+  background: #555;
+  border-color: #555;
+}
+
+.dql-builder.ratel-theme .btn-mini {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0;
+  color: #333;
+  background: #eee;
+  border: 1px solid #d2d2d2;
+  border-radius: 1px;
+  padding: 2px 7px;
+}
+
+.dql-builder.ratel-theme .btn-mini:hover {
+  background: #f7f7f7;
+}
+
+.dql-builder.ratel-theme .param-card {
+  border: 1px solid #e4e4e4;
+  border-radius: 1px;
+  background: #fff;
+  padding: 6px;
+  margin-bottom: 6px;
+}
+
+.dql-builder.ratel-theme .param-card input,
+.dql-builder.ratel-theme .param-card select {
+  border-radius: 1px;
+  font-size: 11px;
+  padding: 3px 5px;
+}
+
+.dql-builder.ratel-theme .param-empty,
+.dql-builder.ratel-theme .filter-empty {
+  font-size: 11px;
+  color: #9a9a9a;
+}
+
+.dql-builder.ratel-theme .filters-section {
+  border-top: none;
+}
+
+.dql-builder.ratel-theme .filter-panel {
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+}
+
+.dql-builder.ratel-theme .filter-panel.is-edge {
+  margin: 4px 0 4px 8px;
+  padding: 6px;
+  border: 1px solid #e8e8e8;
+  background: #fff;
+}
+
+.dql-builder.ratel-theme .filter-panel-label {
+  color: #666;
+  font-size: 11px;
+}
+
+.dql-builder.ratel-theme .filter-op-toggle {
+  border-radius: 1px;
+  border-color: #d2d2d2;
+}
+
+.dql-builder.ratel-theme .filter-op-btn {
+  font-size: 10px;
+  padding: 2px 7px;
+  color: #888;
+}
+
+.dql-builder.ratel-theme .filter-op-btn.active {
+  background: #555;
+  color: #fff;
+}
+
+.dql-builder.ratel-theme .filter-row {
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.dql-builder.ratel-theme .field-row {
+  border-radius: 0;
+  padding: 4px 10px;
+  font-size: 12px;
+}
+
+.dql-builder.ratel-theme .field-row:hover {
+  background: #f5f5f5;
+}
+
+.dql-builder.ratel-theme .field-check input {
+  accent-color: #555;
+}
+
+.dql-builder.ratel-theme .alias-input {
+  background: #fff;
+  border: 1px solid transparent;
+  border-radius: 1px;
+  color: #666;
+  font-size: 11px;
+  padding: 2px 5px;
+}
+
+.dql-builder.ratel-theme .alias-input:hover {
+  border-color: #d2d2d2;
+}
+
+.dql-builder.ratel-theme .alias-input:focus {
+  border-color: #999;
+  background: #fff;
+  box-shadow: none;
+  color: #333;
+}
+
+.dql-builder.ratel-theme .field-name {
+  font-size: 12px;
+}
+
+.dql-builder.ratel-theme .field-type {
+  font-size: 10px;
+  color: #9a9a9a;
+}
+
+.dql-builder.ratel-theme .field-row.is-object .field-type {
+  color: #c45c26;
+}
+
+.dql-builder.ratel-theme .entity-resize::before {
+  border-color: #bbb;
+}
+
+.dql-builder.ratel-theme input,
+.dql-builder.ratel-theme select,
+.dql-builder.ratel-theme textarea {
+  background: #fff;
+  border: 1px solid #d2d2d2;
+  color: #333;
+  border-radius: 1px;
+}
+
+.dql-builder.ratel-theme input:focus,
+.dql-builder.ratel-theme select:focus,
+.dql-builder.ratel-theme textarea:focus {
+  border-color: #999;
+  outline: none;
+  box-shadow: none;
+}

--- a/client/src/components/QueryBuilder/index.js
+++ b/client/src/components/QueryBuilder/index.js
@@ -1,0 +1,459 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { runQuery } from 'actions/frames'
+import { updateQueryAndAction, updateQueryVars } from 'actions/query'
+import { OK } from 'lib/constants'
+import { getDgraphClient } from 'lib/helpers'
+
+import './lib/schema.js'
+import './lib/schema-loader.js'
+import './lib/query-parser.js'
+import './lib/app.js'
+import './lib/styles.css'
+import './QueryBuilder.scss'
+
+/**
+ * Convert builder variables JSON into Ratel's queryVars shape:
+ * [[checked, "name: value"], ...]
+ */
+export function builderVarsToQueryVars(varsText) {
+  if (!varsText || !String(varsText).trim()) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(varsText)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return []
+    }
+    const entries = Object.entries(parsed)
+    if (
+      entries.length &&
+      entries.every(
+        ([, v]) => v && typeof v === 'object' && !Array.isArray(v),
+      )
+    ) {
+      const first = entries[0][1]
+      return Object.entries(first).map(([key, value]) => {
+        const name = String(key).replace(/^\$/, '')
+        return [true, `${name}: ${value}`]
+      })
+    }
+    return entries.map(([key, value]) => {
+      const name = String(key).replace(/^\$/, '')
+      return [true, `${name}: ${value}`]
+    })
+  } catch {
+    return []
+  }
+}
+
+function SchemaStatus({ state, errorMsg, typeCount, onRetry }) {
+  if (state === 'loading') {
+    return (
+      <span className='qb-status is-loading'>
+        <i className='fas fa-circle-notch fa-spin' /> Loading schema…
+      </span>
+    )
+  }
+  if (state === 'error') {
+    return (
+      <span className='qb-status is-error'>
+        {errorMsg || 'Failed to load schema'}
+        <button type='button' className='qb-link-btn' onClick={onRetry}>
+          Retry
+        </button>
+      </span>
+    )
+  }
+  if (state === 'empty') {
+    return (
+      <span className='qb-status is-warn'>
+        No types found — add types in Schema first.
+      </span>
+    )
+  }
+  if (state === 'ok') {
+    return (
+      <span className='qb-status is-ok'>
+        {typeCount} type{typeCount === 1 ? '' : 's'} loaded
+      </span>
+    )
+  }
+  return <span className='qb-status'>Connect to load schema.</span>
+}
+
+/**
+ * Visual canvas for building DQL.
+ * In Console (`embedded`), only the canvas mounts here — DQL/vars use Ratel's editors.
+ */
+const QueryBuilder = forwardRef(function QueryBuilder(
+  { embedded = false, syncToStore = true },
+  ref,
+) {
+  const dispatch = useDispatch()
+  const currentServer = useSelector(
+    (state) => state.connection.serverHistory[0],
+  )
+  const { readOnly, bestEffort } = useSelector((state) => state.query)
+
+  const rootRef = useRef(null)
+  const apiRef = useRef(null)
+  const latestQueryRef = useRef({ query: '', variables: '' })
+  // When the text editor drives an import, don't let canvas→store sync
+  // overwrite the user's in-progress DQL with regenerated text.
+  const pauseStoreSyncRef = useRef(false)
+  const [builderReady, setBuilderReady] = useState(false)
+
+  const [schemaState, setSchemaState] = useState('idle')
+  const [schemaError, setSchemaError] = useState('')
+  const [typeCount, setTypeCount] = useState(0)
+  const [hasQuery, setHasQuery] = useState(false)
+
+  const canQuery = currentServer?.aclState === OK
+
+  const syncStore = useCallback(
+    (query, variables) => {
+      if (!syncToStore || pauseStoreSyncRef.current) {
+        return
+      }
+      const text = (query || '').trim()
+      if (!text || text.startsWith('#')) {
+        dispatch(updateQueryAndAction('', 'query'))
+        dispatch(updateQueryVars([]))
+        return
+      }
+      dispatch(updateQueryAndAction(text, 'query'))
+      dispatch(updateQueryVars(builderVarsToQueryVars(variables)))
+    },
+    [dispatch, syncToStore],
+  )
+
+  const onQueryChange = useCallback(
+    ({ query, variables }) => {
+      latestQueryRef.current = {
+        query: query || '',
+        variables: variables || '',
+      }
+      const text = (query || '').trim()
+      setHasQuery(!!text && !text.startsWith('#'))
+      syncStore(query, variables)
+    },
+    [syncStore],
+  )
+
+  const applySchemaPayload = useCallback((payload) => {
+    const loader = window.DQLSchemaLoader
+    if (!loader || !apiRef.current) {
+      return
+    }
+    try {
+      const entities = loader.fromSchemaJson(payload)
+      const count = Object.keys(entities).length
+      setTypeCount(count)
+      if (!count) {
+        setSchemaState('empty')
+        apiRef.current.setSchema({}, { clearCanvas: true })
+        return
+      }
+      apiRef.current.applyLoadedSchema(entities, 'connected Alpha')
+      setSchemaState('ok')
+      setSchemaError('')
+    } catch (err) {
+      setSchemaState('error')
+      setSchemaError(err?.message || String(err))
+    }
+  }, [])
+
+  const fetchSchema = useCallback(async () => {
+    if (!canQuery || !apiRef.current) {
+      if (!canQuery) {
+        setSchemaState('idle')
+      }
+      return
+    }
+    setSchemaState('loading')
+    setSchemaError('')
+    try {
+      const client = await getDgraphClient()
+      const response = await client.newTxn().query('schema {}')
+      const data = response.data || response
+      const types = data.types || data.Types || []
+      if (!types.length) {
+        setTypeCount(0)
+        setSchemaState('empty')
+        apiRef.current.setSchema({}, { clearCanvas: true })
+        setSchemaError('')
+        return
+      }
+      applySchemaPayload(data)
+    } catch (err) {
+      console.error(err)
+      setSchemaState('error')
+      setSchemaError(
+        `Error fetching schema from Alpha: ${err?.message || err}`,
+      )
+    }
+  }, [applySchemaPayload, canQuery])
+
+  useEffect(() => {
+    let cancelled = false
+    let api = null
+
+    async function boot() {
+      if (cancelled || !rootRef.current || !window.DQLBuilder?.mount) {
+        return
+      }
+      api = window.DQLBuilder.mount(rootRef.current, {
+        hideSchemaControls: true,
+        persistWorkspace: true,
+        canvasOnly: embedded,
+        onQueryChange,
+      })
+      apiRef.current = api
+      if (!cancelled) {
+        setBuilderReady(true)
+      }
+    }
+
+    boot()
+
+    return () => {
+      cancelled = true
+      setBuilderReady(false)
+      api?.destroy?.()
+      apiRef.current = null
+    }
+  }, [embedded, onQueryChange])
+
+  useEffect(() => {
+    if (!builderReady) {
+      return
+    }
+    fetchSchema()
+  }, [
+    builderReady,
+    canQuery,
+    currentServer?.url,
+    currentServer?.refreshToken,
+    currentServer?.aclState,
+    fetchSchema,
+  ])
+
+  const getBuiltQuery = useCallback(() => {
+    const text = (
+      apiRef.current?.getQuery?.() ||
+      latestQueryRef.current.query ||
+      ''
+    ).trim()
+    const varsText =
+      apiRef.current?.getVars?.() || latestQueryRef.current.variables || ''
+    return {
+      query: text,
+      queryVars: builderVarsToQueryVars(varsText),
+      ready: !!text && !text.startsWith('#'),
+    }
+  }, [])
+
+  const runBuiltQuery = useCallback(() => {
+    const { query, queryVars, ready } = getBuiltQuery()
+    if (!ready) {
+      return false
+    }
+    dispatch(updateQueryAndAction(query, 'query'))
+    dispatch(updateQueryVars(queryVars))
+    dispatch(
+      runQuery(query, 'query', {
+        queryVars,
+        readOnly,
+        bestEffort,
+      }),
+    )
+    return true
+  }, [bestEffort, dispatch, getBuiltQuery, readOnly])
+
+  const clearBuilder = useCallback(() => {
+    if (apiRef.current?.clearCanvas) {
+      apiRef.current.clearCanvas()
+    } else {
+      rootRef.current?.querySelector('#clearBtn')?.click()
+    }
+    dispatch(updateQueryAndAction('', 'query'))
+    dispatch(updateQueryVars([]))
+    setHasQuery(false)
+  }, [dispatch])
+
+  const importQuery = useCallback(
+    (text) => {
+      if (!apiRef.current?.importQuery) {
+        return false
+      }
+      pauseStoreSyncRef.current = true
+      try {
+        const ok = apiRef.current.importQuery(text)
+        if (ok) {
+          const vars = apiRef.current.getVars?.() || ''
+          latestQueryRef.current = {
+            query: text || '',
+            variables: vars,
+          }
+          // Keep the editor's text; only refresh variable bindings from canvas.
+          dispatch(updateQueryVars(builderVarsToQueryVars(vars)))
+          const trimmed = String(text || '').trim()
+          setHasQuery(!!trimmed && !trimmed.startsWith('#'))
+        }
+        return ok
+      } finally {
+        pauseStoreSyncRef.current = false
+      }
+    },
+    [dispatch],
+  )
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      run: runBuiltQuery,
+      clear: clearBuilder,
+      hasQuery: () => hasQuery || getBuiltQuery().ready,
+      getBuiltQuery,
+      importQuery,
+      refreshSchema: fetchSchema,
+    }),
+    [
+      clearBuilder,
+      fetchSchema,
+      getBuiltQuery,
+      hasQuery,
+      importQuery,
+      runBuiltQuery,
+    ],
+  )
+
+  return (
+    <div
+      className={
+        embedded
+          ? 'query-builder-view is-embedded is-ratel'
+          : 'query-builder-view'
+      }
+    >
+      {!embedded && (
+        <div className='query-builder-toolbar'>
+          <div className='query-builder-toolbar-left'>
+            <h2>Query Builder</h2>
+            <SchemaStatus
+              state={canQuery ? schemaState : 'idle'}
+              errorMsg={schemaError}
+              typeCount={typeCount}
+              onRetry={fetchSchema}
+            />
+          </div>
+          <div className='query-builder-toolbar-right'>
+            <button
+              type='button'
+              className='btn btn-sm btn-secondary'
+              disabled={!canQuery}
+              onClick={fetchSchema}
+              title='Reload schema from the connected Alpha'
+            >
+              <i className='fas fa-sync-alt' /> Refresh schema
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!canQuery && (
+        <div className='alert alert-warning query-builder-alert'>
+          You must be connected (and logged in, if ACL is enabled) to load
+          schema and run queries.
+        </div>
+      )}
+
+      <div
+        className={
+          embedded
+            ? 'dql-builder app query-builder-host ratel-theme canvas-only'
+            : 'dql-builder app query-builder-host'
+        }
+        ref={rootRef}
+      >
+        <div className='canvas-wrap'>
+          <div className='panel-label'>
+            <span className='canvas-label-left'>
+              <span>Canvas</span>
+              {embedded && (
+                <SchemaStatus
+                  state={canQuery ? schemaState : 'idle'}
+                  errorMsg={schemaError}
+                  typeCount={typeCount}
+                  onRetry={fetchSchema}
+                />
+              )}
+            </span>
+            <div className='panel-actions'>
+              <div className='entity-menu' id='entityMenuWrap'>
+                <button
+                  type='button'
+                  id='addEntityBtn'
+                  className='btn-ghost btn-add-entity'
+                  aria-haspopup='true'
+                  aria-expanded='false'
+                >
+                  + Add entity
+                </button>
+                <div
+                  id='entityMenu'
+                  className='entity-menu-panel'
+                  hidden
+                  role='menu'
+                  aria-label='Add entity'
+                />
+              </div>
+              {embedded && (
+                <button
+                  type='button'
+                  className='btn-ghost'
+                  disabled={!canQuery}
+                  onClick={fetchSchema}
+                  title='Reload schema from the connected Alpha'
+                >
+                  <i className='fas fa-sync-alt' /> Refresh
+                </button>
+              )}
+              <button type='button' id='clearBtn' className='btn-ghost'>
+                Clear
+              </button>
+            </div>
+          </div>
+          <div id='canvas' className='canvas' tabIndex={0}>
+            <div
+              id='canvasSurface'
+              className='canvas-surface'
+              aria-hidden='true'
+            />
+            <div className='canvas-empty' id='canvasEmpty'>
+              {canQuery
+                ? 'Add an entity to start building a query.'
+                : 'Connect to Dgraph to start building queries.'}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+})
+
+export default QueryBuilder

--- a/client/src/components/QueryBuilder/index.js
+++ b/client/src/components/QueryBuilder/index.js
@@ -41,9 +41,7 @@ export function builderVarsToQueryVars(varsText) {
     const entries = Object.entries(parsed)
     if (
       entries.length &&
-      entries.every(
-        ([, v]) => v && typeof v === 'object' && !Array.isArray(v),
-      )
+      entries.every(([, v]) => v && typeof v === 'object' && !Array.isArray(v))
     ) {
       const first = entries[0][1]
       return Object.entries(first).map(([key, value]) => {
@@ -202,9 +200,7 @@ const QueryBuilder = forwardRef(function QueryBuilder(
     } catch (err) {
       console.error(err)
       setSchemaState('error')
-      setSchemaError(
-        `Error fetching schema from Alpha: ${err?.message || err}`,
-      )
+      setSchemaError(`Error fetching schema from Alpha: ${err?.message || err}`)
     }
   }, [applySchemaPayload, canQuery])
 

--- a/client/src/components/QueryBuilder/lib/app.js
+++ b/client/src/components/QueryBuilder/lib/app.js
@@ -1738,9 +1738,18 @@ window.DQLBuilder = (() => {
       const def = schema[typeName]
       if (!def || !hasAnySelection(selection)) return ''
 
+      // Emit fields in selection insertion order (import / click order), not
+      // schema declaration order — otherwise hand-edited DQL gets reshuffled
+      // the next time the canvas regenerates.
+      const fieldByName = new Map(
+        (def.fields || []).map((field) => [field.name, field]),
+      )
       const lines = []
-      def.fields.forEach((field) => {
-        if (!(field.name in selection)) return
+      Object.keys(selection).forEach((fieldName) => {
+        const field = fieldByName.get(fieldName) || {
+          name: fieldName,
+          kind: 'scalar',
+        }
 
         const fieldPath = pathPrefix
           ? `${pathPrefix}.${field.name}`

--- a/client/src/components/QueryBuilder/lib/app.js
+++ b/client/src/components/QueryBuilder/lib/app.js
@@ -1,1078 +1,1099 @@
 window.DQLBuilder = (() => {
   function mount(root, options = {}) {
-  if (!root) throw new Error('DQLBuilder.mount: root element is required');
-  const opts = {
-    hideSchemaControls: true,
-    persistWorkspace: true,
-    ...options,
-  };
-  const $ = (id) => root.querySelector('#' + id);
-
-  let schema = opts.schema || window.DQL_SCHEMA || {};
-  const PARAM_TYPES = ["string", "int", "float", "bool"];
-  const FILTER_FUNCS = [
-    { value: "eq", label: "eq" },
-    { value: "ge", label: "ge" },
-    { value: "le", label: "le" },
-    { value: "gt", label: "gt" },
-    { value: "lt", label: "lt" },
-    { value: "has", label: "has" },
-    { value: "alloftext", label: "alloftext" },
-    { value: "anyoftext", label: "anyoftext" },
-    { value: "allofterms", label: "allofterms" },
-    { value: "anyofterms", label: "anyofterms" },
-    { value: "regexp", label: "regexp" },
-    { value: "uid_in", label: "uid_in" },
-    { value: "not eq", label: "not eq" },
-    { value: "not has", label: "not has" },
-  ];
-
-  function isUnaryFilter(func) {
-    const f = String(func || "").replace(/^not\s+/i, "").toLowerCase();
-    return f === "has";
-  }
-
-  const canvasEl = $("canvas");
-  const canvasSurfaceEl = $("canvasSurface");
-  const canvasEmptyEl = $("canvasEmpty");
-  const addEntityBtn = $("addEntityBtn");
-  const entityMenuEl = $("entityMenu");
-  const entityMenuWrap = $("entityMenuWrap");
-  const copyBtn = $("copyBtn");
-  const copyVarsBtn = $("copyVarsBtn");
-  const clearBtn = $("clearBtn");
-  const applyDqlBtn = $("applyDqlBtn");
-  const revertDqlBtn = $("revertDqlBtn");
-  const dqlDirtyBadge = $("dqlDirtyBadge");
-  const dqlEditHint = $("dqlEditHint");
-  const consoleOutputEl = $("consoleOutput");
-  const consoleFilterEl = $("consoleFilter");
-  const consoleLevelEl = $("consoleLevel");
-  const consoleClearBtn = $("consoleClearBtn");
-  const consoleErrorCountEl = $("consoleErrorCount");
-  const consoleWarnCountEl = $("consoleWarnCount");
-
-  /**
-   * Each canvas node is one DQL query block.
-   * Parameters are $variables only.
-   * Filters are separate groups (AND/OR) on the root or on object edges.
-   * @typedef {{ id: string, name: string, type: string, value: string, mode: "var"|"default" }} Param
-   * @typedef {{
-   *   id: string, func: string, predicate: string,
-   *   valueMode: "literal"|"param", literal: string, paramName: string
-   * }} FilterCond
-   * @typedef {{ op: "AND"|"OR", conditions: FilterCond[] }} FilterGroup
-   * @typedef {{
-   *   id: string, type: string, name: string, x: number, y: number,
-   *   selection: Record<string, any>, params: Param[],
-   *   rootFilter: FilterGroup, edgeFilters: Record<string, FilterGroup>
-   * }} QueryNode
-   * @type {QueryNode[]}
-   */
-  let nodes = [];
-  let dragPaletteType = null;
-  /** @type {{ id: string, offsetX: number, offsetY: number } | null} */
-  let moveState = null;
-  /** @type {{ id: string, startX: number, startY: number, startW: number, startH: number } | null} */
-  let resizeState = null;
-  let selectedNodeId = null;
-  let nodeSeq = 0;
-  let paramSeq = 0;
-  let filterSeq = 0;
-  const animatedNodes = new Set();
-  /** True when `schema` came from the built-in sample (reload picks up schema.js edits). */
-  let schemaIsSample = true;
-
-  /* ---------- Dev workspace persistence (survives Vite live reload) ---------- */
-
-  const WORKSPACE_KEY = "dql-builder:workspace:v1";
-  let saveWorkspaceTimer = null;
-
-  function saveWorkspace() {
-    if (!opts.persistWorkspace) return;
-    try {
-      sessionStorage.setItem(
-        WORKSPACE_KEY,
-        JSON.stringify({
-          schemaIsSample,
-          schema: schemaIsSample ? null : schema,
-          nodes,
-          selectedNodeId,
-          nodeSeq,
-          paramSeq,
-          filterSeq,
-        })
-      );
-    } catch {
-      /* quota / private mode */
+    if (!root) throw new Error('DQLBuilder.mount: root element is required')
+    const opts = {
+      hideSchemaControls: true,
+      persistWorkspace: true,
+      ...options,
     }
-  }
+    const $ = (id) => root.querySelector('#' + id)
 
-  function scheduleSaveWorkspace() {
-    clearTimeout(saveWorkspaceTimer);
-    saveWorkspaceTimer = setTimeout(saveWorkspace, 120);
-  }
+    let schema = opts.schema || window.DQL_SCHEMA || {}
+    const PARAM_TYPES = ['string', 'int', 'float', 'bool']
+    const FILTER_FUNCS = [
+      { value: 'eq', label: 'eq' },
+      { value: 'ge', label: 'ge' },
+      { value: 'le', label: 'le' },
+      { value: 'gt', label: 'gt' },
+      { value: 'lt', label: 'lt' },
+      { value: 'has', label: 'has' },
+      { value: 'alloftext', label: 'alloftext' },
+      { value: 'anyoftext', label: 'anyoftext' },
+      { value: 'allofterms', label: 'allofterms' },
+      { value: 'anyofterms', label: 'anyofterms' },
+      { value: 'regexp', label: 'regexp' },
+      { value: 'uid_in', label: 'uid_in' },
+      { value: 'not eq', label: 'not eq' },
+      { value: 'not has', label: 'not has' },
+    ]
 
-  function clearWorkspace() {
-    clearTimeout(saveWorkspaceTimer);
-    if (!opts.persistWorkspace) return;
-    try {
-      sessionStorage.removeItem(WORKSPACE_KEY);
-    } catch {
-      /* ignore */
+    function isUnaryFilter(func) {
+      const f = String(func || '')
+        .replace(/^not\s+/i, '')
+        .toLowerCase()
+      return f === 'has'
     }
-  }
 
-  function restoreWorkspace() {
-    try {
-      const raw = sessionStorage.getItem(WORKSPACE_KEY);
-      if (!raw) return false;
-      const data = JSON.parse(raw);
-      if (!data || !Array.isArray(data.nodes)) return false;
+    const canvasEl = $('canvas')
+    const canvasSurfaceEl = $('canvasSurface')
+    const canvasEmptyEl = $('canvasEmpty')
+    const addEntityBtn = $('addEntityBtn')
+    const entityMenuEl = $('entityMenu')
+    const entityMenuWrap = $('entityMenuWrap')
+    const copyBtn = $('copyBtn')
+    const copyVarsBtn = $('copyVarsBtn')
+    const clearBtn = $('clearBtn')
+    const applyDqlBtn = $('applyDqlBtn')
+    const revertDqlBtn = $('revertDqlBtn')
+    const dqlDirtyBadge = $('dqlDirtyBadge')
+    const dqlEditHint = $('dqlEditHint')
+    const consoleOutputEl = $('consoleOutput')
+    const consoleFilterEl = $('consoleFilter')
+    const consoleLevelEl = $('consoleLevel')
+    const consoleClearBtn = $('consoleClearBtn')
+    const consoleErrorCountEl = $('consoleErrorCount')
+    const consoleWarnCountEl = $('consoleWarnCount')
 
-      if (data.schemaIsSample) {
-        schema = window.DQL_SCHEMA;
-        schemaIsSample = true;
-      } else if (data.schema && typeof data.schema === "object") {
-        schema = data.schema;
-        schemaIsSample = false;
-      } else {
-        return false;
+    /**
+     * Each canvas node is one DQL query block.
+     * Parameters are $variables only.
+     * Filters are separate groups (AND/OR) on the root or on object edges.
+     * @typedef {{ id: string, name: string, type: string, value: string, mode: "var"|"default" }} Param
+     * @typedef {{
+     *   id: string, func: string, predicate: string,
+     *   valueMode: "literal"|"param", literal: string, paramName: string
+     * }} FilterCond
+     * @typedef {{ op: "AND"|"OR", conditions: FilterCond[] }} FilterGroup
+     * @typedef {{
+     *   id: string, type: string, name: string, x: number, y: number,
+     *   selection: Record<string, any>, params: Param[],
+     *   rootFilter: FilterGroup, edgeFilters: Record<string, FilterGroup>
+     * }} QueryNode
+     * @type {QueryNode[]}
+     */
+    let nodes = []
+    let dragPaletteType = null
+    /** @type {{ id: string, offsetX: number, offsetY: number } | null} */
+    let moveState = null
+    /** @type {{ id: string, startX: number, startY: number, startW: number, startH: number } | null} */
+    let resizeState = null
+    let selectedNodeId = null
+    let nodeSeq = 0
+    let paramSeq = 0
+    let filterSeq = 0
+    const animatedNodes = new Set()
+    /** True when `schema` came from the built-in sample (reload picks up schema.js edits). */
+    let schemaIsSample = true
+
+    /* ---------- Dev workspace persistence (survives Vite live reload) ---------- */
+
+    const WORKSPACE_KEY = 'dql-builder:workspace:v1'
+    let saveWorkspaceTimer = null
+
+    function saveWorkspace() {
+      if (!opts.persistWorkspace) return
+      try {
+        sessionStorage.setItem(
+          WORKSPACE_KEY,
+          JSON.stringify({
+            schemaIsSample,
+            schema: schemaIsSample ? null : schema,
+            nodes,
+            selectedNodeId,
+            nodeSeq,
+            paramSeq,
+            filterSeq,
+          }),
+        )
+      } catch {
+        /* quota / private mode */
       }
-
-      nodes = data.nodes.map((n) => migrateNode({ ...n }));
-      selectedNodeId = data.selectedNodeId || null;
-      nodeSeq = Number(data.nodeSeq) || nodes.length;
-      paramSeq = Number(data.paramSeq) || 0;
-      filterSeq = Number(data.filterSeq) || 0;
-      nodes.forEach((n) => {
-        animatedNodes.add(n.id);
-        (n.rootFilter?.conditions || []).forEach((c) => {
-          if (!c.id) c.id = filterUid();
-        });
-        Object.values(n.edgeFilters || {}).forEach((g) => {
-          (g.conditions || []).forEach((c) => {
-            if (!c.id) c.id = filterUid();
-          });
-        });
-      });
-      resolveOverlaps();
-      return true;
-    } catch {
-      return false;
     }
-  }
 
-  /* ---------- Output (Monaco with textarea fallback) ---------- */
-
-  let dqlEditor = null;
-  let varsEditor = null;
-  let dqlFallback = null;
-  let varsFallback = null;
-  let queryText = "";
-  let varsText = "";
-  /** True while the user has unsaved edits in the DQL editor. */
-  let dqlDirty = false;
-  /** Suppress dirty-flag while we push generated text into the editor. */
-  let writingDql = false;
-
-  function getDqlText() {
-    if (dqlEditor) return dqlEditor.getValue();
-    if (dqlFallback) return dqlFallback.value;
-    return queryText;
-  }
-
-  function updateDqlChrome() {
-    const dirty = dqlDirty;
-    if (dqlDirtyBadge) dqlDirtyBadge.hidden = !dirty;
-    if (dqlEditHint) dqlEditHint.hidden = !dirty;
-    if (applyDqlBtn) applyDqlBtn.hidden = !dirty;
-    if (revertDqlBtn) revertDqlBtn.hidden = !dirty;
-    $("dqlEditor")?.classList.toggle("is-dirty", dirty);
-  }
-
-  function markDqlDirty() {
-    if (writingDql) return;
-    if (!dqlDirty) {
-      dqlDirty = true;
-      updateDqlChrome();
+    function scheduleSaveWorkspace() {
+      clearTimeout(saveWorkspaceTimer)
+      saveWorkspaceTimer = setTimeout(saveWorkspace, 120)
     }
-    if (copyBtn) copyBtn.disabled = !getDqlText().trim();
-  }
 
-  function clearDqlDirty() {
-    dqlDirty = false;
-    updateDqlChrome();
-  }
-
-  function writeDqlEditor(value) {
-    writingDql = true;
-    try {
-      if (dqlEditor) dqlEditor.setValue(value);
-      else if (dqlFallback) dqlFallback.value = value;
-    } finally {
-      writingDql = false;
+    function clearWorkspace() {
+      clearTimeout(saveWorkspaceTimer)
+      if (!opts.persistWorkspace) return
+      try {
+        sessionStorage.removeItem(WORKSPACE_KEY)
+      } catch {
+        /* ignore */
+      }
     }
-  }
 
-  function looksLikeDql(text) {
-    return /\bquery\s+[A-Za-z_][A-Za-z0-9_]*/i.test(String(text || ""));
-  }
+    function restoreWorkspace() {
+      try {
+        const raw = sessionStorage.getItem(WORKSPACE_KEY)
+        if (!raw) return false
+        const data = JSON.parse(raw)
+        if (!data || !Array.isArray(data.nodes)) return false
 
-  /* ---------- Builder console ---------- */
+        if (data.schemaIsSample) {
+          schema = window.DQL_SCHEMA
+          schemaIsSample = true
+        } else if (data.schema && typeof data.schema === 'object') {
+          schema = data.schema
+          schemaIsSample = false
+        } else {
+          return false
+        }
 
-  /** @type {{ id: number, level: 'error'|'warn'|'info', message: string, source: string, time: number }[]} */
-  const consoleEntries = [];
-  let consoleSeq = 0;
+        nodes = data.nodes.map((n) => migrateNode({ ...n }))
+        selectedNodeId = data.selectedNodeId || null
+        nodeSeq = Number(data.nodeSeq) || nodes.length
+        paramSeq = Number(data.paramSeq) || 0
+        filterSeq = Number(data.filterSeq) || 0
+        nodes.forEach((n) => {
+          animatedNodes.add(n.id)
+          ;(n.rootFilter?.conditions || []).forEach((c) => {
+            if (!c.id) c.id = filterUid()
+          })
+          Object.values(n.edgeFilters || {}).forEach((g) => {
+            ;(g.conditions || []).forEach((c) => {
+              if (!c.id) c.id = filterUid()
+            })
+          })
+        })
+        resolveOverlaps()
+        return true
+      } catch {
+        return false
+      }
+    }
 
-  function applyConsoleFilters() {
-    if (!consoleOutputEl) return;
-    const q = (consoleFilterEl?.value || "").trim().toLowerCase();
-    const level = consoleLevelEl?.value || "all";
-    consoleOutputEl.querySelectorAll(".console-row").forEach((row) => {
-      const rowLevel = row.dataset.level;
-      const text = row.dataset.text || "";
-      const levelOk = level === "all" || rowLevel === level;
-      const textOk = !q || text.includes(q);
-      row.classList.toggle("is-hidden", !(levelOk && textOk));
-    });
-  }
+    /* ---------- Output (Monaco with textarea fallback) ---------- */
 
-  function updateConsoleCounts() {
-    const errors = consoleEntries.filter((e) => e.level === "error").length;
-    const warns = consoleEntries.filter((e) => e.level === "warn").length;
-    const errNum = consoleErrorCountEl?.querySelector(".console-count-num");
-    const warnNum = consoleWarnCountEl?.querySelector(".console-count-num");
-    if (errNum) errNum.textContent = String(errors);
-    if (warnNum) warnNum.textContent = String(warns);
-  }
+    let dqlEditor = null
+    let varsEditor = null
+    let dqlFallback = null
+    let varsFallback = null
+    let queryText = ''
+    let varsText = ''
+    /** True while the user has unsaved edits in the DQL editor. */
+    let dqlDirty = false
+    /** Suppress dirty-flag while we push generated text into the editor. */
+    let writingDql = false
 
-  function renderConsoleEmpty() {
-    if (!consoleOutputEl || consoleEntries.length) return;
-    consoleOutputEl.innerHTML =
-      '<p class="console-empty">Console cleared — parse and build messages will appear here.</p>';
-  }
+    function getDqlText() {
+      if (dqlEditor) return dqlEditor.getValue()
+      if (dqlFallback) return dqlFallback.value
+      return queryText
+    }
 
-  function clearConsole() {
-    consoleEntries.length = 0;
-    if (consoleOutputEl) consoleOutputEl.innerHTML = "";
-    updateConsoleCounts();
-    renderConsoleEmpty();
-  }
+    function updateDqlChrome() {
+      const dirty = dqlDirty
+      if (dqlDirtyBadge) dqlDirtyBadge.hidden = !dirty
+      if (dqlEditHint) dqlEditHint.hidden = !dirty
+      if (applyDqlBtn) applyDqlBtn.hidden = !dirty
+      if (revertDqlBtn) revertDqlBtn.hidden = !dirty
+      $('dqlEditor')?.classList.toggle('is-dirty', dirty)
+    }
 
-  /**
-   * @param {'error'|'warn'|'info'} level
-   * @param {string} message
-   * @param {string} [source]
-   */
-  function consoleLog(level, message, source = "builder") {
-    const entry = {
-      id: ++consoleSeq,
-      level,
-      message: String(message || ""),
-      source: String(source || "builder"),
-      time: Date.now(),
-    };
-    consoleEntries.push(entry);
-    updateConsoleCounts();
-    if (!consoleOutputEl) return;
+    function markDqlDirty() {
+      if (writingDql) return
+      if (!dqlDirty) {
+        dqlDirty = true
+        updateDqlChrome()
+      }
+      if (copyBtn) copyBtn.disabled = !getDqlText().trim()
+    }
 
-    const empty = consoleOutputEl.querySelector(".console-empty");
-    if (empty) empty.remove();
+    function clearDqlDirty() {
+      dqlDirty = false
+      updateDqlChrome()
+    }
 
-    const row = document.createElement("div");
-    row.className = `console-row is-${entry.level}`;
-    row.dataset.level = entry.level;
-    row.dataset.text = `${entry.message} ${entry.source}`.toLowerCase();
-    row.innerHTML = `
+    function writeDqlEditor(value) {
+      writingDql = true
+      try {
+        if (dqlEditor) dqlEditor.setValue(value)
+        else if (dqlFallback) dqlFallback.value = value
+      } finally {
+        writingDql = false
+      }
+    }
+
+    function looksLikeDql(text) {
+      return /\bquery\s+[A-Za-z_][A-Za-z0-9_]*/i.test(String(text || ''))
+    }
+
+    /* ---------- Builder console ---------- */
+
+    /** @type {{ id: number, level: 'error'|'warn'|'info', message: string, source: string, time: number }[]} */
+    const consoleEntries = []
+    let consoleSeq = 0
+
+    function applyConsoleFilters() {
+      if (!consoleOutputEl) return
+      const q = (consoleFilterEl?.value || '').trim().toLowerCase()
+      const level = consoleLevelEl?.value || 'all'
+      consoleOutputEl.querySelectorAll('.console-row').forEach((row) => {
+        const rowLevel = row.dataset.level
+        const text = row.dataset.text || ''
+        const levelOk = level === 'all' || rowLevel === level
+        const textOk = !q || text.includes(q)
+        row.classList.toggle('is-hidden', !(levelOk && textOk))
+      })
+    }
+
+    function updateConsoleCounts() {
+      const errors = consoleEntries.filter((e) => e.level === 'error').length
+      const warns = consoleEntries.filter((e) => e.level === 'warn').length
+      const errNum = consoleErrorCountEl?.querySelector('.console-count-num')
+      const warnNum = consoleWarnCountEl?.querySelector('.console-count-num')
+      if (errNum) errNum.textContent = String(errors)
+      if (warnNum) warnNum.textContent = String(warns)
+    }
+
+    function renderConsoleEmpty() {
+      if (!consoleOutputEl || consoleEntries.length) return
+      consoleOutputEl.innerHTML =
+        '<p class="console-empty">Console cleared — parse and build messages will appear here.</p>'
+    }
+
+    function clearConsole() {
+      consoleEntries.length = 0
+      if (consoleOutputEl) consoleOutputEl.innerHTML = ''
+      updateConsoleCounts()
+      renderConsoleEmpty()
+    }
+
+    /**
+     * @param {'error'|'warn'|'info'} level
+     * @param {string} message
+     * @param {string} [source]
+     */
+    function consoleLog(level, message, source = 'builder') {
+      const entry = {
+        id: ++consoleSeq,
+        level,
+        message: String(message || ''),
+        source: String(source || 'builder'),
+        time: Date.now(),
+      }
+      consoleEntries.push(entry)
+      updateConsoleCounts()
+      if (!consoleOutputEl) return
+
+      const empty = consoleOutputEl.querySelector('.console-empty')
+      if (empty) empty.remove()
+
+      const row = document.createElement('div')
+      row.className = `console-row is-${entry.level}`
+      row.dataset.level = entry.level
+      row.dataset.text = `${entry.message} ${entry.source}`.toLowerCase()
+      row.innerHTML = `
       <span class="console-row-icon" aria-hidden="true"></span>
       <span class="console-row-msg"></span>
       <span class="console-row-source"></span>
-    `;
-    row.querySelector(".console-row-msg").textContent = entry.message;
-    row.querySelector(".console-row-source").textContent = entry.source;
-    consoleOutputEl.appendChild(row);
-    consoleOutputEl.scrollTop = consoleOutputEl.scrollHeight;
+    `
+      row.querySelector('.console-row-msg').textContent = entry.message
+      row.querySelector('.console-row-source').textContent = entry.source
+      consoleOutputEl.appendChild(row)
+      consoleOutputEl.scrollTop = consoleOutputEl.scrollHeight
 
-    applyConsoleFilters();
-  }
-
-  function consoleError(message, source) {
-    consoleLog("error", message, source);
-  }
-
-  function consoleWarn(message, source) {
-    consoleLog("warn", message, source);
-  }
-
-  function consoleInfo(message, source) {
-    consoleLog("info", message, source);
-  }
-
-  if (consoleClearBtn) consoleClearBtn.addEventListener("click", clearConsole);
-  if (consoleFilterEl) consoleFilterEl.addEventListener("input", applyConsoleFilters);
-  if (consoleLevelEl) consoleLevelEl.addEventListener("change", applyConsoleFilters);
-  if (consoleOutputEl) renderConsoleEmpty();
-
-  function setOutputs(dql, vars) {
-    queryText = dql;
-    varsText = vars;
-    if (!dqlDirty) writeDqlEditor(dql);
-    if (varsEditor) varsEditor.setValue(vars);
-    else if (varsFallback) varsFallback.value = vars;
-    if (copyBtn) copyBtn.disabled = !(dqlDirty ? getDqlText().trim() : dql);
-    if (copyVarsBtn) copyVarsBtn.disabled = !vars;
-    try {
-      opts.onQueryChange?.({ query: dqlDirty ? getDqlText() : dql, variables: vars });
-    } catch (_) {}
-  }
-
-  function makeFallbackTextarea(hostId, { readOnly = true } = {}) {
-    const host = $(hostId);
-    if (!host) return null;
-    const ta = document.createElement("textarea");
-    ta.readOnly = readOnly;
-    ta.spellcheck = false;
-    ta.style.cssText =
-      "width:100%;height:100%;border:none;outline:none;resize:none;padding:1rem;" +
-      "font-family:var(--mono);font-size:0.82rem;line-height:1.55;color:var(--ink);background:transparent;";
-    host.appendChild(ta);
-    return ta;
-  }
-
-  function initEditors() {
-    // Canvas-only (Ratel Console) — host editors live outside this mount.
-    if (opts.canvasOnly || !$("dqlEditor")) {
-      return;
-    }
-    if (!window.require) {
-      dqlFallback = makeFallbackTextarea("dqlEditor", { readOnly: false });
-      varsFallback = makeFallbackTextarea("varsEditor", { readOnly: true });
-      dqlFallback.addEventListener("input", () => markDqlDirty());
-      dqlFallback.addEventListener("keydown", (e) => {
-        if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
-          e.preventDefault();
-          applyDqlFromEditor({ reason: "shortcut" });
-        }
-      });
-      dqlFallback.addEventListener("blur", () => {
-        applyDqlFromEditor({ reason: "blur", soft: true });
-      });
-      setOutputs(queryText, varsText);
-      return;
+      applyConsoleFilters()
     }
 
-    window.require.config({
-      paths: { vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs" },
-    });
+    function consoleError(message, source) {
+      consoleLog('error', message, source)
+    }
 
-    window.require(["vs/editor/editor.main"], () => {
-      monaco.editor.defineTheme("dql-dark", {
-        base: "vs-dark",
-        inherit: true,
-        rules: [
-          { token: "keyword", foreground: "3dd68c", fontStyle: "bold" },
-          { token: "string", foreground: "fdd663" },
-          { token: "number", foreground: "8ab4f8" },
-          { token: "comment", foreground: "9aa0a6", fontStyle: "italic" },
-        ],
-        colors: {
-          "editor.background": "#202124",
-          "editor.foreground": "#e8eaed",
-          "editor.lineHighlightBackground": "#292a2d",
-          "editorLineNumber.foreground": "#5f6368",
-          "editorGutter.background": "#202124",
-          "editorCursor.foreground": "#e8eaed",
-          "editor.selectionBackground": "#3c4043",
-          "editor.inactiveSelectionBackground": "#303134",
-          "editorWidget.background": "#292a2d",
-          "editorWidget.border": "#3c4043",
-          "input.background": "#1a1b1e",
-          "dropdown.background": "#292a2d",
+    function consoleWarn(message, source) {
+      consoleLog('warn', message, source)
+    }
+
+    function consoleInfo(message, source) {
+      consoleLog('info', message, source)
+    }
+
+    if (consoleClearBtn) consoleClearBtn.addEventListener('click', clearConsole)
+    if (consoleFilterEl)
+      consoleFilterEl.addEventListener('input', applyConsoleFilters)
+    if (consoleLevelEl)
+      consoleLevelEl.addEventListener('change', applyConsoleFilters)
+    if (consoleOutputEl) renderConsoleEmpty()
+
+    function setOutputs(dql, vars) {
+      queryText = dql
+      varsText = vars
+      if (!dqlDirty) writeDqlEditor(dql)
+      if (varsEditor) varsEditor.setValue(vars)
+      else if (varsFallback) varsFallback.value = vars
+      if (copyBtn) copyBtn.disabled = !(dqlDirty ? getDqlText().trim() : dql)
+      if (copyVarsBtn) copyVarsBtn.disabled = !vars
+      try {
+        opts.onQueryChange?.({
+          query: dqlDirty ? getDqlText() : dql,
+          variables: vars,
+        })
+      } catch (_) {}
+    }
+
+    function makeFallbackTextarea(hostId, { readOnly = true } = {}) {
+      const host = $(hostId)
+      if (!host) return null
+      const ta = document.createElement('textarea')
+      ta.readOnly = readOnly
+      ta.spellcheck = false
+      ta.style.cssText =
+        'width:100%;height:100%;border:none;outline:none;resize:none;padding:1rem;' +
+        'font-family:var(--mono);font-size:0.82rem;line-height:1.55;color:var(--ink);background:transparent;'
+      host.appendChild(ta)
+      return ta
+    }
+
+    function initEditors() {
+      // Canvas-only (Ratel Console) — host editors live outside this mount.
+      if (opts.canvasOnly || !$('dqlEditor')) {
+        return
+      }
+      if (!window.require) {
+        dqlFallback = makeFallbackTextarea('dqlEditor', { readOnly: false })
+        varsFallback = makeFallbackTextarea('varsEditor', { readOnly: true })
+        dqlFallback.addEventListener('input', () => markDqlDirty())
+        dqlFallback.addEventListener('keydown', (e) => {
+          if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+            e.preventDefault()
+            applyDqlFromEditor({ reason: 'shortcut' })
+          }
+        })
+        dqlFallback.addEventListener('blur', () => {
+          applyDqlFromEditor({ reason: 'blur', soft: true })
+        })
+        setOutputs(queryText, varsText)
+        return
+      }
+
+      window.require.config({
+        paths: {
+          vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs',
         },
-      });
+      })
 
-      const common = {
-        theme: "dql-dark",
-        minimap: { enabled: false },
-        automaticLayout: true,
-        fontFamily: "IBM Plex Mono, ui-monospace, monospace",
-        fontSize: 12.5,
-        lineHeight: 20,
-        scrollBeyondLastLine: false,
-        renderLineHighlight: "line",
-        overviewRulerLanes: 0,
-        hideCursorInOverviewRuler: true,
-        scrollbar: { verticalScrollbarSize: 8, horizontalScrollbarSize: 8 },
-        padding: { top: 12, bottom: 12 },
-        wordWrap: "on",
-      };
+      window.require(['vs/editor/editor.main'], () => {
+        monaco.editor.defineTheme('dql-dark', {
+          base: 'vs-dark',
+          inherit: true,
+          rules: [
+            { token: 'keyword', foreground: '3dd68c', fontStyle: 'bold' },
+            { token: 'string', foreground: 'fdd663' },
+            { token: 'number', foreground: '8ab4f8' },
+            { token: 'comment', foreground: '9aa0a6', fontStyle: 'italic' },
+          ],
+          colors: {
+            'editor.background': '#202124',
+            'editor.foreground': '#e8eaed',
+            'editor.lineHighlightBackground': '#292a2d',
+            'editorLineNumber.foreground': '#5f6368',
+            'editorGutter.background': '#202124',
+            'editorCursor.foreground': '#e8eaed',
+            'editor.selectionBackground': '#3c4043',
+            'editor.inactiveSelectionBackground': '#303134',
+            'editorWidget.background': '#292a2d',
+            'editorWidget.border': '#3c4043',
+            'input.background': '#1a1b1e',
+            'dropdown.background': '#292a2d',
+          },
+        })
 
-      // GraphQL grammar is the closest built-in match for DQL.
-      dqlEditor = monaco.editor.create($("dqlEditor"), {
-        ...common,
-        readOnly: false,
-        value: queryText,
-        language: "graphql",
-        contextmenu: true,
-        ariaLabel: "DQL editor",
-      });
-      varsEditor = monaco.editor.create($("varsEditor"), {
-        ...common,
-        readOnly: true,
-        value: varsText,
-        language: "json",
-        lineNumbers: "off",
-        contextmenu: false,
-        renderLineHighlight: "none",
-      });
-
-      dqlEditor.onDidChangeModelContent(() => {
-        if (!writingDql) markDqlDirty();
-      });
-
-      dqlEditor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
-        applyDqlFromEditor({ reason: "shortcut" });
-      });
-
-      dqlEditor.onDidBlurEditorWidget(() => {
-        // Defer so a click on Apply/Revert is processed first.
-        setTimeout(() => {
-          if (document.activeElement?.closest?.("#applyDqlBtn, #revertDqlBtn")) return;
-          applyDqlFromEditor({ reason: "blur", soft: true });
-        }, 0);
-      });
-    });
-  }
-
-  /* ---------- Helpers ---------- */
-
-  function uid() {
-    nodeSeq += 1;
-    return `node-${nodeSeq}`;
-  }
-
-  function paramUid() {
-    paramSeq += 1;
-    return `param-${paramSeq}`;
-  }
-
-  function filterUid() {
-    filterSeq += 1;
-    return `filter-${filterSeq}`;
-  }
-
-  function emptyFilterGroup(op = "AND") {
-    return { op: op === "OR" ? "OR" : "AND", conditions: [] };
-  }
-
-  function newFilterCondition(predicate = "", typeHint = "string") {
-    return {
-      id: filterUid(),
-      func: "eq",
-      predicate,
-      valueMode: "literal",
-      literal: defaultParamValue(typeHint),
-      paramName: "",
-    };
-  }
-
-  function ensureFilterGroup(group) {
-    if (!group || typeof group !== "object") return emptyFilterGroup();
-    return {
-      op: group.op === "OR" ? "OR" : "AND",
-      conditions: Array.isArray(group.conditions) ? group.conditions : [],
-    };
-  }
-
-  /** Migrate legacy param-bound filters → rootFilter / edgeFilters. */
-  function migrateNode(node) {
-    if (!node.rootFilter) node.rootFilter = emptyFilterGroup();
-    else node.rootFilter = ensureFilterGroup(node.rootFilter);
-    if (!node.edgeFilters || typeof node.edgeFilters !== "object") node.edgeFilters = {};
-
-    const legacy = [];
-    const kept = [];
-    (node.params || []).forEach((p) => {
-      if (p && p.func && p.predicate) legacy.push(p);
-      else if (p) {
-        kept.push({
-          id: p.id || paramUid(),
-          name: p.name,
-          type: PARAM_TYPES.includes(p.type) ? p.type : "string",
-          value: p.value ?? "",
-          mode: p.mode === "default" ? "default" : "var",
-        });
-      }
-    });
-
-    legacy.forEach((p) => {
-      const walk = splitPredicatePath(node.type, p.predicate) || {
-        edgeParts: [],
-        leaf: p.predicate,
-        edgePath: "",
-      };
-      const unary = isUnaryFilter(p.func);
-      const cond = {
-        id: filterUid(),
-        func: p.func,
-        predicate: walk.leaf,
-        valueMode: p.mode === "literal" || unary ? "literal" : "param",
-        literal: p.mode === "literal" ? String(p.value ?? "") : "",
-        paramName: p.mode === "literal" || unary ? "" : p.name,
-      };
-      if (!walk.edgePath) {
-        node.rootFilter.conditions.push(cond);
-      } else {
-        if (!node.edgeFilters[walk.edgePath]) {
-          node.edgeFilters[walk.edgePath] = emptyFilterGroup();
+        const common = {
+          theme: 'dql-dark',
+          minimap: { enabled: false },
+          automaticLayout: true,
+          fontFamily: 'IBM Plex Mono, ui-monospace, monospace',
+          fontSize: 12.5,
+          lineHeight: 20,
+          scrollBeyondLastLine: false,
+          renderLineHighlight: 'line',
+          overviewRulerLanes: 0,
+          hideCursorInOverviewRuler: true,
+          scrollbar: { verticalScrollbarSize: 8, horizontalScrollbarSize: 8 },
+          padding: { top: 12, bottom: 12 },
+          wordWrap: 'on',
         }
-        node.edgeFilters[walk.edgePath].conditions.push(cond);
+
+        // GraphQL grammar is the closest built-in match for DQL.
+        dqlEditor = monaco.editor.create($('dqlEditor'), {
+          ...common,
+          readOnly: false,
+          value: queryText,
+          language: 'graphql',
+          contextmenu: true,
+          ariaLabel: 'DQL editor',
+        })
+        varsEditor = monaco.editor.create($('varsEditor'), {
+          ...common,
+          readOnly: true,
+          value: varsText,
+          language: 'json',
+          lineNumbers: 'off',
+          contextmenu: false,
+          renderLineHighlight: 'none',
+        })
+
+        dqlEditor.onDidChangeModelContent(() => {
+          if (!writingDql) markDqlDirty()
+        })
+
+        dqlEditor.addCommand(
+          monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+          () => {
+            applyDqlFromEditor({ reason: 'shortcut' })
+          },
+        )
+
+        dqlEditor.onDidBlurEditorWidget(() => {
+          // Defer so a click on Apply/Revert is processed first.
+          setTimeout(() => {
+            if (
+              document.activeElement?.closest?.('#applyDqlBtn, #revertDqlBtn')
+            )
+              return
+            applyDqlFromEditor({ reason: 'blur', soft: true })
+          }, 0)
+        })
+      })
+    }
+
+    /* ---------- Helpers ---------- */
+
+    function uid() {
+      nodeSeq += 1
+      return `node-${nodeSeq}`
+    }
+
+    function paramUid() {
+      paramSeq += 1
+      return `param-${paramSeq}`
+    }
+
+    function filterUid() {
+      filterSeq += 1
+      return `filter-${filterSeq}`
+    }
+
+    function emptyFilterGroup(op = 'AND') {
+      return { op: op === 'OR' ? 'OR' : 'AND', conditions: [] }
+    }
+
+    function newFilterCondition(predicate = '', typeHint = 'string') {
+      return {
+        id: filterUid(),
+        func: 'eq',
+        predicate,
+        valueMode: 'literal',
+        literal: defaultParamValue(typeHint),
+        paramName: '',
       }
-      if (!unary && p.mode !== "literal") {
-        if (!kept.some((k) => k.name === p.name)) {
+    }
+
+    function ensureFilterGroup(group) {
+      if (!group || typeof group !== 'object') return emptyFilterGroup()
+      return {
+        op: group.op === 'OR' ? 'OR' : 'AND',
+        conditions: Array.isArray(group.conditions) ? group.conditions : [],
+      }
+    }
+
+    /** Migrate legacy param-bound filters → rootFilter / edgeFilters. */
+    function migrateNode(node) {
+      if (!node.rootFilter) node.rootFilter = emptyFilterGroup()
+      else node.rootFilter = ensureFilterGroup(node.rootFilter)
+      if (!node.edgeFilters || typeof node.edgeFilters !== 'object')
+        node.edgeFilters = {}
+
+      const legacy = []
+      const kept = []
+      ;(node.params || []).forEach((p) => {
+        if (p && p.func && p.predicate) legacy.push(p)
+        else if (p) {
           kept.push({
             id: p.id || paramUid(),
             name: p.name,
-            type: PARAM_TYPES.includes(p.type) ? p.type : "string",
-            value: p.value ?? "",
-            mode: p.mode === "default" ? "default" : "var",
-          });
+            type: PARAM_TYPES.includes(p.type) ? p.type : 'string',
+            value: p.value ?? '',
+            mode: p.mode === 'default' ? 'default' : 'var',
+          })
         }
-      }
-    });
+      })
 
-    node.params = kept;
-    if (node.width != null) node.width = Math.max(300, Number(node.width) || 380);
-    if (node.height != null) node.height = Math.max(240, Number(node.height) || 520);
-    return node;
-  }
-
-  function typeAtEdgePath(rootType, edgePath) {
-    if (!edgePath) return rootType;
-    const walk = splitPredicatePath(rootType, edgePath);
-    if (!walk) return rootType;
-    let typeName = rootType;
-    for (const edge of walk.edgeParts) {
-      const field = (schema[typeName]?.fields || []).find((f) => f.name === edge);
-      if (!field?.ofType) return typeName;
-      typeName = field.ofType;
-    }
-    const leaf = (schema[typeName]?.fields || []).find((f) => f.name === walk.leaf);
-    return leaf?.ofType || typeName;
-  }
-
-  function fieldDisplayName(name) {
-    const raw = String(name || "");
-    const i = raw.lastIndexOf(".");
-    return i >= 0 ? raw.slice(i + 1) : raw;
-  }
-
-  function scalarOptionsForType(typeName) {
-    return scalarPredicates(typeName).map((f) => ({
-      value: f.name,
-      label: fieldDisplayName(f.name),
-    }));
-  }
-
-  function defaultName(typeName) {
-    const base = `get${typeName}`;
-    if (!nodes.some((n) => n.name === base)) return base;
-    let i = 2;
-    while (nodes.some((n) => n.name === `${base}${i}`)) i += 1;
-    return `${base}${i}`;
-  }
-
-  function sanitizeName(raw, fallback) {
-    let name = String(raw || "")
-      .trim()
-      .replace(/^\$/, "")
-      .replace(/[^A-Za-z0-9_]/g, "_")
-      .replace(/^([^A-Za-z_])/, "_$1");
-    if (!name) name = fallback;
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) name = fallback;
-    return name;
-  }
-
-  function defaultSelection(typeName) {
-    const def = schema[typeName];
-    const selection = {};
-    def.fields
-      .filter((f) => f.kind === "scalar")
-      .slice(0, 2)
-      .forEach((f) => {
-        selection[f.name] = null;
-      });
-    return selection;
-  }
-
-  function scalarPredicates(typeName) {
-    return (schema[typeName]?.fields || []).filter(
-      (f) => f.kind === "scalar" && f.name !== "uid"
-    );
-  }
-
-  function defaultParamValue(type) {
-    if (type === "int" || type === "float") return "0";
-    if (type === "bool") return "false";
-    return "";
-  }
-
-  /** Resolve a predicate path to its schema field, respecting dotted field names. */
-  function resolvePredicateField(typeName, pathStr) {
-    const walk = splitPredicatePath(typeName, pathStr);
-    if (!walk) return null;
-    let currentType = typeName;
-    for (const edge of walk.edgeParts) {
-      const field = (schema[currentType]?.fields || []).find((f) => f.name === edge);
-      if (!field?.ofType) return null;
-      currentType = field.ofType;
-    }
-    return (schema[currentType]?.fields || []).find((f) => f.name === walk.leaf) || null;
-  }
-
-  /**
-   * Split "posts.published" or a namespaced "User.email" into edge parts + leaf,
-   * matching longest field names on the schema at each step.
-   */
-  function splitPredicatePath(typeName, pathStr) {
-    const raw = String(pathStr || "");
-    if (!raw) return null;
-
-    const fieldsAt = (t) => schema[t]?.fields || [];
-    if (fieldsAt(typeName).some((f) => f.name === raw)) {
-      return { edgeParts: [], leaf: raw, edgePath: "" };
-    }
-
-    const segments = raw.split(".");
-    const edgeParts = [];
-    let currentType = typeName;
-    let i = 0;
-
-    while (i < segments.length) {
-      const fields = fieldsAt(currentType);
-      let matched = null;
-      let matchedEnd = -1;
-      for (let j = segments.length; j > i; j -= 1) {
-        const candidate = segments.slice(i, j).join(".");
-        const field = fields.find((f) => f.name === candidate);
-        if (field) {
-          matched = field;
-          matchedEnd = j;
-          break;
+      legacy.forEach((p) => {
+        const walk = splitPredicatePath(node.type, p.predicate) || {
+          edgeParts: [],
+          leaf: p.predicate,
+          edgePath: '',
         }
+        const unary = isUnaryFilter(p.func)
+        const cond = {
+          id: filterUid(),
+          func: p.func,
+          predicate: walk.leaf,
+          valueMode: p.mode === 'literal' || unary ? 'literal' : 'param',
+          literal: p.mode === 'literal' ? String(p.value ?? '') : '',
+          paramName: p.mode === 'literal' || unary ? '' : p.name,
+        }
+        if (!walk.edgePath) {
+          node.rootFilter.conditions.push(cond)
+        } else {
+          if (!node.edgeFilters[walk.edgePath]) {
+            node.edgeFilters[walk.edgePath] = emptyFilterGroup()
+          }
+          node.edgeFilters[walk.edgePath].conditions.push(cond)
+        }
+        if (!unary && p.mode !== 'literal') {
+          if (!kept.some((k) => k.name === p.name)) {
+            kept.push({
+              id: p.id || paramUid(),
+              name: p.name,
+              type: PARAM_TYPES.includes(p.type) ? p.type : 'string',
+              value: p.value ?? '',
+              mode: p.mode === 'default' ? 'default' : 'var',
+            })
+          }
+        }
+      })
+
+      node.params = kept
+      if (node.width != null)
+        node.width = Math.max(300, Number(node.width) || 380)
+      if (node.height != null)
+        node.height = Math.max(240, Number(node.height) || 520)
+      return node
+    }
+
+    function typeAtEdgePath(rootType, edgePath) {
+      if (!edgePath) return rootType
+      const walk = splitPredicatePath(rootType, edgePath)
+      if (!walk) return rootType
+      let typeName = rootType
+      for (const edge of walk.edgeParts) {
+        const field = (schema[typeName]?.fields || []).find(
+          (f) => f.name === edge,
+        )
+        if (!field?.ofType) return typeName
+        typeName = field.ofType
+      }
+      const leaf = (schema[typeName]?.fields || []).find(
+        (f) => f.name === walk.leaf,
+      )
+      return leaf?.ofType || typeName
+    }
+
+    function fieldDisplayName(name) {
+      const raw = String(name || '')
+      const i = raw.lastIndexOf('.')
+      return i >= 0 ? raw.slice(i + 1) : raw
+    }
+
+    function scalarOptionsForType(typeName) {
+      return scalarPredicates(typeName).map((f) => ({
+        value: f.name,
+        label: fieldDisplayName(f.name),
+      }))
+    }
+
+    function defaultName(typeName) {
+      const base = `get${typeName}`
+      if (!nodes.some((n) => n.name === base)) return base
+      let i = 2
+      while (nodes.some((n) => n.name === `${base}${i}`)) i += 1
+      return `${base}${i}`
+    }
+
+    function sanitizeName(raw, fallback) {
+      let name = String(raw || '')
+        .trim()
+        .replace(/^\$/, '')
+        .replace(/[^A-Za-z0-9_]/g, '_')
+        .replace(/^([^A-Za-z_])/, '_$1')
+      if (!name) name = fallback
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) name = fallback
+      return name
+    }
+
+    function defaultSelection(typeName) {
+      const def = schema[typeName]
+      const selection = {}
+      def.fields
+        .filter((f) => f.kind === 'scalar')
+        .slice(0, 2)
+        .forEach((f) => {
+          selection[f.name] = null
+        })
+      return selection
+    }
+
+    function scalarPredicates(typeName) {
+      return (schema[typeName]?.fields || []).filter(
+        (f) => f.kind === 'scalar' && f.name !== 'uid',
+      )
+    }
+
+    function defaultParamValue(type) {
+      if (type === 'int' || type === 'float') return '0'
+      if (type === 'bool') return 'false'
+      return ''
+    }
+
+    /** Resolve a predicate path to its schema field, respecting dotted field names. */
+    function resolvePredicateField(typeName, pathStr) {
+      const walk = splitPredicatePath(typeName, pathStr)
+      if (!walk) return null
+      let currentType = typeName
+      for (const edge of walk.edgeParts) {
+        const field = (schema[currentType]?.fields || []).find(
+          (f) => f.name === edge,
+        )
+        if (!field?.ofType) return null
+        currentType = field.ofType
+      }
+      return (
+        (schema[currentType]?.fields || []).find((f) => f.name === walk.leaf) ||
+        null
+      )
+    }
+
+    /**
+     * Split "posts.published" or a namespaced "User.email" into edge parts + leaf,
+     * matching longest field names on the schema at each step.
+     */
+    function splitPredicatePath(typeName, pathStr) {
+      const raw = String(pathStr || '')
+      if (!raw) return null
+
+      const fieldsAt = (t) => schema[t]?.fields || []
+      if (fieldsAt(typeName).some((f) => f.name === raw)) {
+        return { edgeParts: [], leaf: raw, edgePath: '' }
       }
 
-      if (!matched) {
+      const segments = raw.split('.')
+      const edgeParts = []
+      let currentType = typeName
+      let i = 0
+
+      while (i < segments.length) {
+        const fields = fieldsAt(currentType)
+        let matched = null
+        let matchedEnd = -1
+        for (let j = segments.length; j > i; j -= 1) {
+          const candidate = segments.slice(i, j).join('.')
+          const field = fields.find((f) => f.name === candidate)
+          if (field) {
+            matched = field
+            matchedEnd = j
+            break
+          }
+        }
+
+        if (!matched) {
+          return {
+            edgeParts,
+            leaf: segments.slice(i).join('.'),
+            edgePath: edgeParts.join('.'),
+          }
+        }
+
+        const start = i
+        i = matchedEnd
+
+        if (i >= segments.length) {
+          return {
+            edgeParts,
+            leaf: matched.name,
+            edgePath: edgeParts.join('.'),
+          }
+        }
+
+        if (matched.kind === 'object' && matched.ofType) {
+          edgeParts.push(matched.name)
+          currentType = matched.ofType
+          continue
+        }
+
+        // Scalar matched but path continues — keep the unmatched remainder as one leaf.
         return {
           edgeParts,
-          leaf: segments.slice(i).join("."),
-          edgePath: edgeParts.join("."),
-        };
+          leaf: segments.slice(start).join('.'),
+          edgePath: edgeParts.join('.'),
+        }
       }
 
-      const start = i;
-      i = matchedEnd;
-
-      if (i >= segments.length) {
-        return { edgeParts, leaf: matched.name, edgePath: edgeParts.join(".") };
-      }
-
-      if (matched.kind === "object" && matched.ofType) {
-        edgeParts.push(matched.name);
-        currentType = matched.ofType;
-        continue;
-      }
-
-      // Scalar matched but path continues — keep the unmatched remainder as one leaf.
-      return {
-        edgeParts,
-        leaf: segments.slice(start).join("."),
-        edgePath: edgeParts.join("."),
-      };
+      return null
     }
 
-    return null;
-  }
+    function paramTypeForPredicate(typeName, predicate) {
+      const field = resolvePredicateField(typeName, predicate)
+      return PARAM_TYPES.includes(field?.type) ? field.type : 'string'
+    }
 
-  function paramTypeForPredicate(typeName, predicate) {
-    const field = resolvePredicateField(typeName, predicate);
-    return PARAM_TYPES.includes(field?.type) ? field.type : "string";
-  }
+    function getAtPath(selection, path) {
+      let cursor = selection
+      for (const key of path) {
+        if (!cursor || typeof cursor !== 'object' || !(key in cursor))
+          return undefined
+        cursor = cursor[key]
+      }
+      return cursor
+    }
 
-  /**
-   * Filter targets for a block: its own scalar predicates plus, for every
-   * expanded object edge, the nested type's scalars as dotted paths
-   * ("posts.published"). Nested targets produce an @filter on that edge.
-   */
-  function filterTargets(typeName, selection, prefix = []) {
-    let targets = scalarPredicates(typeName).map((f) => {
-      const parts = [...prefix, f.name];
+    function setAtPath(selection, path, value) {
+      if (path.length === 0) return value
+      const [head, ...rest] = path
+      const next = { ...selection }
+      if (rest.length === 0) {
+        if (value === undefined) delete next[head]
+        else next[head] = value
+        return next
+      }
+      const child =
+        next[head] && typeof next[head] === 'object' ? { ...next[head] } : {}
+      next[head] = setAtPath(child, rest, value)
+      return next
+    }
+
+    function isSelected(selection, path) {
+      return getAtPath(selection, path) !== undefined
+    }
+
+    /** Encode a field-name path for data attributes (names may contain dots). */
+    function encodePath(path) {
+      return JSON.stringify(path)
+    }
+
+    function decodePath(raw) {
+      try {
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed)) return parsed.map(String)
+      } catch {
+        /* legacy dotted paths */
+      }
+      return String(raw || '')
+        .split('.')
+        .filter((p) => p.length)
+    }
+
+    function pathKey(path) {
+      return path.join('.')
+    }
+
+    function escapeAttr(value) {
+      return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+    }
+
+    function updateEmptyState() {
+      canvasEmptyEl.classList.toggle('hidden', nodes.length > 0)
+      if (!nodes.length) {
+        canvasEmptyEl.textContent =
+          'Edit DQL on the left, or add an entity from + Add entity above.'
+      }
+    }
+
+    function stopDragPropagation(el) {
+      ;['pointerdown', 'mousedown', 'click'].forEach((evt) => {
+        el.addEventListener(evt, (e) => e.stopPropagation())
+      })
+    }
+
+    function getNode(id) {
+      return nodes.find((n) => n.id === id)
+    }
+
+    function setSelected(id) {
+      selectedNodeId = id
+      canvasEl.querySelectorAll('.entity-node').forEach((nodeEl) => {
+        nodeEl.classList.toggle('selected', nodeEl.dataset.id === id)
+        nodeEl.style.zIndex = nodeEl.dataset.id === id ? '5' : '2'
+      })
+    }
+
+    /* ---------- Entity menu (canvas header) ---------- */
+
+    const DEFAULT_NODE_W = 420
+    const DEFAULT_NODE_H = 520
+    const NODE_GAP = 28
+    const CANVAS_PAD = 48
+    const CANVAS_MIN_W = 3200
+    const CANVAS_MIN_H = 2400
+
+    function estimateNodeSize(node) {
       return {
-        value: parts.join("."),
-        label: parts.map(fieldDisplayName).join("."),
-      };
-    });
+        w: Math.max(300, Number(node.width) || DEFAULT_NODE_W),
+        h: Math.max(220, Number(node.height) || DEFAULT_NODE_H),
+      }
+    }
 
-    if (prefix.length >= 6) return targets;
-
-    (schema[typeName]?.fields || [])
-      .filter(
-        (f) =>
-          f.kind === "object" &&
-          f.ofType &&
-          schema[f.ofType] &&
-          selection &&
-          typeof selection[f.name] === "object" &&
-          selection[f.name] !== null
+    function rectsOverlap(a, b, gap = NODE_GAP) {
+      return !(
+        a.x + a.w + gap <= b.x ||
+        b.x + b.w + gap <= a.x ||
+        a.y + a.h + gap <= b.y ||
+        b.y + b.h + gap <= a.y
       )
-      .forEach((f) => {
-        targets = targets.concat(
-          filterTargets(f.ofType, selection[f.name], [...prefix, f.name])
-        );
-      });
-
-    return targets;
-  }
-
-  function getAtPath(selection, path) {
-    let cursor = selection;
-    for (const key of path) {
-      if (!cursor || typeof cursor !== "object" || !(key in cursor)) return undefined;
-      cursor = cursor[key];
-    }
-    return cursor;
-  }
-
-  function setAtPath(selection, path, value) {
-    if (path.length === 0) return value;
-    const [head, ...rest] = path;
-    const next = { ...selection };
-    if (rest.length === 0) {
-      if (value === undefined) delete next[head];
-      else next[head] = value;
-      return next;
-    }
-    const child =
-      next[head] && typeof next[head] === "object" ? { ...next[head] } : {};
-    next[head] = setAtPath(child, rest, value);
-    return next;
-  }
-
-  function isSelected(selection, path) {
-    return getAtPath(selection, path) !== undefined;
-  }
-
-  /** Encode a field-name path for data attributes (names may contain dots). */
-  function encodePath(path) {
-    return JSON.stringify(path);
-  }
-
-  function decodePath(raw) {
-    try {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) return parsed.map(String);
-    } catch {
-      /* legacy dotted paths */
-    }
-    return String(raw || "").split(".").filter((p) => p.length);
-  }
-
-  function pathKey(path) {
-    return path.join(".");
-  }
-
-  function escapeAttr(value) {
-    return String(value ?? "")
-      .replace(/&/g, "&amp;")
-      .replace(/"/g, "&quot;")
-      .replace(/</g, "&lt;");
-  }
-
-  function updateEmptyState() {
-    canvasEmptyEl.classList.toggle("hidden", nodes.length > 0);
-    if (!nodes.length) {
-      canvasEmptyEl.textContent =
-        "Edit DQL on the left, or add an entity from + Add entity above.";
-    }
-  }
-
-  function stopDragPropagation(el) {
-    ["pointerdown", "mousedown", "click"].forEach((evt) => {
-      el.addEventListener(evt, (e) => e.stopPropagation());
-    });
-  }
-
-  function getNode(id) {
-    return nodes.find((n) => n.id === id);
-  }
-
-  function setSelected(id) {
-    selectedNodeId = id;
-    canvasEl.querySelectorAll(".entity-node").forEach((nodeEl) => {
-      nodeEl.classList.toggle("selected", nodeEl.dataset.id === id);
-      nodeEl.style.zIndex = nodeEl.dataset.id === id ? "5" : "2";
-    });
-  }
-
-  /* ---------- Entity menu (canvas header) ---------- */
-
-  const DEFAULT_NODE_W = 420;
-  const DEFAULT_NODE_H = 520;
-  const NODE_GAP = 28;
-  const CANVAS_PAD = 48;
-  const CANVAS_MIN_W = 3200;
-  const CANVAS_MIN_H = 2400;
-
-  function estimateNodeSize(node) {
-    return {
-      w: Math.max(300, Number(node.width) || DEFAULT_NODE_W),
-      h: Math.max(220, Number(node.height) || DEFAULT_NODE_H),
-    };
-  }
-
-  function rectsOverlap(a, b, gap = NODE_GAP) {
-    return !(
-      a.x + a.w + gap <= b.x ||
-      b.x + b.w + gap <= a.x ||
-      a.y + a.h + gap <= b.y ||
-      b.y + b.h + gap <= a.y
-    );
-  }
-
-  function findFreePosition(width, height, preferred, excludeId) {
-    const w = width || DEFAULT_NODE_W;
-    const h = height || DEFAULT_NODE_H;
-    const others = nodes
-      .filter((n) => n.id !== excludeId)
-      .map((n) => {
-        const s = estimateNodeSize(n);
-        return { x: n.x, y: n.y, w: s.w, h: s.h };
-      });
-
-    const tryPos = (x, y) => {
-      const cand = { x: Math.max(CANVAS_PAD, x), y: Math.max(CANVAS_PAD, y), w, h };
-      if (!others.some((o) => rectsOverlap(cand, o))) return cand;
-      return null;
-    };
-
-    if (preferred) {
-      const hit = tryPos(preferred.x, preferred.y);
-      if (hit) return hit;
     }
 
-    // Scan a grid across a generous canvas.
-    const stepX = Math.floor(w + NODE_GAP);
-    const stepY = Math.floor(Math.min(h, 280) + NODE_GAP);
-    for (let row = 0; row < 40; row += 1) {
-      for (let col = 0; col < 24; col += 1) {
-        const hit = tryPos(CANVAS_PAD + col * stepX, CANVAS_PAD + row * stepY);
-        if (hit) return hit;
+    function findFreePosition(width, height, preferred, excludeId) {
+      const w = width || DEFAULT_NODE_W
+      const h = height || DEFAULT_NODE_H
+      const others = nodes
+        .filter((n) => n.id !== excludeId)
+        .map((n) => {
+          const s = estimateNodeSize(n)
+          return { x: n.x, y: n.y, w: s.w, h: s.h }
+        })
+
+      const tryPos = (x, y) => {
+        const cand = {
+          x: Math.max(CANVAS_PAD, x),
+          y: Math.max(CANVAS_PAD, y),
+          w,
+          h,
+        }
+        if (!others.some((o) => rectsOverlap(cand, o))) return cand
+        return null
+      }
+
+      if (preferred) {
+        const hit = tryPos(preferred.x, preferred.y)
+        if (hit) return hit
+      }
+
+      // Scan a grid across a generous canvas.
+      const stepX = Math.floor(w + NODE_GAP)
+      const stepY = Math.floor(Math.min(h, 280) + NODE_GAP)
+      for (let row = 0; row < 40; row += 1) {
+        for (let col = 0; col < 24; col += 1) {
+          const hit = tryPos(CANVAS_PAD + col * stepX, CANVAS_PAD + row * stepY)
+          if (hit) return hit
+        }
+      }
+      return {
+        x: CANVAS_PAD + nodes.length * 24,
+        y: CANVAS_PAD + nodes.length * 24,
+        w,
+        h,
       }
     }
-    return {
-      x: CANVAS_PAD + nodes.length * 24,
-      y: CANVAS_PAD + nodes.length * 24,
-      w,
-      h,
-    };
-  }
 
-  /** Push overlapping cards onto free slots (session restore / imports). */
-  function resolveOverlaps() {
-    nodes.forEach((n) => {
-      const s = estimateNodeSize(n);
-      const self = { x: n.x, y: n.y, w: s.w, h: s.h };
-      const hit = nodes.some((o) => {
-        if (o.id === n.id) return false;
-        const os = estimateNodeSize(o);
-        return rectsOverlap(self, { x: o.x, y: o.y, w: os.w, h: os.h });
-      });
-      if (!hit) return;
-      const pos = findFreePosition(s.w, s.h, null, n.id);
-      n.x = pos.x;
-      n.y = pos.y;
-    });
-  }
+    /** Push overlapping cards onto free slots (session restore / imports). */
+    function resolveOverlaps() {
+      nodes.forEach((n) => {
+        const s = estimateNodeSize(n)
+        const self = { x: n.x, y: n.y, w: s.w, h: s.h }
+        const hit = nodes.some((o) => {
+          if (o.id === n.id) return false
+          const os = estimateNodeSize(o)
+          return rectsOverlap(self, { x: o.x, y: o.y, w: os.w, h: os.h })
+        })
+        if (!hit) return
+        const pos = findFreePosition(s.w, s.h, null, n.id)
+        n.x = pos.x
+        n.y = pos.y
+      })
+    }
 
-  function updateCanvasSurface() {
-    if (!canvasSurfaceEl) return;
-    let maxR = CANVAS_MIN_W;
-    let maxB = CANVAS_MIN_H;
-    nodes.forEach((n) => {
-      const s = estimateNodeSize(n);
-      maxR = Math.max(maxR, n.x + s.w + 600);
-      maxB = Math.max(maxB, n.y + s.h + 600);
-    });
-    // Also account for live DOM sizes when available.
-    canvasEl.querySelectorAll(".entity-node").forEach((el) => {
-      const x = parseFloat(el.style.left) || 0;
-      const y = parseFloat(el.style.top) || 0;
-      maxR = Math.max(maxR, x + el.offsetWidth + 600);
-      maxB = Math.max(maxB, y + el.offsetHeight + 600);
-    });
-    canvasSurfaceEl.style.width = `${Math.ceil(maxR)}px`;
-    canvasSurfaceEl.style.height = `${Math.ceil(maxB)}px`;
-  }
+    function updateCanvasSurface() {
+      if (!canvasSurfaceEl) return
+      let maxR = CANVAS_MIN_W
+      let maxB = CANVAS_MIN_H
+      nodes.forEach((n) => {
+        const s = estimateNodeSize(n)
+        maxR = Math.max(maxR, n.x + s.w + 600)
+        maxB = Math.max(maxB, n.y + s.h + 600)
+      })
+      // Also account for live DOM sizes when available.
+      canvasEl.querySelectorAll('.entity-node').forEach((el) => {
+        const x = parseFloat(el.style.left) || 0
+        const y = parseFloat(el.style.top) || 0
+        maxR = Math.max(maxR, x + el.offsetWidth + 600)
+        maxB = Math.max(maxB, y + el.offsetHeight + 600)
+      })
+      canvasSurfaceEl.style.width = `${Math.ceil(maxR)}px`
+      canvasSurfaceEl.style.height = `${Math.ceil(maxB)}px`
+    }
 
-  function closeEntityMenu() {
-    if (!entityMenuEl || !addEntityBtn) return;
-    entityMenuEl.hidden = true;
-    addEntityBtn.setAttribute("aria-expanded", "false");
-  }
+    function closeEntityMenu() {
+      if (!entityMenuEl || !addEntityBtn) return
+      entityMenuEl.hidden = true
+      addEntityBtn.setAttribute('aria-expanded', 'false')
+    }
 
-  function toggleEntityMenu() {
-    if (!entityMenuEl || !addEntityBtn) return;
-    const open = entityMenuEl.hidden;
-    entityMenuEl.hidden = !open;
-    addEntityBtn.setAttribute("aria-expanded", open ? "true" : "false");
-  }
+    function toggleEntityMenu() {
+      if (!entityMenuEl || !addEntityBtn) return
+      const open = entityMenuEl.hidden
+      entityMenuEl.hidden = !open
+      addEntityBtn.setAttribute('aria-expanded', open ? 'true' : 'false')
+    }
 
-  function renderDock() {
-    renderEntityMenu();
-  }
+    function renderDock() {
+      renderEntityMenu()
+    }
 
-  function renderEntityMenu() {
-    if (!entityMenuEl) return;
-    entityMenuEl.innerHTML = "";
-    const list = document.createElement("div");
-    list.className = "entity-menu-list";
+    function renderEntityMenu() {
+      if (!entityMenuEl) return
+      entityMenuEl.innerHTML = ''
+      const list = document.createElement('div')
+      list.className = 'entity-menu-list'
 
-    Object.entries(schema).forEach(([typeName, def]) => {
-      const item = document.createElement("button");
-      item.type = "button";
-      item.className = "entity-menu-item";
-      item.role = "menuitem";
-      item.draggable = true;
-      item.dataset.type = typeName;
-      item.title = `Add ${typeName} query block — drag onto canvas or click`;
-      item.innerHTML = `
+      Object.entries(schema).forEach(([typeName, def]) => {
+        const item = document.createElement('button')
+        item.type = 'button'
+        item.className = 'entity-menu-item'
+        item.role = 'menuitem'
+        item.draggable = true
+        item.dataset.type = typeName
+        item.title = `Add ${typeName} query block — drag onto canvas or click`
+        item.innerHTML = `
         <span class="palette-dot" style="background:${def.color}"></span>
         <span class="entity-menu-name">${typeName}</span>
         <span class="entity-menu-hint">+</span>
-      `;
-      item.addEventListener("click", () => {
-        closeEntityMenu();
-        const pos = findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H);
-        placeEntity(typeName, pos.x, pos.y);
-      });
-      item.addEventListener("dragstart", (e) => {
-        dragPaletteType = typeName;
-        item.classList.add("dragging");
-        e.dataTransfer.effectAllowed = "copy";
-        e.dataTransfer.setData("text/plain", typeName);
-      });
-      item.addEventListener("dragend", () => {
-        dragPaletteType = null;
-        item.classList.remove("dragging");
-      });
-      list.appendChild(item);
-    });
+      `
+        item.addEventListener('click', () => {
+          closeEntityMenu()
+          const pos = findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H)
+          placeEntity(typeName, pos.x, pos.y)
+        })
+        item.addEventListener('dragstart', (e) => {
+          dragPaletteType = typeName
+          item.classList.add('dragging')
+          e.dataTransfer.effectAllowed = 'copy'
+          e.dataTransfer.setData('text/plain', typeName)
+        })
+        item.addEventListener('dragend', () => {
+          dragPaletteType = null
+          item.classList.remove('dragging')
+        })
+        list.appendChild(item)
+      })
 
-    entityMenuEl.appendChild(list);
-  }
-
-  /* ---------- Query block rendering ---------- */
-
-  function renderFilterValueControls(cond, params) {
-    const unary = isUnaryFilter(cond.func);
-    if (unary) return `<span class="filter-value-blank">—</span>`;
-
-    const mode = cond.valueMode === "param" ? "param" : "literal";
-    const modeOpts = optionsHtml(
-      [
-        { value: "literal", label: "literal" },
-        { value: "param", label: "$param" },
-      ],
-      mode
-    );
-
-    if (mode === "param") {
-      const paramOpts = (params || []).map((p) => ({
-        value: p.name,
-        label: `$${p.name}`,
-      }));
-      return `
-        <select class="filter-value-mode" title="Value source">${modeOpts}</select>
-        <select class="filter-param" title="Parameter">${optionsHtml(
-          paramOpts.length ? paramOpts : [{ value: "", label: "— add a $param" }],
-          cond.paramName || ""
-        )}</select>
-      `;
+      entityMenuEl.appendChild(list)
     }
 
-    return `
-      <select class="filter-value-mode" title="Value source">${modeOpts}</select>
-      <input type="text" class="filter-literal" value="${escapeAttr(cond.literal || "")}" placeholder="value" spellcheck="false" title="Literal value" />
-    `;
-  }
+    /* ---------- Query block rendering ---------- */
 
-  function renderFilterGroupPanel(group, typeName, params, { edgePath = "", compact = false } = {}) {
-    const g = ensureFilterGroup(group);
-    const preds = scalarOptionsForType(typeName);
-    const rows = g.conditions
-      .map((cond) => {
-        const unary = isUnaryFilter(cond.func);
+    function renderFilterValueControls(cond, params) {
+      const unary = isUnaryFilter(cond.func)
+      if (unary) return `<span class="filter-value-blank">—</span>`
+
+      const mode = cond.valueMode === 'param' ? 'param' : 'literal'
+      const modeOpts = optionsHtml(
+        [
+          { value: 'literal', label: 'literal' },
+          { value: 'param', label: '$param' },
+        ],
+        mode,
+      )
+
+      if (mode === 'param') {
+        const paramOpts = (params || []).map((p) => ({
+          value: p.name,
+          label: `$${p.name}`,
+        }))
         return `
+        <select class="filter-value-mode" title="Value source">${modeOpts}</select>
+        <select class="filter-param" title="Parameter">${optionsHtml(
+          paramOpts.length
+            ? paramOpts
+            : [{ value: '', label: '— add a $param' }],
+          cond.paramName || '',
+        )}</select>
+      `
+      }
+
+      return `
+      <select class="filter-value-mode" title="Value source">${modeOpts}</select>
+      <input type="text" class="filter-literal" value="${escapeAttr(cond.literal || '')}" placeholder="value" spellcheck="false" title="Literal value" />
+    `
+    }
+
+    function renderFilterGroupPanel(
+      group,
+      typeName,
+      params,
+      { edgePath = '', compact = false } = {},
+    ) {
+      const g = ensureFilterGroup(group)
+      const preds = scalarOptionsForType(typeName)
+      const rows = g.conditions
+        .map((cond) => {
+          return `
           <div class="filter-row" data-filter-id="${cond.id}">
-            <select class="filter-func" title="Filter function">${optionsHtml(FILTER_FUNCS, cond.func || "eq")}</select>
+            <select class="filter-func" title="Filter function">${optionsHtml(FILTER_FUNCS, cond.func || 'eq')}</select>
             <select class="filter-predicate" title="Predicate">${optionsHtml(
-              preds.length ? preds : [{ value: "", label: "—" }],
-              cond.predicate || ""
+              preds.length ? preds : [{ value: '', label: '—' }],
+              cond.predicate || '',
             )}</select>
             ${renderFilterValueControls(cond, params)}
             <button type="button" class="filter-remove" title="Remove filter" aria-label="Remove filter">×</button>
           </div>
-        `;
-      })
-      .join("");
+        `
+        })
+        .join('')
 
-    const cls = compact ? "filter-panel is-edge" : "filter-panel is-root";
-    return `
+      const cls = compact ? 'filter-panel is-edge' : 'filter-panel is-root'
+      return `
       <div class="${cls}" data-edge-path="${escapeAttr(edgePath)}">
         <div class="filter-panel-head">
           <span class="filter-panel-label">@filter</span>
           <div class="filter-op-toggle" role="group" aria-label="Combine filters with">
-            <button type="button" class="filter-op-btn${g.op !== "OR" ? " active" : ""}" data-op="AND">AND</button>
-            <button type="button" class="filter-op-btn${g.op === "OR" ? " active" : ""}" data-op="OR">OR</button>
+            <button type="button" class="filter-op-btn${g.op !== 'OR' ? ' active' : ''}" data-op="AND">AND</button>
+            <button type="button" class="filter-op-btn${g.op === 'OR' ? ' active' : ''}" data-op="OR">OR</button>
           </div>
           <button type="button" class="btn-mini add-filter">+ Add</button>
         </div>
         ${rows || '<p class="filter-empty">No conditions</p>'}
       </div>
-    `;
-  }
+    `
+    }
 
-  function renderFieldTree(typeName, selection, path, depth, aliases, node) {
-    const def = schema[typeName];
-    if (!def) return "";
+    function renderFieldTree(typeName, selection, path, depth, aliases, node) {
+      const def = schema[typeName]
+      if (!def) return ''
 
-    return def.fields
-      .map((field) => {
-        const fieldPath = [...path, field.name];
-        const key = pathKey(fieldPath);
-        const checked = isSelected(selection, fieldPath);
-        const isObject = field.kind === "object";
-        const objectClass = isObject ? " is-object" : "";
+      return def.fields
+        .map((field) => {
+          const fieldPath = [...path, field.name]
+          const key = pathKey(fieldPath)
+          const checked = isSelected(selection, fieldPath)
+          const isObject = field.kind === 'object'
+          const objectClass = isObject ? ' is-object' : ''
 
-        let edgeFilterHtml = "";
-        let nestedHtml = "";
-        if (isObject && checked && field.ofType && schema[field.ofType] && depth < 8) {
-          const edgeGroup = node.edgeFilters?.[key] || emptyFilterGroup();
-          edgeFilterHtml = renderFilterGroupPanel(edgeGroup, field.ofType, node.params, {
-            edgePath: key,
-            compact: true,
-          });
-          nestedHtml = `
+          let edgeFilterHtml = ''
+          let nestedHtml = ''
+          if (
+            isObject &&
+            checked &&
+            field.ofType &&
+            schema[field.ofType] &&
+            depth < 8
+          ) {
+            const edgeGroup = node.edgeFilters?.[key] || emptyFilterGroup()
+            edgeFilterHtml = renderFilterGroupPanel(
+              edgeGroup,
+              field.ofType,
+              node.params,
+              {
+                edgePath: key,
+                compact: true,
+              },
+            )
+            nestedHtml = `
             <ul class="nested-fields" data-depth="${depth + 1}">
               ${renderFieldTree(field.ofType, selection, fieldPath, depth + 1, aliases, node)}
             </ul>
-          `;
-        }
+          `
+          }
 
-        const aliasValue = aliases[key] || "";
-        const aliasHtml = checked
-          ? `<input
+          const aliasValue = aliases[key] || ''
+          const aliasHtml = checked
+            ? `<input
               type="text"
               class="alias-input"
               data-alias-path="${escapeAttr(encodePath(fieldPath))}"
@@ -1081,10 +1102,10 @@ window.DQLBuilder = (() => {
               spellcheck="false"
               title="Alias — result key for this predicate"
             />`
-          : `<span class="field-type" title="${escapeAttr(field.type)}">${field.type}</span>`;
+            : `<span class="field-type" title="${escapeAttr(field.type)}">${field.type}</span>`
 
-        const label = fieldDisplayName(field.name);
-        return `
+          const label = fieldDisplayName(field.name)
+          return `
           <li>
             <div class="field-row${objectClass}" style="padding-left:${0.35 + depth * 0.4}rem">
               <label class="field-check">
@@ -1092,8 +1113,8 @@ window.DQLBuilder = (() => {
                   type="checkbox"
                   data-path="${escapeAttr(encodePath(fieldPath))}"
                   data-kind="${field.kind}"
-                  data-oftype="${field.ofType || ""}"
-                  ${checked ? "checked" : ""}
+                  data-oftype="${field.ofType || ''}"
+                  ${checked ? 'checked' : ''}
                 />
                 <span class="field-name" title="${escapeAttr(field.name)}">${escapeAttr(label)}</span>
               </label>
@@ -1102,29 +1123,33 @@ window.DQLBuilder = (() => {
             ${edgeFilterHtml}
             ${nestedHtml}
           </li>
-        `;
-      })
-      .join("");
-  }
-
-  function optionsHtml(items, selected) {
-    const list = items.slice();
-    if (selected != null && selected !== "" && !list.some((item) => item.value === selected)) {
-      list.push({ value: selected, label: selected });
+        `
+        })
+        .join('')
     }
-    return list
-      .map(
-        (item) =>
-          `<option value="${item.value}" ${item.value === selected ? "selected" : ""}>${item.label}</option>`
-      )
-      .join("");
-  }
 
-  function renderParamsSection(node) {
-    const rows = (node.params || [])
-      .map((param) => {
-        const typeOpts = PARAM_TYPES.map((t) => ({ value: t, label: t }));
-        return `
+    function optionsHtml(items, selected) {
+      const list = items.slice()
+      if (
+        selected != null &&
+        selected !== '' &&
+        !list.some((item) => item.value === selected)
+      ) {
+        list.push({ value: selected, label: selected })
+      }
+      return list
+        .map(
+          (item) =>
+            `<option value="${item.value}" ${item.value === selected ? 'selected' : ''}>${item.label}</option>`,
+        )
+        .join('')
+    }
+
+    function renderParamsSection(node) {
+      const rows = (node.params || [])
+        .map((param) => {
+          const typeOpts = PARAM_TYPES.map((t) => ({ value: t, label: t }))
+          return `
           <div class="param-card" data-param-id="${param.id}">
             <div class="param-main">
               <input type="text" class="param-name" value="${escapeAttr(param.name)}" placeholder="name" spellcheck="false" title="Parameter name" />
@@ -1133,20 +1158,20 @@ window.DQLBuilder = (() => {
               <select class="param-mode" title="$variable, or $variable with a default in the signature">
                 ${optionsHtml(
                   [
-                    { value: "var", label: "$var" },
-                    { value: "default", label: "$ = def" },
+                    { value: 'var', label: '$var' },
+                    { value: 'default', label: '$ = def' },
                   ],
-                  param.mode || "var"
+                  param.mode || 'var',
                 )}
               </select>
               <button type="button" class="param-remove" title="Remove parameter" aria-label="Remove parameter">×</button>
             </div>
           </div>
-        `;
-      })
-      .join("");
+        `
+        })
+        .join('')
 
-    return `
+      return `
       <div class="block-section params-section">
         <div class="block-section-head">
           <span class="block-section-title">Parameters</span>
@@ -1154,75 +1179,75 @@ window.DQLBuilder = (() => {
         </div>
         ${rows || '<p class="param-empty">$variables for filters to reference</p>'}
       </div>
-    `;
-  }
+    `
+    }
 
-  function renderRootFiltersSection(node) {
-    return `
+    function renderRootFiltersSection(node) {
+      return `
       <div class="block-section filters-section">
         <div class="block-section-head no-margin">
           <span class="block-section-title">Root filters</span>
         </div>
-        ${renderFilterGroupPanel(node.rootFilter, node.type, node.params, { edgePath: "" })}
+        ${renderFilterGroupPanel(node.rootFilter, node.type, node.params, { edgePath: '' })}
       </div>
-    `;
-  }
+    `
+    }
 
-  function renderDirectivesSection(node) {
-    const toggle = (key) => `
+    function renderDirectivesSection(node) {
+      const toggle = (key) => `
       <button
         type="button"
-        class="directive-toggle${node.directives?.[key] ? " active" : ""}"
+        class="directive-toggle${node.directives?.[key] ? ' active' : ''}"
         data-directive="${key}"
         title="Toggle @${key} on this query block"
       >@${key}</button>
-    `;
-    return `
+    `
+      return `
       <div class="block-section directives-section">
         <div class="block-section-head no-margin">
           <span class="block-section-title">Directives</span>
           <div class="directive-toggles">
-            ${toggle("cascade")}
-            ${toggle("normalize")}
+            ${toggle('cascade')}
+            ${toggle('normalize')}
           </div>
         </div>
       </div>
-    `;
-  }
+    `
+    }
 
-  function renderNodes() {
-    // Full re-render replaces the DOM — keep field-list scroll so toggling
-    // a property near the bottom doesn't jump back to the top.
-    const fieldScroll = new Map();
-    canvasEl.querySelectorAll(".entity-node").forEach((el) => {
-      const id = el.dataset.id;
-      const body = el.querySelector(".entity-node-body");
-      if (id && body) {
-        fieldScroll.set(id, { top: body.scrollTop, left: body.scrollLeft });
-      }
-    });
+    function renderNodes() {
+      // Full re-render replaces the DOM — keep field-list scroll so toggling
+      // a property near the bottom doesn't jump back to the top.
+      const fieldScroll = new Map()
+      canvasEl.querySelectorAll('.entity-node').forEach((el) => {
+        const id = el.dataset.id
+        const body = el.querySelector('.entity-node-body')
+        if (id && body) {
+          fieldScroll.set(id, { top: body.scrollTop, left: body.scrollLeft })
+        }
+      })
 
-    canvasEl.querySelectorAll(".entity-node").forEach((el) => el.remove());
+      canvasEl.querySelectorAll('.entity-node').forEach((el) => el.remove())
 
-    nodes.forEach((node) => {
-      const def = schema[node.type];
-      const el = document.createElement("article");
-      el.className = `entity-node${selectedNodeId === node.id ? " selected" : ""}`;
-      el.dataset.id = node.id;
-      el.style.left = `${node.x}px`;
-      el.style.top = `${node.y}px`;
-      el.style.zIndex = selectedNodeId === node.id ? "5" : "2";
-      const size = estimateNodeSize(node);
-      el.style.width = `${size.w}px`;
-      el.style.height = `${size.h}px`;
-      if (!node.width) node.width = size.w;
-      if (!node.height) node.height = size.h;
+      nodes.forEach((node) => {
+        const def = schema[node.type]
+        const el = document.createElement('article')
+        el.className = `entity-node${selectedNodeId === node.id ? ' selected' : ''}`
+        el.dataset.id = node.id
+        el.style.left = `${node.x}px`
+        el.style.top = `${node.y}px`
+        el.style.zIndex = selectedNodeId === node.id ? '5' : '2'
+        const size = estimateNodeSize(node)
+        el.style.width = `${size.w}px`
+        el.style.height = `${size.h}px`
+        if (!node.width) node.width = size.w
+        if (!node.height) node.height = size.h
 
-      // Pop-in only on first appearance, not on every re-render.
-      if (animatedNodes.has(node.id)) el.style.animation = "none";
-      else animatedNodes.add(node.id);
+        // Pop-in only on first appearance, not on every re-render.
+        if (animatedNodes.has(node.id)) el.style.animation = 'none'
+        else animatedNodes.add(node.id)
 
-      el.innerHTML = `
+        el.innerHTML = `
         <header class="entity-node-header" data-drag-handle>
           <span class="dot" style="background:${def.color}"></span>
           <div class="entity-node-meta">
@@ -1238,7 +1263,7 @@ window.DQLBuilder = (() => {
             <input
               type="text"
               class="result-name-input"
-              value="${escapeAttr(node.resultName || "")}"
+              value="${escapeAttr(node.resultName || '')}"
               placeholder="${escapeAttr(innerBlockName(sanitizeName(node.name, `get${node.type}`)))}"
               spellcheck="false"
               aria-label="Result key"
@@ -1254,1043 +1279,1112 @@ window.DQLBuilder = (() => {
           <ul class="entity-fields">${renderFieldTree(node.type, node.selection, [], 0, node.aliases || {}, node)}</ul>
         </div>
         <div class="entity-resize" data-resize-handle title="Drag to resize"></div>
-      `;
+      `
 
-      const header = el.querySelector(".entity-node-header");
-      const nameInput = el.querySelector(".query-name-input");
+        const header = el.querySelector('.entity-node-header')
+        const nameInput = el.querySelector('.query-name-input')
 
-      header.addEventListener("pointerdown", (e) => {
-        if (e.target.closest(".entity-node-remove, .query-name-input, .result-name-input")) return;
-        e.preventDefault();
-        setSelected(node.id);
-        const rect = el.getBoundingClientRect();
-        moveState = {
-          id: node.id,
-          offsetX: e.clientX - rect.left,
-          offsetY: e.clientY - rect.top,
-        };
-        el.classList.add("dragging");
-        document.body.classList.add("is-dragging-node");
-      });
-
-      const resizeHandle = el.querySelector("[data-resize-handle]");
-      if (resizeHandle) {
-        resizeHandle.addEventListener("pointerdown", (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          setSelected(node.id);
-          resizeState = {
+        header.addEventListener('pointerdown', (e) => {
+          if (
+            e.target.closest(
+              '.entity-node-remove, .query-name-input, .result-name-input',
+            )
+          )
+            return
+          e.preventDefault()
+          setSelected(node.id)
+          const rect = el.getBoundingClientRect()
+          moveState = {
             id: node.id,
-            startX: e.clientX,
-            startY: e.clientY,
-            startW: el.offsetWidth,
-            startH: el.offsetHeight,
-          };
-          el.classList.add("resizing");
-          document.body.classList.add("is-resizing-node");
-          resizeHandle.setPointerCapture?.(e.pointerId);
-        });
-      }
-
-      stopDragPropagation(nameInput);
-      nameInput.addEventListener("input", () => {
-        node.name = nameInput.value;
-        refreshQuery();
-      });
-      nameInput.addEventListener("change", () => {
-        node.name = sanitizeName(nameInput.value, defaultName(node.type));
-        nameInput.value = node.name;
-        refreshQuery();
-      });
-      nameInput.addEventListener("keydown", (e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          nameInput.blur();
-        }
-        e.stopPropagation();
-      });
-
-      const resultInput = el.querySelector(".result-name-input");
-      stopDragPropagation(resultInput);
-      resultInput.addEventListener("input", () => {
-        node.resultName = resultInput.value;
-        refreshQuery();
-      });
-      resultInput.addEventListener("change", () => {
-        node.resultName = resultInput.value.trim()
-          ? sanitizeName(resultInput.value, "")
-          : "";
-        resultInput.value = node.resultName;
-        refreshQuery();
-      });
-      resultInput.addEventListener("keydown", (e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          resultInput.blur();
-        }
-        e.stopPropagation();
-      });
-
-      el.querySelectorAll(".alias-input").forEach((input) => {
-        stopDragPropagation(input);
-        const syncAliasSize = () => {
-          const len = Math.max(5, Math.min(28, (input.value || "alias").length + 1));
-          input.size = len;
-        };
-        syncAliasSize();
-        input.addEventListener("input", () => {
-          const key = pathKey(decodePath(input.dataset.aliasPath));
-          const value = input.value.trim();
-          if (value) node.aliases[key] = value;
-          else delete node.aliases[key];
-          syncAliasSize();
-          refreshQuery();
-        });
-        input.addEventListener("change", () => {
-          const key = pathKey(decodePath(input.dataset.aliasPath));
-          if (node.aliases[key]) {
-            // Aliases may be dotted (Author.Name), so keep dots.
-            node.aliases[key] = node.aliases[key].replace(/[^A-Za-z0-9_.]/g, "_");
-            input.value = node.aliases[key];
-            syncAliasSize();
-            refreshQuery();
+            offsetX: e.clientX - rect.left,
+            offsetY: e.clientY - rect.top,
           }
-        });
-        input.addEventListener("keydown", (e) => e.stopPropagation());
-      });
+          el.classList.add('dragging')
+          document.body.classList.add('is-dragging-node')
+        })
 
-      el.querySelector(".entity-node-remove").addEventListener("click", (e) => {
-        e.stopPropagation();
-        nodes = nodes.filter((n) => n.id !== node.id);
-        if (selectedNodeId === node.id) selectedNodeId = null;
-        renderNodes();
-        refreshQuery();
-      });
-
-      el.querySelectorAll(".directive-toggle").forEach((btn) => {
-        stopDragPropagation(btn);
-        btn.addEventListener("click", () => {
-          const key = btn.dataset.directive;
-          node.directives[key] = !node.directives[key];
-          btn.classList.toggle("active", node.directives[key]);
-          refreshQuery();
-        });
-      });
-
-      el.querySelector(".add-param").addEventListener("click", (e) => {
-        e.stopPropagation();
-        let name = `param${node.params.length + 1}`;
-        let i = 2;
-        while (node.params.some((p) => p.name === name)) {
-          name = `param${i}`;
-          i += 1;
+        const resizeHandle = el.querySelector('[data-resize-handle]')
+        if (resizeHandle) {
+          resizeHandle.addEventListener('pointerdown', (e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setSelected(node.id)
+            resizeState = {
+              id: node.id,
+              startX: e.clientX,
+              startY: e.clientY,
+              startW: el.offsetWidth,
+              startH: el.offsetHeight,
+            }
+            el.classList.add('resizing')
+            document.body.classList.add('is-resizing-node')
+            resizeHandle.setPointerCapture?.(e.pointerId)
+          })
         }
-        node.params.push({
-          id: paramUid(),
-          name,
-          type: "string",
-          value: "",
-          mode: "var",
-        });
-        renderNodes();
-        refreshQuery();
-      });
 
-      el.querySelectorAll(".param-card").forEach((card) => {
-        const param = node.params.find((p) => p.id === card.dataset.paramId);
-        if (!param) return;
-
-        const nameEl = card.querySelector(".param-name");
-        const typeEl = card.querySelector(".param-type");
-        const valueEl = card.querySelector(".param-value");
-        const modeEl = card.querySelector(".param-mode");
-        const removeBtn = card.querySelector(".param-remove");
-
-        [nameEl, typeEl, valueEl, modeEl, removeBtn].forEach(stopDragPropagation);
-
-        modeEl.addEventListener("change", () => {
-          param.mode = modeEl.value === "default" ? "default" : "var";
-          refreshQuery();
-        });
-        nameEl.addEventListener("input", () => {
-          const prev = param.name;
-          param.name = nameEl.value.replace(/^\$/, "");
-          // Keep filter references in sync while typing.
-          const renameIn = (group) => {
-            (group?.conditions || []).forEach((c) => {
-              if (c.valueMode === "param" && c.paramName === prev) c.paramName = param.name;
-            });
-          };
-          renameIn(node.rootFilter);
-          Object.values(node.edgeFilters || {}).forEach(renameIn);
-          refreshQuery();
-        });
-        nameEl.addEventListener("change", () => {
-          const prev = param.name;
-          param.name = sanitizeName(param.name, "param");
-          nameEl.value = param.name;
-          const renameIn = (group) => {
-            (group?.conditions || []).forEach((c) => {
-              if (c.valueMode === "param" && c.paramName === prev) c.paramName = param.name;
-            });
-          };
-          renameIn(node.rootFilter);
-          Object.values(node.edgeFilters || {}).forEach(renameIn);
-          renderNodes();
-          refreshQuery();
-        });
-        typeEl.addEventListener("change", () => {
-          param.type = typeEl.value;
-          if (!param.value) param.value = defaultParamValue(param.type);
-          refreshQuery();
-        });
-        valueEl.addEventListener("input", () => {
-          param.value = valueEl.value;
-          refreshQuery();
-        });
-        removeBtn.addEventListener("click", () => {
-          const removed = param.name;
-          node.params = node.params.filter((p) => p.id !== param.id);
-          const clearRef = (group) => {
-            (group?.conditions || []).forEach((c) => {
-              if (c.valueMode === "param" && c.paramName === removed) {
-                c.paramName = "";
-              }
-            });
-          };
-          clearRef(node.rootFilter);
-          Object.values(node.edgeFilters || {}).forEach(clearRef);
-          renderNodes();
-          refreshQuery();
-        });
-      });
-
-      const getFilterGroup = (edgePath) => {
-        if (!edgePath) {
-          if (!node.rootFilter) node.rootFilter = emptyFilterGroup();
-          return node.rootFilter;
-        }
-        if (!node.edgeFilters) node.edgeFilters = {};
-        if (!node.edgeFilters[edgePath]) node.edgeFilters[edgePath] = emptyFilterGroup();
-        return node.edgeFilters[edgePath];
-      };
-
-      el.querySelectorAll(".filter-panel").forEach((panel) => {
-        const edgePath = panel.dataset.edgePath || "";
-        const group = getFilterGroup(edgePath);
-        const typeName = typeAtEdgePath(node.type, edgePath);
-
-        panel.querySelectorAll(".filter-op-btn").forEach((btn) => {
-          stopDragPropagation(btn);
-          btn.addEventListener("click", () => {
-            group.op = btn.dataset.op === "OR" ? "OR" : "AND";
-            renderNodes();
-            refreshQuery();
-          });
-        });
-
-        panel.querySelector(".add-filter")?.addEventListener("click", (e) => {
-          e.stopPropagation();
-          const preds = scalarPredicates(typeName);
-          const used = new Set(group.conditions.map((c) => c.predicate));
-          const next = preds.find((p) => !used.has(p.name)) || preds[0];
-          const predName = next?.name || "";
-          const type = paramTypeForPredicate(typeName, predName);
-          group.conditions.push(newFilterCondition(predName, type));
-          renderNodes();
-          refreshQuery();
-        });
-
-        panel.querySelectorAll(".filter-row").forEach((row) => {
-          const cond = group.conditions.find((c) => c.id === row.dataset.filterId);
-          if (!cond) return;
-
-          const funcEl = row.querySelector(".filter-func");
-          const predEl = row.querySelector(".filter-predicate");
-          const modeEl = row.querySelector(".filter-value-mode");
-          const literalEl = row.querySelector(".filter-literal");
-          const paramEl = row.querySelector(".filter-param");
-          const removeBtn = row.querySelector(".filter-remove");
-
-          [funcEl, predEl, modeEl, literalEl, paramEl, removeBtn]
-            .filter(Boolean)
-            .forEach(stopDragPropagation);
-
-          funcEl?.addEventListener("change", () => {
-            cond.func = funcEl.value;
-            if (isUnaryFilter(cond.func)) {
-              cond.valueMode = "literal";
-              cond.literal = "";
-              cond.paramName = "";
-            }
-            renderNodes();
-            refreshQuery();
-          });
-          predEl?.addEventListener("change", () => {
-            cond.predicate = predEl.value;
-            const type = paramTypeForPredicate(typeName, cond.predicate);
-            if (cond.valueMode === "literal" && !isUnaryFilter(cond.func)) {
-              cond.literal = defaultParamValue(type);
-            }
-            refreshQuery();
-          });
-          modeEl?.addEventListener("change", () => {
-            cond.valueMode = modeEl.value === "param" ? "param" : "literal";
-            if (cond.valueMode === "param") {
-              if (!cond.paramName && node.params[0]) cond.paramName = node.params[0].name;
-              if (!cond.paramName) {
-                // Auto-create a param from the predicate leaf.
-                const seed = sanitizeName(
-                  (cond.predicate || "param").replace(/\./g, "_"),
-                  "param"
-                );
-                let name = seed;
-                let i = 2;
-                while (node.params.some((p) => p.name === name)) {
-                  name = `${seed}${i}`;
-                  i += 1;
-                }
-                const type = paramTypeForPredicate(typeName, cond.predicate);
-                node.params.push({
-                  id: paramUid(),
-                  name,
-                  type,
-                  value: defaultParamValue(type),
-                  mode: "var",
-                });
-                cond.paramName = name;
-              }
-            }
-            renderNodes();
-            refreshQuery();
-          });
-          literalEl?.addEventListener("input", () => {
-            cond.literal = literalEl.value;
-            refreshQuery();
-          });
-          paramEl?.addEventListener("change", () => {
-            cond.paramName = paramEl.value;
-            refreshQuery();
-          });
-          removeBtn?.addEventListener("click", () => {
-            group.conditions = group.conditions.filter((c) => c.id !== cond.id);
-            if (edgePath && !group.conditions.length) {
-              delete node.edgeFilters[edgePath];
-            }
-            renderNodes();
-            refreshQuery();
-          });
-        });
-      });
-
-      el.querySelectorAll('input[type="checkbox"]').forEach((input) => {
-        input.addEventListener("change", () => {
-          const path = decodePath(input.dataset.path);
-          const kind = input.dataset.kind;
-          const current = getNode(node.id);
-          if (!current) return;
-
-          if (input.checked) {
-            if (kind === "object") {
-              current.selection = setAtPath(current.selection, path, {});
-            } else {
-              current.selection = setAtPath(current.selection, path, null);
-            }
-          } else {
-            current.selection = setAtPath(current.selection, path, undefined);
-            const pathStr = pathKey(path);
-            Object.keys(current.aliases || {}).forEach((key) => {
-              if (key === pathStr || key.startsWith(`${pathStr}.`)) {
-                delete current.aliases[key];
-              }
-            });
-            // Drop edge filters on this edge and anything nested under it.
-            Object.keys(current.edgeFilters || {}).forEach((key) => {
-              if (key === pathStr || key.startsWith(`${pathStr}.`)) {
-                delete current.edgeFilters[key];
-              }
-            });
+        stopDragPropagation(nameInput)
+        nameInput.addEventListener('input', () => {
+          node.name = nameInput.value
+          refreshQuery()
+        })
+        nameInput.addEventListener('change', () => {
+          node.name = sanitizeName(nameInput.value, defaultName(node.type))
+          nameInput.value = node.name
+          refreshQuery()
+        })
+        nameInput.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            nameInput.blur()
           }
-          renderNodes();
-          refreshQuery();
-        });
-      });
+          e.stopPropagation()
+        })
 
-      el.addEventListener("mousedown", (e) => {
-        if (e.target.closest("input, label, button, select")) return;
-        setSelected(node.id);
-      });
+        const resultInput = el.querySelector('.result-name-input')
+        stopDragPropagation(resultInput)
+        resultInput.addEventListener('input', () => {
+          node.resultName = resultInput.value
+          refreshQuery()
+        })
+        resultInput.addEventListener('change', () => {
+          node.resultName = resultInput.value.trim()
+            ? sanitizeName(resultInput.value, '')
+            : ''
+          resultInput.value = node.resultName
+          refreshQuery()
+        })
+        resultInput.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            resultInput.blur()
+          }
+          e.stopPropagation()
+        })
 
-      canvasEl.appendChild(el);
-
-      const savedScroll = fieldScroll.get(node.id);
-      if (savedScroll) {
-        const body = el.querySelector(".entity-node-body");
-        if (body) {
-          body.scrollTop = savedScroll.top;
-          body.scrollLeft = savedScroll.left;
-        }
-      }
-    });
-
-    updateEmptyState();
-    updateCanvasSurface();
-  }
-
-  function placeEntity(typeName, x, y) {
-    if (!schema[typeName]) return;
-
-    const pos =
-      x != null && y != null
-        ? findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H, { x, y })
-        : findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H);
-
-    nodes.push({
-      id: uid(),
-      type: typeName,
-      name: defaultName(typeName),
-      x: pos.x,
-      y: pos.y,
-      width: DEFAULT_NODE_W,
-      height: DEFAULT_NODE_H,
-      selection: defaultSelection(typeName),
-      params: [],
-      rootFilter: emptyFilterGroup(),
-      edgeFilters: {},
-      directives: { cascade: false, normalize: false },
-      aliases: {},
-      resultName: "",
-    });
-    selectedNodeId = nodes[nodes.length - 1].id;
-    renderNodes();
-    refreshQuery();
-  }
-
-  /* ---------- DQL generation ---------- */
-
-  function indent(level) {
-    return "  ".repeat(level);
-  }
-
-  function hasAnySelection(selection) {
-    return selection && typeof selection === "object" && Object.keys(selection).length > 0;
-  }
-
-  function renderSelection(typeName, selection, depth, node, pathPrefix, aliases) {
-    const def = schema[typeName];
-    if (!def || !hasAnySelection(selection)) return "";
-
-    const lines = [];
-    def.fields.forEach((field) => {
-      if (!(field.name in selection)) return;
-
-      const fieldPath = pathPrefix ? `${pathPrefix}.${field.name}` : field.name;
-      const alias = aliases[fieldPath] ? `${aliases[fieldPath]}: ` : "";
-
-      if (field.kind === "scalar") {
-        lines.push(`${indent(depth)}${alias}${field.name}`);
-        return;
-      }
-
-      const nestedType = field.ofType;
-      const filterStr = formatFilterDirective(
-        node.edgeFilters?.[fieldPath],
-        nestedType || typeName
-      );
-
-      const nestedSel = selection[field.name];
-
-      // Depth cap only — allow the same type to reappear on a nested edge
-      // (e.g. User → posts → author → User) so long as the selection is finite.
-      if (!nestedType || !schema[nestedType] || depth >= 14) {
-        lines.push(`${indent(depth)}${alias}${field.name}${filterStr} {`);
-        lines.push(`${indent(depth)}}`);
-        return;
-      }
-
-      const nestedBody = renderSelection(
-        nestedType,
-        nestedSel && typeof nestedSel === "object" ? nestedSel : {},
-        depth + 1,
-        node,
-        fieldPath,
-        aliases
-      );
-      lines.push(`${indent(depth)}${alias}${field.name}${filterStr} {`);
-      if (nestedBody) lines.push(nestedBody);
-      lines.push(`${indent(depth)}}`);
-    });
-
-    return lines.join("\n");
-  }
-
-  function uniqueBlockNames(roots) {
-    const seen = new Map();
-    return roots.map((node) => {
-      const fallback = `get${node.type}`;
-      let name = sanitizeName(node.name, fallback);
-      if (seen.has(name)) {
-        const count = seen.get(name) + 1;
-        seen.set(name, count);
-        name = `${name}_${count}`;
-      } else {
-        seen.set(name, 1);
-      }
-      return name;
-    });
-  }
-
-  function collectParams(roots) {
-    const map = new Map();
-    roots.forEach((node) => {
-      (node.params || []).forEach((param) => {
-        if (param.mode === "literal") return;
-        const name = sanitizeName(param.name, "");
-        if (!name || map.has(name)) return;
-        map.set(name, { ...param, name });
-      });
-    });
-    return [...map.values()];
-  }
-
-  /** Format a param's value as a DQL literal ("Alice", 42, true). */
-  function formatDqlLiteral(param) {
-    if (param.type === "int") {
-      const n = parseInt(param.value, 10);
-      return String(Number.isFinite(n) ? n : 0);
-    }
-    if (param.type === "float") {
-      const n = parseFloat(param.value);
-      return String(Number.isFinite(n) ? n : 0);
-    }
-    if (param.type === "bool") {
-      return String(String(param.value).toLowerCase() === "true");
-    }
-    return JSON.stringify(String(param.value ?? ""));
-  }
-
-  function formatParamValue(param) {
-    if (param.type === "int") {
-      const n = parseInt(param.value, 10);
-      return Number.isFinite(n) ? n : 0;
-    }
-    if (param.type === "float") {
-      const n = parseFloat(param.value);
-      return Number.isFinite(n) ? n : 0;
-    }
-    if (param.type === "bool") {
-      return String(param.value).toLowerCase() === "true";
-    }
-    return String(param.value ?? "");
-  }
-
-  function formatFilterCondition(cond, typeName) {
-    if (!cond?.func || !cond?.predicate) return null;
-    if (isUnaryFilter(cond.func)) return `${cond.func}(${cond.predicate})`;
-
-    if (cond.valueMode === "param") {
-      const name = sanitizeName(cond.paramName, "");
-      if (!name) return null;
-      return `${cond.func}(${cond.predicate}, $${name})`;
-    }
-
-    const type = paramTypeForPredicate(typeName, cond.predicate);
-    const valuePart = formatDqlLiteral({ type, value: cond.literal });
-    return `${cond.func}(${cond.predicate}, ${valuePart})`;
-  }
-
-  function formatFilterDirective(group, typeName) {
-    const g = ensureFilterGroup(group);
-    const parts = g.conditions
-      .map((c) => formatFilterCondition(c, typeName))
-      .filter(Boolean);
-    if (!parts.length) return "";
-    return ` @filter(${parts.join(` ${g.op} `)})`;
-  }
-
-  /**
-   * Result key inside the operation: "query getUser { User(...) }".
-   * Strip a leading "get" when the remainder is a valid identifier,
-   * otherwise reuse the operation name.
-   */
-  function innerBlockName(opName) {
-    if (/^get./.test(opName)) {
-      const rest = opName.slice(3);
-      if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(rest)) return rest;
-    }
-    return opName;
-  }
-
-  function blockParams(node) {
-    const seen = new Set();
-    const result = [];
-    (node.params || []).forEach((param) => {
-      const name = sanitizeName(param.name, "");
-      if (!name || seen.has(name)) return;
-      seen.add(name);
-      result.push({ ...param, name });
-    });
-    return result;
-  }
-
-  function refreshQuery() {
-    try {
-      const roots = nodes.filter((n) => hasAnySelection(n.selection));
-      if (!roots.length) {
-        setOutputs(
-          nodes.length ? "# Pick at least one predicate on a query block." : "",
-          ""
-        );
-        return;
-      }
-
-      const names = uniqueBlockNames(roots);
-      const allParams = collectParams(roots);
-
-      // One named operation per canvas block, each with its own signature.
-      const operations = roots.map((node, i) => {
-        const filter = formatFilterDirective(node.rootFilter, node.type);
-        const directives =
-          (node.directives?.cascade ? " @cascade" : "") +
-          (node.directives?.normalize ? " @normalize" : "");
-        const body = renderSelection(
-          node.type,
-          node.selection,
-          2,
-          node,
-          "",
-          node.aliases || {}
-        );
-
-        const params = blockParams(node);
-        const signature = params.length
-          ? `(${params
-              .map(
-                (p) =>
-                  `$${p.name}: ${p.type}${p.mode === "default" ? ` = ${formatDqlLiteral(p)}` : ""}`
+        el.querySelectorAll('.alias-input').forEach((input) => {
+          stopDragPropagation(input)
+          const syncAliasSize = () => {
+            const len = Math.max(
+              5,
+              Math.min(28, (input.value || 'alias').length + 1),
+            )
+            input.size = len
+          }
+          syncAliasSize()
+          input.addEventListener('input', () => {
+            const key = pathKey(decodePath(input.dataset.aliasPath))
+            const value = input.value.trim()
+            if (value) node.aliases[key] = value
+            else delete node.aliases[key]
+            syncAliasSize()
+            refreshQuery()
+          })
+          input.addEventListener('change', () => {
+            const key = pathKey(decodePath(input.dataset.aliasPath))
+            if (node.aliases[key]) {
+              // Aliases may be dotted (Author.Name), so keep dots.
+              node.aliases[key] = node.aliases[key].replace(
+                /[^A-Za-z0-9_.]/g,
+                '_',
               )
-              .join(", ")})`
-          : "";
-        const inner = sanitizeName(node.resultName, "") || innerBlockName(names[i]);
+              input.value = node.aliases[key]
+              syncAliasSize()
+              refreshQuery()
+            }
+          })
+          input.addEventListener('keydown', (e) => e.stopPropagation())
+        })
 
-        return (
-          `query ${names[i]}${signature} {\n` +
-          `${indent(1)}${inner}(func: type("${node.type}"))${filter}${directives} {\n` +
-          `${body}\n${indent(1)}}\n}`
-        );
-      });
+        el.querySelector('.entity-node-remove').addEventListener(
+          'click',
+          (e) => {
+            e.stopPropagation()
+            nodes = nodes.filter((n) => n.id !== node.id)
+            if (selectedNodeId === node.id) selectedNodeId = null
+            renderNodes()
+            refreshQuery()
+          },
+        )
 
-      // Single block → flat vars object; multiple → grouped per operation,
-      // since each operation is executed separately with its own variables.
-      let vars = "";
-      if (allParams.length) {
-        const varsFor = (node) => {
-          const obj = {};
-          blockParams(node).forEach((p) => {
-            obj[`$${p.name}`] = formatParamValue(p);
-          });
-          return obj;
-        };
+        el.querySelectorAll('.directive-toggle').forEach((btn) => {
+          stopDragPropagation(btn)
+          btn.addEventListener('click', () => {
+            const key = btn.dataset.directive
+            node.directives[key] = !node.directives[key]
+            btn.classList.toggle('active', node.directives[key])
+            refreshQuery()
+          })
+        })
 
-        if (roots.length === 1) {
-          vars = JSON.stringify(varsFor(roots[0]), null, 2);
-        } else {
-          const grouped = {};
-          roots.forEach((node, i) => {
-            if (blockParams(node).length) grouped[names[i]] = varsFor(node);
-          });
-          vars = JSON.stringify(grouped, null, 2);
+        el.querySelector('.add-param').addEventListener('click', (e) => {
+          e.stopPropagation()
+          let name = `param${node.params.length + 1}`
+          let i = 2
+          while (node.params.some((p) => p.name === name)) {
+            name = `param${i}`
+            i += 1
+          }
+          node.params.push({
+            id: paramUid(),
+            name,
+            type: 'string',
+            value: '',
+            mode: 'var',
+          })
+          renderNodes()
+          refreshQuery()
+        })
+
+        el.querySelectorAll('.param-card').forEach((card) => {
+          const param = node.params.find((p) => p.id === card.dataset.paramId)
+          if (!param) return
+
+          const nameEl = card.querySelector('.param-name')
+          const typeEl = card.querySelector('.param-type')
+          const valueEl = card.querySelector('.param-value')
+          const modeEl = card.querySelector('.param-mode')
+          const removeBtn = card.querySelector('.param-remove')
+          ;[nameEl, typeEl, valueEl, modeEl, removeBtn].forEach(
+            stopDragPropagation,
+          )
+
+          modeEl.addEventListener('change', () => {
+            param.mode = modeEl.value === 'default' ? 'default' : 'var'
+            refreshQuery()
+          })
+          nameEl.addEventListener('input', () => {
+            const prev = param.name
+            param.name = nameEl.value.replace(/^\$/, '')
+            // Keep filter references in sync while typing.
+            const renameIn = (group) => {
+              ;(group?.conditions || []).forEach((c) => {
+                if (c.valueMode === 'param' && c.paramName === prev)
+                  c.paramName = param.name
+              })
+            }
+            renameIn(node.rootFilter)
+            Object.values(node.edgeFilters || {}).forEach(renameIn)
+            refreshQuery()
+          })
+          nameEl.addEventListener('change', () => {
+            const prev = param.name
+            param.name = sanitizeName(param.name, 'param')
+            nameEl.value = param.name
+            const renameIn = (group) => {
+              ;(group?.conditions || []).forEach((c) => {
+                if (c.valueMode === 'param' && c.paramName === prev)
+                  c.paramName = param.name
+              })
+            }
+            renameIn(node.rootFilter)
+            Object.values(node.edgeFilters || {}).forEach(renameIn)
+            renderNodes()
+            refreshQuery()
+          })
+          typeEl.addEventListener('change', () => {
+            param.type = typeEl.value
+            if (!param.value) param.value = defaultParamValue(param.type)
+            refreshQuery()
+          })
+          valueEl.addEventListener('input', () => {
+            param.value = valueEl.value
+            refreshQuery()
+          })
+          removeBtn.addEventListener('click', () => {
+            const removed = param.name
+            node.params = node.params.filter((p) => p.id !== param.id)
+            const clearRef = (group) => {
+              ;(group?.conditions || []).forEach((c) => {
+                if (c.valueMode === 'param' && c.paramName === removed) {
+                  c.paramName = ''
+                }
+              })
+            }
+            clearRef(node.rootFilter)
+            Object.values(node.edgeFilters || {}).forEach(clearRef)
+            renderNodes()
+            refreshQuery()
+          })
+        })
+
+        const getFilterGroup = (edgePath) => {
+          if (!edgePath) {
+            if (!node.rootFilter) node.rootFilter = emptyFilterGroup()
+            return node.rootFilter
+          }
+          if (!node.edgeFilters) node.edgeFilters = {}
+          if (!node.edgeFilters[edgePath])
+            node.edgeFilters[edgePath] = emptyFilterGroup()
+          return node.edgeFilters[edgePath]
         }
-      }
 
-      setOutputs(operations.join("\n\n"), vars);
-    } catch (err) {
-      consoleError(err.message || String(err), "query-build");
-      setOutputs(`# Query build failed:\n# ${err.message || err}`, "");
-    } finally {
-      scheduleSaveWorkspace();
+        el.querySelectorAll('.filter-panel').forEach((panel) => {
+          const edgePath = panel.dataset.edgePath || ''
+          const group = getFilterGroup(edgePath)
+          const typeName = typeAtEdgePath(node.type, edgePath)
+
+          panel.querySelectorAll('.filter-op-btn').forEach((btn) => {
+            stopDragPropagation(btn)
+            btn.addEventListener('click', () => {
+              group.op = btn.dataset.op === 'OR' ? 'OR' : 'AND'
+              renderNodes()
+              refreshQuery()
+            })
+          })
+
+          panel.querySelector('.add-filter')?.addEventListener('click', (e) => {
+            e.stopPropagation()
+            const preds = scalarPredicates(typeName)
+            const used = new Set(group.conditions.map((c) => c.predicate))
+            const next = preds.find((p) => !used.has(p.name)) || preds[0]
+            const predName = next?.name || ''
+            const type = paramTypeForPredicate(typeName, predName)
+            group.conditions.push(newFilterCondition(predName, type))
+            renderNodes()
+            refreshQuery()
+          })
+
+          panel.querySelectorAll('.filter-row').forEach((row) => {
+            const cond = group.conditions.find(
+              (c) => c.id === row.dataset.filterId,
+            )
+            if (!cond) return
+
+            const funcEl = row.querySelector('.filter-func')
+            const predEl = row.querySelector('.filter-predicate')
+            const modeEl = row.querySelector('.filter-value-mode')
+            const literalEl = row.querySelector('.filter-literal')
+            const paramEl = row.querySelector('.filter-param')
+            const removeBtn = row.querySelector('.filter-remove')
+            ;[funcEl, predEl, modeEl, literalEl, paramEl, removeBtn]
+              .filter(Boolean)
+              .forEach(stopDragPropagation)
+
+            funcEl?.addEventListener('change', () => {
+              cond.func = funcEl.value
+              if (isUnaryFilter(cond.func)) {
+                cond.valueMode = 'literal'
+                cond.literal = ''
+                cond.paramName = ''
+              }
+              renderNodes()
+              refreshQuery()
+            })
+            predEl?.addEventListener('change', () => {
+              cond.predicate = predEl.value
+              const type = paramTypeForPredicate(typeName, cond.predicate)
+              if (cond.valueMode === 'literal' && !isUnaryFilter(cond.func)) {
+                cond.literal = defaultParamValue(type)
+              }
+              refreshQuery()
+            })
+            modeEl?.addEventListener('change', () => {
+              cond.valueMode = modeEl.value === 'param' ? 'param' : 'literal'
+              if (cond.valueMode === 'param') {
+                if (!cond.paramName && node.params[0])
+                  cond.paramName = node.params[0].name
+                if (!cond.paramName) {
+                  // Auto-create a param from the predicate leaf.
+                  const seed = sanitizeName(
+                    (cond.predicate || 'param').replace(/\./g, '_'),
+                    'param',
+                  )
+                  let name = seed
+                  let i = 2
+                  while (node.params.some((p) => p.name === name)) {
+                    name = `${seed}${i}`
+                    i += 1
+                  }
+                  const type = paramTypeForPredicate(typeName, cond.predicate)
+                  node.params.push({
+                    id: paramUid(),
+                    name,
+                    type,
+                    value: defaultParamValue(type),
+                    mode: 'var',
+                  })
+                  cond.paramName = name
+                }
+              }
+              renderNodes()
+              refreshQuery()
+            })
+            literalEl?.addEventListener('input', () => {
+              cond.literal = literalEl.value
+              refreshQuery()
+            })
+            paramEl?.addEventListener('change', () => {
+              cond.paramName = paramEl.value
+              refreshQuery()
+            })
+            removeBtn?.addEventListener('click', () => {
+              group.conditions = group.conditions.filter(
+                (c) => c.id !== cond.id,
+              )
+              if (edgePath && !group.conditions.length) {
+                delete node.edgeFilters[edgePath]
+              }
+              renderNodes()
+              refreshQuery()
+            })
+          })
+        })
+
+        el.querySelectorAll('input[type="checkbox"]').forEach((input) => {
+          input.addEventListener('change', () => {
+            const path = decodePath(input.dataset.path)
+            const kind = input.dataset.kind
+            const current = getNode(node.id)
+            if (!current) return
+
+            if (input.checked) {
+              if (kind === 'object') {
+                current.selection = setAtPath(current.selection, path, {})
+              } else {
+                current.selection = setAtPath(current.selection, path, null)
+              }
+            } else {
+              current.selection = setAtPath(current.selection, path, undefined)
+              const pathStr = pathKey(path)
+              Object.keys(current.aliases || {}).forEach((key) => {
+                if (key === pathStr || key.startsWith(`${pathStr}.`)) {
+                  delete current.aliases[key]
+                }
+              })
+              // Drop edge filters on this edge and anything nested under it.
+              Object.keys(current.edgeFilters || {}).forEach((key) => {
+                if (key === pathStr || key.startsWith(`${pathStr}.`)) {
+                  delete current.edgeFilters[key]
+                }
+              })
+            }
+            renderNodes()
+            refreshQuery()
+          })
+        })
+
+        el.addEventListener('mousedown', (e) => {
+          if (e.target.closest('input, label, button, select')) return
+          setSelected(node.id)
+        })
+
+        canvasEl.appendChild(el)
+
+        const savedScroll = fieldScroll.get(node.id)
+        if (savedScroll) {
+          const body = el.querySelector('.entity-node-body')
+          if (body) {
+            body.scrollTop = savedScroll.top
+            body.scrollLeft = savedScroll.left
+          }
+        }
+      })
+
+      updateEmptyState()
+      updateCanvasSurface()
     }
-  }
 
-  /* ---------- Copy ---------- */
+    function placeEntity(typeName, x, y) {
+      if (!schema[typeName]) return
 
-  async function copyText(text, button) {
-    if (!text) return;
-    try {
-      await navigator.clipboard.writeText(text);
-      const prev = button.textContent;
-      button.textContent = "Copied";
-      setTimeout(() => {
-        button.textContent = prev;
-      }, 1200);
-    } catch {
-      /* clipboard unavailable */
-    }
-  }
+      const pos =
+        x != null && y != null
+          ? findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H, { x, y })
+          : findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H)
 
-  /* ---------- Canvas drag & drop ---------- */
-
-  window.addEventListener("pointermove", (e) => {
-    if (resizeState) {
-      const node = getNode(resizeState.id);
-      const el = canvasEl.querySelector(`.entity-node[data-id="${resizeState.id}"]`);
-      if (!node || !el) return;
-      const nextW = Math.max(300, resizeState.startW + (e.clientX - resizeState.startX));
-      const nextH = Math.max(240, resizeState.startH + (e.clientY - resizeState.startY));
-      node.width = nextW;
-      node.height = nextH;
-      el.style.width = `${nextW}px`;
-      el.style.height = `${nextH}px`;
-      updateCanvasSurface();
-      return;
-    }
-
-    if (!moveState) return;
-    const node = getNode(moveState.id);
-    const el = canvasEl.querySelector(`.entity-node[data-id="${moveState.id}"]`);
-    if (!node || !el) return;
-
-    const canvasRect = canvasEl.getBoundingClientRect();
-    node.x = Math.max(
-      0,
-      e.clientX - canvasRect.left - moveState.offsetX + canvasEl.scrollLeft
-    );
-    node.y = Math.max(
-      0,
-      e.clientY - canvasRect.top - moveState.offsetY + canvasEl.scrollTop
-    );
-    el.style.left = `${node.x}px`;
-    el.style.top = `${node.y}px`;
-    updateCanvasSurface();
-  });
-
-  window.addEventListener("pointerup", () => {
-    if (resizeState) {
-      const el = canvasEl.querySelector(`.entity-node[data-id="${resizeState.id}"]`);
-      if (el) el.classList.remove("resizing");
-      document.body.classList.remove("is-resizing-node");
-      resizeState = null;
-      scheduleSaveWorkspace();
-      return;
-    }
-    if (!moveState) return;
-    const el = canvasEl.querySelector(`.entity-node[data-id="${moveState.id}"]`);
-    if (el) el.classList.remove("dragging");
-    document.body.classList.remove("is-dragging-node");
-    moveState = null;
-    scheduleSaveWorkspace();
-  });
-
-  canvasEl.addEventListener("dragover", (e) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "copy";
-    canvasEl.classList.add("drag-over");
-  });
-
-  canvasEl.addEventListener("dragleave", (e) => {
-    if (!canvasEl.contains(e.relatedTarget)) {
-      canvasEl.classList.remove("drag-over");
-    }
-  });
-
-  canvasEl.addEventListener("drop", (e) => {
-    e.preventDefault();
-    canvasEl.classList.remove("drag-over");
-    closeEntityMenu();
-    const typeName = dragPaletteType || e.dataTransfer.getData("text/plain");
-    if (!typeName || !schema[typeName]) return;
-
-    const rect = canvasEl.getBoundingClientRect();
-    const x = e.clientX - rect.left + canvasEl.scrollLeft - DEFAULT_NODE_W / 2;
-    const y = e.clientY - rect.top + canvasEl.scrollTop - 24;
-    placeEntity(typeName, x, y);
-  });
-
-  if (addEntityBtn) {
-    addEntityBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      toggleEntityMenu();
-    });
-  }
-  document.addEventListener("click", (e) => {
-    if (!entityMenuWrap?.contains(e.target)) closeEntityMenu();
-  });
-  document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") closeEntityMenu();
-  });
-
-  if (clearBtn) {
-    clearBtn.addEventListener("click", () => {
-      nodes = [];
-      selectedNodeId = null;
-      clearDqlDirty();
-      clearWorkspace();
-      renderNodes();
-      refreshQuery();
-    });
-  }
-
-  if (copyBtn) copyBtn.addEventListener("click", () => copyText(getDqlText(), copyBtn));
-  if (copyVarsBtn) copyVarsBtn.addEventListener("click", () => copyText(varsText, copyVarsBtn));
-
-  /* ---------- DQL editor → canvas ---------- */
-
-  /**
-   * Parse DQL text into canvas nodes. Extends the live schema when the query
-   * references types/fields that are not loaded yet.
-   */
-  function importQueryText(raw, { source = "import" } = {}) {
-    if (!window.DQLQueryParser) {
-      throw new Error("Query parser is not loaded");
-    }
-    const operations = window.DQLQueryParser.parse(raw);
-    const { schema: nextSchema, warnings } = window.DQLQueryParser.ensureSchema(
-      schema,
-      operations
-    );
-    const drafts = window.DQLQueryParser.toNodes(operations, nextSchema);
-
-    schema = nextSchema;
-    schemaIsSample = false;
-    nodes = [];
-    selectedNodeId = null;
-    animatedNodes.clear();
-
-    drafts.forEach((draft, i) => {
-      const withIds = (group) => {
-        const g = ensureFilterGroup(group);
-        return {
-          op: g.op,
-          conditions: g.conditions.map((c) => ({
-            id: filterUid(),
-            func: c.func || "eq",
-            predicate: c.predicate || "",
-            valueMode: c.valueMode === "param" ? "param" : "literal",
-            literal: c.literal ?? "",
-            paramName: c.paramName || "",
-          })),
-        };
-      };
-      const edgeFilters = {};
-      Object.entries(draft.edgeFilters || {}).forEach(([key, group]) => {
-        edgeFilters[key] = withIds(group);
-      });
-
-      const pos = findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H);
       nodes.push({
         id: uid(),
-        type: draft.type,
-        name: draft.name,
+        type: typeName,
+        name: defaultName(typeName),
         x: pos.x,
         y: pos.y,
         width: DEFAULT_NODE_W,
         height: DEFAULT_NODE_H,
-        selection: draft.selection,
-        params: (draft.params || []).map((p) => ({
-          id: paramUid(),
-          name: p.name,
-          type: PARAM_TYPES.includes(p.type) ? p.type : "string",
-          value: p.value ?? "",
-          mode: p.mode === "default" ? "default" : "var",
-        })),
-        rootFilter: withIds(draft.rootFilter),
-        edgeFilters,
-        directives: {
-          cascade: !!draft.directives?.cascade,
-          normalize: !!draft.directives?.normalize,
-        },
-        aliases: { ...(draft.aliases || {}) },
-        resultName: draft.resultName || "",
-      });
-    });
-
-    if (nodes.length) selectedNodeId = nodes[0].id;
-    resolveOverlaps();
-
-    // Clear dirty before refresh so generated DQL can write back into the editor.
-    clearDqlDirty();
-    renderDock();
-    renderNodes();
-    refreshQuery();
-
-    consoleInfo(
-      `Applied ${nodes.length} query block${nodes.length === 1 ? "" : "s"}`,
-      source
-    );
-    (warnings || []).forEach((w) => consoleWarn(w, source));
-    return `Loaded ${nodes.length} query block${nodes.length === 1 ? "" : "s"}`;
-  }
-
-  /**
-   * Commit the DQL editor buffer to the canvas.
-   * @param {{ reason?: string, soft?: boolean }} [opts]
-   *   soft — used on blur: skip if not dirty / not a complete-looking query,
-   *   and don't log errors for empty buffers.
-   */
-  function applyDqlFromEditor({ reason = "apply", soft = false } = {}) {
-    if (soft && !dqlDirty) return false;
-
-    const text = getDqlText().trim();
-    if (!text) {
-      if (soft) return false;
-      nodes = [];
-      selectedNodeId = null;
-      clearDqlDirty();
-      renderNodes();
-      refreshQuery();
-      consoleInfo("Cleared canvas from empty DQL editor", "editor");
-      return true;
+        selection: defaultSelection(typeName),
+        params: [],
+        rootFilter: emptyFilterGroup(),
+        edgeFilters: {},
+        directives: { cascade: false, normalize: false },
+        aliases: {},
+        resultName: '',
+      })
+      selectedNodeId = nodes[nodes.length - 1].id
+      renderNodes()
+      refreshQuery()
     }
 
-    if (!looksLikeDql(text)) {
-      if (soft) return false;
-      consoleError(
-        "Expected one or more `query Name { … }` operations before applying",
-        "editor"
-      );
-      return false;
+    /* ---------- DQL generation ---------- */
+
+    function indent(level) {
+      return '  '.repeat(level)
     }
 
-    // No-op if the buffer still matches the last generated output.
-    if (text === queryText.trim()) {
-      clearDqlDirty();
-      return true;
+    function hasAnySelection(selection) {
+      return (
+        selection &&
+        typeof selection === 'object' &&
+        Object.keys(selection).length > 0
+      )
     }
 
-    try {
-      importQueryText(text, { source: "editor" });
-      return true;
-    } catch (err) {
-      // Soft blur: stay dirty quietly while the user is still typing.
-      if (!soft) consoleError(err.message || String(err), "editor");
-      if (!dqlDirty) {
-        dqlDirty = true;
-        updateDqlChrome();
+    function renderSelection(
+      typeName,
+      selection,
+      depth,
+      node,
+      pathPrefix,
+      aliases,
+    ) {
+      const def = schema[typeName]
+      if (!def || !hasAnySelection(selection)) return ''
+
+      const lines = []
+      def.fields.forEach((field) => {
+        if (!(field.name in selection)) return
+
+        const fieldPath = pathPrefix
+          ? `${pathPrefix}.${field.name}`
+          : field.name
+        const alias = aliases[fieldPath] ? `${aliases[fieldPath]}: ` : ''
+
+        if (field.kind === 'scalar') {
+          lines.push(`${indent(depth)}${alias}${field.name}`)
+          return
+        }
+
+        const nestedType = field.ofType
+        const filterStr = formatFilterDirective(
+          node.edgeFilters?.[fieldPath],
+          nestedType || typeName,
+        )
+
+        const nestedSel = selection[field.name]
+
+        // Depth cap only — allow the same type to reappear on a nested edge
+        // (e.g. User → posts → author → User) so long as the selection is finite.
+        if (!nestedType || !schema[nestedType] || depth >= 14) {
+          lines.push(`${indent(depth)}${alias}${field.name}${filterStr} {`)
+          lines.push(`${indent(depth)}}`)
+          return
+        }
+
+        const nestedBody = renderSelection(
+          nestedType,
+          nestedSel && typeof nestedSel === 'object' ? nestedSel : {},
+          depth + 1,
+          node,
+          fieldPath,
+          aliases,
+        )
+        lines.push(`${indent(depth)}${alias}${field.name}${filterStr} {`)
+        if (nestedBody) lines.push(nestedBody)
+        lines.push(`${indent(depth)}}`)
+      })
+
+      return lines.join('\n')
+    }
+
+    function uniqueBlockNames(roots) {
+      const seen = new Map()
+      return roots.map((node) => {
+        const fallback = `get${node.type}`
+        let name = sanitizeName(node.name, fallback)
+        if (seen.has(name)) {
+          const count = seen.get(name) + 1
+          seen.set(name, count)
+          name = `${name}_${count}`
+        } else {
+          seen.set(name, 1)
+        }
+        return name
+      })
+    }
+
+    function collectParams(roots) {
+      const map = new Map()
+      roots.forEach((node) => {
+        ;(node.params || []).forEach((param) => {
+          if (param.mode === 'literal') return
+          const name = sanitizeName(param.name, '')
+          if (!name || map.has(name)) return
+          map.set(name, { ...param, name })
+        })
+      })
+      return [...map.values()]
+    }
+
+    /** Format a param's value as a DQL literal ("Alice", 42, true). */
+    function formatDqlLiteral(param) {
+      if (param.type === 'int') {
+        const n = parseInt(param.value, 10)
+        return String(Number.isFinite(n) ? n : 0)
       }
-      return false;
+      if (param.type === 'float') {
+        const n = parseFloat(param.value)
+        return String(Number.isFinite(n) ? n : 0)
+      }
+      if (param.type === 'bool') {
+        return String(String(param.value).toLowerCase() === 'true')
+      }
+      return JSON.stringify(String(param.value ?? ''))
+    }
+
+    function formatParamValue(param) {
+      if (param.type === 'int') {
+        const n = parseInt(param.value, 10)
+        return Number.isFinite(n) ? n : 0
+      }
+      if (param.type === 'float') {
+        const n = parseFloat(param.value)
+        return Number.isFinite(n) ? n : 0
+      }
+      if (param.type === 'bool') {
+        return String(param.value).toLowerCase() === 'true'
+      }
+      return String(param.value ?? '')
+    }
+
+    function formatFilterCondition(cond, typeName) {
+      if (!cond?.func || !cond?.predicate) return null
+      if (isUnaryFilter(cond.func)) return `${cond.func}(${cond.predicate})`
+
+      if (cond.valueMode === 'param') {
+        const name = sanitizeName(cond.paramName, '')
+        if (!name) return null
+        return `${cond.func}(${cond.predicate}, $${name})`
+      }
+
+      const type = paramTypeForPredicate(typeName, cond.predicate)
+      const valuePart = formatDqlLiteral({ type, value: cond.literal })
+      return `${cond.func}(${cond.predicate}, ${valuePart})`
+    }
+
+    function formatFilterDirective(group, typeName) {
+      const g = ensureFilterGroup(group)
+      const parts = g.conditions
+        .map((c) => formatFilterCondition(c, typeName))
+        .filter(Boolean)
+      if (!parts.length) return ''
+      return ` @filter(${parts.join(` ${g.op} `)})`
+    }
+
+    /**
+     * Result key inside the operation: "query getUser { User(...) }".
+     * Strip a leading "get" when the remainder is a valid identifier,
+     * otherwise reuse the operation name.
+     */
+    function innerBlockName(opName) {
+      if (/^get./.test(opName)) {
+        const rest = opName.slice(3)
+        if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(rest)) return rest
+      }
+      return opName
+    }
+
+    function blockParams(node) {
+      const seen = new Set()
+      const result = []
+      ;(node.params || []).forEach((param) => {
+        const name = sanitizeName(param.name, '')
+        if (!name || seen.has(name)) return
+        seen.add(name)
+        result.push({ ...param, name })
+      })
+      return result
+    }
+
+    function refreshQuery() {
+      try {
+        const roots = nodes.filter((n) => hasAnySelection(n.selection))
+        if (!roots.length) {
+          setOutputs(
+            nodes.length
+              ? '# Pick at least one predicate on a query block.'
+              : '',
+            '',
+          )
+          return
+        }
+
+        const names = uniqueBlockNames(roots)
+        const allParams = collectParams(roots)
+
+        // One named operation per canvas block, each with its own signature.
+        const operations = roots.map((node, i) => {
+          const filter = formatFilterDirective(node.rootFilter, node.type)
+          const directives =
+            (node.directives?.cascade ? ' @cascade' : '') +
+            (node.directives?.normalize ? ' @normalize' : '')
+          const body = renderSelection(
+            node.type,
+            node.selection,
+            2,
+            node,
+            '',
+            node.aliases || {},
+          )
+
+          const params = blockParams(node)
+          const signature = params.length
+            ? `(${params
+                .map(
+                  (p) =>
+                    `$${p.name}: ${p.type}${p.mode === 'default' ? ` = ${formatDqlLiteral(p)}` : ''}`,
+                )
+                .join(', ')})`
+            : ''
+          const inner =
+            sanitizeName(node.resultName, '') || innerBlockName(names[i])
+
+          return (
+            `query ${names[i]}${signature} {\n` +
+            `${indent(1)}${inner}(func: type("${node.type}"))${filter}${directives} {\n` +
+            `${body}\n${indent(1)}}\n}`
+          )
+        })
+
+        // Single block → flat vars object; multiple → grouped per operation,
+        // since each operation is executed separately with its own variables.
+        let vars = ''
+        if (allParams.length) {
+          const varsFor = (node) => {
+            const obj = {}
+            blockParams(node).forEach((p) => {
+              obj[`$${p.name}`] = formatParamValue(p)
+            })
+            return obj
+          }
+
+          if (roots.length === 1) {
+            vars = JSON.stringify(varsFor(roots[0]), null, 2)
+          } else {
+            const grouped = {}
+            roots.forEach((node, i) => {
+              if (blockParams(node).length) grouped[names[i]] = varsFor(node)
+            })
+            vars = JSON.stringify(grouped, null, 2)
+          }
+        }
+
+        setOutputs(operations.join('\n\n'), vars)
+      } catch (err) {
+        consoleError(err.message || String(err), 'query-build')
+        setOutputs(`# Query build failed:\n# ${err.message || err}`, '')
+      } finally {
+        scheduleSaveWorkspace()
+      }
+    }
+
+    /* ---------- Copy ---------- */
+
+    async function copyText(text, button) {
+      if (!text) return
+      try {
+        await navigator.clipboard.writeText(text)
+        const prev = button.textContent
+        button.textContent = 'Copied'
+        setTimeout(() => {
+          button.textContent = prev
+        }, 1200)
+      } catch {
+        /* clipboard unavailable */
+      }
+    }
+
+    /* ---------- Canvas drag & drop ---------- */
+
+    window.addEventListener('pointermove', (e) => {
+      if (resizeState) {
+        const node = getNode(resizeState.id)
+        const el = canvasEl.querySelector(
+          `.entity-node[data-id="${resizeState.id}"]`,
+        )
+        if (!node || !el) return
+        const nextW = Math.max(
+          300,
+          resizeState.startW + (e.clientX - resizeState.startX),
+        )
+        const nextH = Math.max(
+          240,
+          resizeState.startH + (e.clientY - resizeState.startY),
+        )
+        node.width = nextW
+        node.height = nextH
+        el.style.width = `${nextW}px`
+        el.style.height = `${nextH}px`
+        updateCanvasSurface()
+        return
+      }
+
+      if (!moveState) return
+      const node = getNode(moveState.id)
+      const el = canvasEl.querySelector(
+        `.entity-node[data-id="${moveState.id}"]`,
+      )
+      if (!node || !el) return
+
+      const canvasRect = canvasEl.getBoundingClientRect()
+      node.x = Math.max(
+        0,
+        e.clientX - canvasRect.left - moveState.offsetX + canvasEl.scrollLeft,
+      )
+      node.y = Math.max(
+        0,
+        e.clientY - canvasRect.top - moveState.offsetY + canvasEl.scrollTop,
+      )
+      el.style.left = `${node.x}px`
+      el.style.top = `${node.y}px`
+      updateCanvasSurface()
+    })
+
+    window.addEventListener('pointerup', () => {
+      if (resizeState) {
+        const el = canvasEl.querySelector(
+          `.entity-node[data-id="${resizeState.id}"]`,
+        )
+        if (el) el.classList.remove('resizing')
+        document.body.classList.remove('is-resizing-node')
+        resizeState = null
+        scheduleSaveWorkspace()
+        return
+      }
+      if (!moveState) return
+      const el = canvasEl.querySelector(
+        `.entity-node[data-id="${moveState.id}"]`,
+      )
+      if (el) el.classList.remove('dragging')
+      document.body.classList.remove('is-dragging-node')
+      moveState = null
+      scheduleSaveWorkspace()
+    })
+
+    canvasEl.addEventListener('dragover', (e) => {
+      e.preventDefault()
+      e.dataTransfer.dropEffect = 'copy'
+      canvasEl.classList.add('drag-over')
+    })
+
+    canvasEl.addEventListener('dragleave', (e) => {
+      if (!canvasEl.contains(e.relatedTarget)) {
+        canvasEl.classList.remove('drag-over')
+      }
+    })
+
+    canvasEl.addEventListener('drop', (e) => {
+      e.preventDefault()
+      canvasEl.classList.remove('drag-over')
+      closeEntityMenu()
+      const typeName = dragPaletteType || e.dataTransfer.getData('text/plain')
+      if (!typeName || !schema[typeName]) return
+
+      const rect = canvasEl.getBoundingClientRect()
+      const x = e.clientX - rect.left + canvasEl.scrollLeft - DEFAULT_NODE_W / 2
+      const y = e.clientY - rect.top + canvasEl.scrollTop - 24
+      placeEntity(typeName, x, y)
+    })
+
+    if (addEntityBtn) {
+      addEntityBtn.addEventListener('click', (e) => {
+        e.stopPropagation()
+        toggleEntityMenu()
+      })
+    }
+    document.addEventListener('click', (e) => {
+      if (!entityMenuWrap?.contains(e.target)) closeEntityMenu()
+    })
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') closeEntityMenu()
+    })
+
+    if (clearBtn) {
+      clearBtn.addEventListener('click', () => {
+        nodes = []
+        selectedNodeId = null
+        clearDqlDirty()
+        clearWorkspace()
+        renderNodes()
+        refreshQuery()
+      })
+    }
+
+    if (copyBtn)
+      copyBtn.addEventListener('click', () => copyText(getDqlText(), copyBtn))
+    if (copyVarsBtn)
+      copyVarsBtn.addEventListener('click', () =>
+        copyText(varsText, copyVarsBtn),
+      )
+
+    /* ---------- DQL editor → canvas ---------- */
+
+    /**
+     * Parse DQL text into canvas nodes. Extends the live schema when the query
+     * references types/fields that are not loaded yet.
+     */
+    function importQueryText(raw, { source = 'import' } = {}) {
+      if (!window.DQLQueryParser) {
+        throw new Error('Query parser is not loaded')
+      }
+      const operations = window.DQLQueryParser.parse(raw)
+      const { schema: nextSchema, warnings } =
+        window.DQLQueryParser.ensureSchema(schema, operations)
+      const drafts = window.DQLQueryParser.toNodes(operations, nextSchema)
+
+      schema = nextSchema
+      schemaIsSample = false
+      nodes = []
+      selectedNodeId = null
+      animatedNodes.clear()
+
+      drafts.forEach((draft) => {
+        const withIds = (group) => {
+          const g = ensureFilterGroup(group)
+          return {
+            op: g.op,
+            conditions: g.conditions.map((c) => ({
+              id: filterUid(),
+              func: c.func || 'eq',
+              predicate: c.predicate || '',
+              valueMode: c.valueMode === 'param' ? 'param' : 'literal',
+              literal: c.literal ?? '',
+              paramName: c.paramName || '',
+            })),
+          }
+        }
+        const edgeFilters = {}
+        Object.entries(draft.edgeFilters || {}).forEach(([key, group]) => {
+          edgeFilters[key] = withIds(group)
+        })
+
+        const pos = findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H)
+        nodes.push({
+          id: uid(),
+          type: draft.type,
+          name: draft.name,
+          x: pos.x,
+          y: pos.y,
+          width: DEFAULT_NODE_W,
+          height: DEFAULT_NODE_H,
+          selection: draft.selection,
+          params: (draft.params || []).map((p) => ({
+            id: paramUid(),
+            name: p.name,
+            type: PARAM_TYPES.includes(p.type) ? p.type : 'string',
+            value: p.value ?? '',
+            mode: p.mode === 'default' ? 'default' : 'var',
+          })),
+          rootFilter: withIds(draft.rootFilter),
+          edgeFilters,
+          directives: {
+            cascade: !!draft.directives?.cascade,
+            normalize: !!draft.directives?.normalize,
+          },
+          aliases: { ...(draft.aliases || {}) },
+          resultName: draft.resultName || '',
+        })
+      })
+
+      if (nodes.length) selectedNodeId = nodes[0].id
+      resolveOverlaps()
+
+      // Clear dirty before refresh so generated DQL can write back into the editor.
+      clearDqlDirty()
+      renderDock()
+      renderNodes()
+      refreshQuery()
+
+      consoleInfo(
+        `Applied ${nodes.length} query block${nodes.length === 1 ? '' : 's'}`,
+        source,
+      )
+      ;(warnings || []).forEach((w) => consoleWarn(w, source))
+      return `Loaded ${nodes.length} query block${nodes.length === 1 ? '' : 's'}`
+    }
+
+    /**
+     * Commit the DQL editor buffer to the canvas.
+     * @param {{ reason?: string, soft?: boolean }} [opts]
+     *   soft — used on blur: skip if not dirty / not a complete-looking query,
+     *   and don't log errors for empty buffers.
+     */
+    function applyDqlFromEditor({ soft = false } = {}) {
+      if (soft && !dqlDirty) return false
+
+      const text = getDqlText().trim()
+      if (!text) {
+        if (soft) return false
+        nodes = []
+        selectedNodeId = null
+        clearDqlDirty()
+        renderNodes()
+        refreshQuery()
+        consoleInfo('Cleared canvas from empty DQL editor', 'editor')
+        return true
+      }
+
+      if (!looksLikeDql(text)) {
+        if (soft) return false
+        consoleError(
+          'Expected one or more `query Name { … }` operations before applying',
+          'editor',
+        )
+        return false
+      }
+
+      // No-op if the buffer still matches the last generated output.
+      if (text === queryText.trim()) {
+        clearDqlDirty()
+        return true
+      }
+
+      try {
+        importQueryText(text, { source: 'editor' })
+        return true
+      } catch (err) {
+        // Soft blur: stay dirty quietly while the user is still typing.
+        if (!soft) consoleError(err.message || String(err), 'editor')
+        if (!dqlDirty) {
+          dqlDirty = true
+          updateDqlChrome()
+        }
+        return false
+      }
+    }
+
+    function revertDqlEditor() {
+      clearDqlDirty()
+      writeDqlEditor(queryText)
+      if (copyBtn) copyBtn.disabled = !queryText
+      consoleInfo('Reverted DQL editor to last canvas output', 'editor')
+    }
+
+    if (applyDqlBtn)
+      applyDqlBtn.addEventListener('click', () =>
+        applyDqlFromEditor({ reason: 'button' }),
+      )
+    if (revertDqlBtn)
+      revertDqlBtn.addEventListener('click', () => revertDqlEditor())
+
+    // Ctrl/Cmd+V on the canvas loads a pasted query directly.
+    canvasEl.addEventListener('paste', (e) => {
+      const text = e.clipboardData?.getData('text/plain') || ''
+      if (!looksLikeDql(text)) return
+      if (e.target.closest('input, textarea, select, .monaco-editor')) return
+      e.preventDefault()
+      try {
+        const msg = importQueryText(text, { source: 'paste' })
+        canvasEmptyEl.textContent = msg
+        setTimeout(() => updateEmptyState(), 1600)
+      } catch (err) {
+        // Drop the text into the DQL editor so the user can fix it.
+        clearDqlDirty()
+        writeDqlEditor(text)
+        markDqlDirty()
+        consoleError(err.message || String(err), 'paste')
+      }
+    })
+
+    /* ---------- Schema API (Ratel supplies schema; no Load-schema modal) ---------- */
+
+    function setSchema(next, { isSample = false, clearCanvas = true } = {}) {
+      schema = next || {}
+      schemaIsSample = isSample
+      if (clearCanvas) {
+        nodes = []
+        selectedNodeId = null
+        animatedNodes.clear()
+        clearDqlDirty()
+      }
+      renderDock()
+      renderNodes()
+      refreshQuery()
+    }
+
+    function applyLoadedSchema(next, sourceLabel) {
+      const count = Object.keys(next || {}).length
+      if (!count) {
+        consoleError(
+          'Schema parsed, but it contains no usable object types.',
+          'schema',
+        )
+        return
+      }
+      setSchema(next, { isSample: false })
+      consoleInfo(
+        'Loaded ' +
+          count +
+          ' entit' +
+          (count === 1 ? 'y' : 'ies') +
+          ' from ' +
+          sourceLabel,
+        'schema',
+      )
+    }
+
+    const loadSchemaBtn = $('loadSchemaBtn')
+    if (loadSchemaBtn) loadSchemaBtn.hidden = true
+
+    /* ---------- Init ---------- */
+
+    const restored = opts.persistWorkspace ? restoreWorkspace() : false
+    if (opts.schema && (!restored || schemaIsSample)) {
+      schema = opts.schema
+      schemaIsSample = false
+    }
+    renderDock()
+    if (restored) {
+      renderNodes()
+      consoleInfo('Restored canvas from previous session', 'workspace')
+    } else {
+      updateEmptyState()
+    }
+    initEditors()
+    refreshQuery()
+
+    function destroy() {
+      try {
+        dqlEditor?.dispose?.()
+        varsEditor?.dispose?.()
+      } catch (_) {}
+      dqlEditor = null
+      varsEditor = null
+      clearTimeout(saveWorkspaceTimer)
+    }
+
+    function clearCanvas() {
+      nodes = []
+      selectedNodeId = null
+      clearDqlDirty()
+      clearWorkspace()
+      renderNodes()
+      refreshQuery()
+    }
+
+    function importExternalQuery(text) {
+      const raw = String(text || '').trim()
+      if (!raw) {
+        clearCanvas()
+        return true
+      }
+      try {
+        importQueryText(raw, { source: 'ratel-editor' })
+        return true
+      } catch (err) {
+        consoleError(err.message || String(err), 'editor')
+        return false
+      }
+    }
+
+    return {
+      setSchema,
+      applyLoadedSchema,
+      getQuery: () => (dqlDirty ? getDqlText() : queryText),
+      getVars: () => varsText,
+      refresh: refreshQuery,
+      clearCanvas,
+      importQuery: importExternalQuery,
+      destroy,
     }
   }
 
-  function revertDqlEditor() {
-    clearDqlDirty();
-    writeDqlEditor(queryText);
-    if (copyBtn) copyBtn.disabled = !queryText;
-    consoleInfo("Reverted DQL editor to last canvas output", "editor");
-  }
-
-  if (applyDqlBtn) applyDqlBtn.addEventListener("click", () => applyDqlFromEditor({ reason: "button" }));
-  if (revertDqlBtn) revertDqlBtn.addEventListener("click", () => revertDqlEditor());
-
-  // Ctrl/Cmd+V on the canvas loads a pasted query directly.
-  canvasEl.addEventListener("paste", (e) => {
-    const text = e.clipboardData?.getData("text/plain") || "";
-    if (!looksLikeDql(text)) return;
-    if (e.target.closest("input, textarea, select, .monaco-editor")) return;
-    e.preventDefault();
-    try {
-      const msg = importQueryText(text, { source: "paste" });
-      canvasEmptyEl.textContent = msg;
-      setTimeout(() => updateEmptyState(), 1600);
-    } catch (err) {
-      // Drop the text into the DQL editor so the user can fix it.
-      clearDqlDirty();
-      writeDqlEditor(text);
-      markDqlDirty();
-      consoleError(err.message || String(err), "paste");
-    }
-  });
-
-  /* ---------- Schema API (Ratel supplies schema; no Load-schema modal) ---------- */
-
-  function setSchema(next, { isSample = false, clearCanvas = true } = {}) {
-    schema = next || {};
-    schemaIsSample = isSample;
-    if (clearCanvas) {
-      nodes = [];
-      selectedNodeId = null;
-      animatedNodes.clear();
-      clearDqlDirty();
-    }
-    renderDock();
-    renderNodes();
-    refreshQuery();
-  }
-
-  function applyLoadedSchema(next, sourceLabel) {
-    const count = Object.keys(next || {}).length;
-    if (!count) {
-      consoleError('Schema parsed, but it contains no usable object types.', 'schema');
-      return;
-    }
-    setSchema(next, { isSample: false });
-    consoleInfo('Loaded ' + count + ' entit' + (count === 1 ? 'y' : 'ies') + ' from ' + sourceLabel, 'schema');
-  }
-
-  const loadSchemaBtn = $('loadSchemaBtn');
-  if (loadSchemaBtn) loadSchemaBtn.hidden = true;
-
-  /* ---------- Init ---------- */
-
-  const restored = opts.persistWorkspace ? restoreWorkspace() : false;
-  if (opts.schema && (!restored || schemaIsSample)) {
-    schema = opts.schema;
-    schemaIsSample = false;
-  }
-  renderDock();
-  if (restored) {
-    renderNodes();
-    consoleInfo('Restored canvas from previous session', 'workspace');
-  } else {
-    updateEmptyState();
-  }
-  initEditors();
-  refreshQuery();
-
-  function destroy() {
-    try {
-      dqlEditor?.dispose?.();
-      varsEditor?.dispose?.();
-    } catch (_) {}
-    dqlEditor = null;
-    varsEditor = null;
-    clearTimeout(saveWorkspaceTimer);
-  }
-
-  function clearCanvas() {
-    nodes = [];
-    selectedNodeId = null;
-    clearDqlDirty();
-    clearWorkspace();
-    renderNodes();
-    refreshQuery();
-  }
-
-  function importExternalQuery(text) {
-    const raw = String(text || "").trim();
-    if (!raw) {
-      clearCanvas();
-      return true;
-    }
-    try {
-      importQueryText(raw, { source: "ratel-editor" });
-      return true;
-    } catch (err) {
-      consoleError(err.message || String(err), "editor");
-      return false;
-    }
-  }
-
-  return {
-    setSchema,
-    applyLoadedSchema,
-    getQuery: () => (dqlDirty ? getDqlText() : queryText),
-    getVars: () => varsText,
-    refresh: refreshQuery,
-    clearCanvas,
-    importQuery: importExternalQuery,
-    destroy,
-  };
-  }
-
-  return { mount };
-})();
+  return { mount }
+})()

--- a/client/src/components/QueryBuilder/lib/app.js
+++ b/client/src/components/QueryBuilder/lib/app.js
@@ -1,0 +1,2296 @@
+window.DQLBuilder = (() => {
+  function mount(root, options = {}) {
+  if (!root) throw new Error('DQLBuilder.mount: root element is required');
+  const opts = {
+    hideSchemaControls: true,
+    persistWorkspace: true,
+    ...options,
+  };
+  const $ = (id) => root.querySelector('#' + id);
+
+  let schema = opts.schema || window.DQL_SCHEMA || {};
+  const PARAM_TYPES = ["string", "int", "float", "bool"];
+  const FILTER_FUNCS = [
+    { value: "eq", label: "eq" },
+    { value: "ge", label: "ge" },
+    { value: "le", label: "le" },
+    { value: "gt", label: "gt" },
+    { value: "lt", label: "lt" },
+    { value: "has", label: "has" },
+    { value: "alloftext", label: "alloftext" },
+    { value: "anyoftext", label: "anyoftext" },
+    { value: "allofterms", label: "allofterms" },
+    { value: "anyofterms", label: "anyofterms" },
+    { value: "regexp", label: "regexp" },
+    { value: "uid_in", label: "uid_in" },
+    { value: "not eq", label: "not eq" },
+    { value: "not has", label: "not has" },
+  ];
+
+  function isUnaryFilter(func) {
+    const f = String(func || "").replace(/^not\s+/i, "").toLowerCase();
+    return f === "has";
+  }
+
+  const canvasEl = $("canvas");
+  const canvasSurfaceEl = $("canvasSurface");
+  const canvasEmptyEl = $("canvasEmpty");
+  const addEntityBtn = $("addEntityBtn");
+  const entityMenuEl = $("entityMenu");
+  const entityMenuWrap = $("entityMenuWrap");
+  const copyBtn = $("copyBtn");
+  const copyVarsBtn = $("copyVarsBtn");
+  const clearBtn = $("clearBtn");
+  const applyDqlBtn = $("applyDqlBtn");
+  const revertDqlBtn = $("revertDqlBtn");
+  const dqlDirtyBadge = $("dqlDirtyBadge");
+  const dqlEditHint = $("dqlEditHint");
+  const consoleOutputEl = $("consoleOutput");
+  const consoleFilterEl = $("consoleFilter");
+  const consoleLevelEl = $("consoleLevel");
+  const consoleClearBtn = $("consoleClearBtn");
+  const consoleErrorCountEl = $("consoleErrorCount");
+  const consoleWarnCountEl = $("consoleWarnCount");
+
+  /**
+   * Each canvas node is one DQL query block.
+   * Parameters are $variables only.
+   * Filters are separate groups (AND/OR) on the root or on object edges.
+   * @typedef {{ id: string, name: string, type: string, value: string, mode: "var"|"default" }} Param
+   * @typedef {{
+   *   id: string, func: string, predicate: string,
+   *   valueMode: "literal"|"param", literal: string, paramName: string
+   * }} FilterCond
+   * @typedef {{ op: "AND"|"OR", conditions: FilterCond[] }} FilterGroup
+   * @typedef {{
+   *   id: string, type: string, name: string, x: number, y: number,
+   *   selection: Record<string, any>, params: Param[],
+   *   rootFilter: FilterGroup, edgeFilters: Record<string, FilterGroup>
+   * }} QueryNode
+   * @type {QueryNode[]}
+   */
+  let nodes = [];
+  let dragPaletteType = null;
+  /** @type {{ id: string, offsetX: number, offsetY: number } | null} */
+  let moveState = null;
+  /** @type {{ id: string, startX: number, startY: number, startW: number, startH: number } | null} */
+  let resizeState = null;
+  let selectedNodeId = null;
+  let nodeSeq = 0;
+  let paramSeq = 0;
+  let filterSeq = 0;
+  const animatedNodes = new Set();
+  /** True when `schema` came from the built-in sample (reload picks up schema.js edits). */
+  let schemaIsSample = true;
+
+  /* ---------- Dev workspace persistence (survives Vite live reload) ---------- */
+
+  const WORKSPACE_KEY = "dql-builder:workspace:v1";
+  let saveWorkspaceTimer = null;
+
+  function saveWorkspace() {
+    if (!opts.persistWorkspace) return;
+    try {
+      sessionStorage.setItem(
+        WORKSPACE_KEY,
+        JSON.stringify({
+          schemaIsSample,
+          schema: schemaIsSample ? null : schema,
+          nodes,
+          selectedNodeId,
+          nodeSeq,
+          paramSeq,
+          filterSeq,
+        })
+      );
+    } catch {
+      /* quota / private mode */
+    }
+  }
+
+  function scheduleSaveWorkspace() {
+    clearTimeout(saveWorkspaceTimer);
+    saveWorkspaceTimer = setTimeout(saveWorkspace, 120);
+  }
+
+  function clearWorkspace() {
+    clearTimeout(saveWorkspaceTimer);
+    if (!opts.persistWorkspace) return;
+    try {
+      sessionStorage.removeItem(WORKSPACE_KEY);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function restoreWorkspace() {
+    try {
+      const raw = sessionStorage.getItem(WORKSPACE_KEY);
+      if (!raw) return false;
+      const data = JSON.parse(raw);
+      if (!data || !Array.isArray(data.nodes)) return false;
+
+      if (data.schemaIsSample) {
+        schema = window.DQL_SCHEMA;
+        schemaIsSample = true;
+      } else if (data.schema && typeof data.schema === "object") {
+        schema = data.schema;
+        schemaIsSample = false;
+      } else {
+        return false;
+      }
+
+      nodes = data.nodes.map((n) => migrateNode({ ...n }));
+      selectedNodeId = data.selectedNodeId || null;
+      nodeSeq = Number(data.nodeSeq) || nodes.length;
+      paramSeq = Number(data.paramSeq) || 0;
+      filterSeq = Number(data.filterSeq) || 0;
+      nodes.forEach((n) => {
+        animatedNodes.add(n.id);
+        (n.rootFilter?.conditions || []).forEach((c) => {
+          if (!c.id) c.id = filterUid();
+        });
+        Object.values(n.edgeFilters || {}).forEach((g) => {
+          (g.conditions || []).forEach((c) => {
+            if (!c.id) c.id = filterUid();
+          });
+        });
+      });
+      resolveOverlaps();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /* ---------- Output (Monaco with textarea fallback) ---------- */
+
+  let dqlEditor = null;
+  let varsEditor = null;
+  let dqlFallback = null;
+  let varsFallback = null;
+  let queryText = "";
+  let varsText = "";
+  /** True while the user has unsaved edits in the DQL editor. */
+  let dqlDirty = false;
+  /** Suppress dirty-flag while we push generated text into the editor. */
+  let writingDql = false;
+
+  function getDqlText() {
+    if (dqlEditor) return dqlEditor.getValue();
+    if (dqlFallback) return dqlFallback.value;
+    return queryText;
+  }
+
+  function updateDqlChrome() {
+    const dirty = dqlDirty;
+    if (dqlDirtyBadge) dqlDirtyBadge.hidden = !dirty;
+    if (dqlEditHint) dqlEditHint.hidden = !dirty;
+    if (applyDqlBtn) applyDqlBtn.hidden = !dirty;
+    if (revertDqlBtn) revertDqlBtn.hidden = !dirty;
+    $("dqlEditor")?.classList.toggle("is-dirty", dirty);
+  }
+
+  function markDqlDirty() {
+    if (writingDql) return;
+    if (!dqlDirty) {
+      dqlDirty = true;
+      updateDqlChrome();
+    }
+    if (copyBtn) copyBtn.disabled = !getDqlText().trim();
+  }
+
+  function clearDqlDirty() {
+    dqlDirty = false;
+    updateDqlChrome();
+  }
+
+  function writeDqlEditor(value) {
+    writingDql = true;
+    try {
+      if (dqlEditor) dqlEditor.setValue(value);
+      else if (dqlFallback) dqlFallback.value = value;
+    } finally {
+      writingDql = false;
+    }
+  }
+
+  function looksLikeDql(text) {
+    return /\bquery\s+[A-Za-z_][A-Za-z0-9_]*/i.test(String(text || ""));
+  }
+
+  /* ---------- Builder console ---------- */
+
+  /** @type {{ id: number, level: 'error'|'warn'|'info', message: string, source: string, time: number }[]} */
+  const consoleEntries = [];
+  let consoleSeq = 0;
+
+  function applyConsoleFilters() {
+    if (!consoleOutputEl) return;
+    const q = (consoleFilterEl?.value || "").trim().toLowerCase();
+    const level = consoleLevelEl?.value || "all";
+    consoleOutputEl.querySelectorAll(".console-row").forEach((row) => {
+      const rowLevel = row.dataset.level;
+      const text = row.dataset.text || "";
+      const levelOk = level === "all" || rowLevel === level;
+      const textOk = !q || text.includes(q);
+      row.classList.toggle("is-hidden", !(levelOk && textOk));
+    });
+  }
+
+  function updateConsoleCounts() {
+    const errors = consoleEntries.filter((e) => e.level === "error").length;
+    const warns = consoleEntries.filter((e) => e.level === "warn").length;
+    const errNum = consoleErrorCountEl?.querySelector(".console-count-num");
+    const warnNum = consoleWarnCountEl?.querySelector(".console-count-num");
+    if (errNum) errNum.textContent = String(errors);
+    if (warnNum) warnNum.textContent = String(warns);
+  }
+
+  function renderConsoleEmpty() {
+    if (!consoleOutputEl || consoleEntries.length) return;
+    consoleOutputEl.innerHTML =
+      '<p class="console-empty">Console cleared — parse and build messages will appear here.</p>';
+  }
+
+  function clearConsole() {
+    consoleEntries.length = 0;
+    if (consoleOutputEl) consoleOutputEl.innerHTML = "";
+    updateConsoleCounts();
+    renderConsoleEmpty();
+  }
+
+  /**
+   * @param {'error'|'warn'|'info'} level
+   * @param {string} message
+   * @param {string} [source]
+   */
+  function consoleLog(level, message, source = "builder") {
+    const entry = {
+      id: ++consoleSeq,
+      level,
+      message: String(message || ""),
+      source: String(source || "builder"),
+      time: Date.now(),
+    };
+    consoleEntries.push(entry);
+    updateConsoleCounts();
+    if (!consoleOutputEl) return;
+
+    const empty = consoleOutputEl.querySelector(".console-empty");
+    if (empty) empty.remove();
+
+    const row = document.createElement("div");
+    row.className = `console-row is-${entry.level}`;
+    row.dataset.level = entry.level;
+    row.dataset.text = `${entry.message} ${entry.source}`.toLowerCase();
+    row.innerHTML = `
+      <span class="console-row-icon" aria-hidden="true"></span>
+      <span class="console-row-msg"></span>
+      <span class="console-row-source"></span>
+    `;
+    row.querySelector(".console-row-msg").textContent = entry.message;
+    row.querySelector(".console-row-source").textContent = entry.source;
+    consoleOutputEl.appendChild(row);
+    consoleOutputEl.scrollTop = consoleOutputEl.scrollHeight;
+
+    applyConsoleFilters();
+  }
+
+  function consoleError(message, source) {
+    consoleLog("error", message, source);
+  }
+
+  function consoleWarn(message, source) {
+    consoleLog("warn", message, source);
+  }
+
+  function consoleInfo(message, source) {
+    consoleLog("info", message, source);
+  }
+
+  if (consoleClearBtn) consoleClearBtn.addEventListener("click", clearConsole);
+  if (consoleFilterEl) consoleFilterEl.addEventListener("input", applyConsoleFilters);
+  if (consoleLevelEl) consoleLevelEl.addEventListener("change", applyConsoleFilters);
+  if (consoleOutputEl) renderConsoleEmpty();
+
+  function setOutputs(dql, vars) {
+    queryText = dql;
+    varsText = vars;
+    if (!dqlDirty) writeDqlEditor(dql);
+    if (varsEditor) varsEditor.setValue(vars);
+    else if (varsFallback) varsFallback.value = vars;
+    if (copyBtn) copyBtn.disabled = !(dqlDirty ? getDqlText().trim() : dql);
+    if (copyVarsBtn) copyVarsBtn.disabled = !vars;
+    try {
+      opts.onQueryChange?.({ query: dqlDirty ? getDqlText() : dql, variables: vars });
+    } catch (_) {}
+  }
+
+  function makeFallbackTextarea(hostId, { readOnly = true } = {}) {
+    const host = $(hostId);
+    if (!host) return null;
+    const ta = document.createElement("textarea");
+    ta.readOnly = readOnly;
+    ta.spellcheck = false;
+    ta.style.cssText =
+      "width:100%;height:100%;border:none;outline:none;resize:none;padding:1rem;" +
+      "font-family:var(--mono);font-size:0.82rem;line-height:1.55;color:var(--ink);background:transparent;";
+    host.appendChild(ta);
+    return ta;
+  }
+
+  function initEditors() {
+    // Canvas-only (Ratel Console) — host editors live outside this mount.
+    if (opts.canvasOnly || !$("dqlEditor")) {
+      return;
+    }
+    if (!window.require) {
+      dqlFallback = makeFallbackTextarea("dqlEditor", { readOnly: false });
+      varsFallback = makeFallbackTextarea("varsEditor", { readOnly: true });
+      dqlFallback.addEventListener("input", () => markDqlDirty());
+      dqlFallback.addEventListener("keydown", (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+          e.preventDefault();
+          applyDqlFromEditor({ reason: "shortcut" });
+        }
+      });
+      dqlFallback.addEventListener("blur", () => {
+        applyDqlFromEditor({ reason: "blur", soft: true });
+      });
+      setOutputs(queryText, varsText);
+      return;
+    }
+
+    window.require.config({
+      paths: { vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs" },
+    });
+
+    window.require(["vs/editor/editor.main"], () => {
+      monaco.editor.defineTheme("dql-dark", {
+        base: "vs-dark",
+        inherit: true,
+        rules: [
+          { token: "keyword", foreground: "3dd68c", fontStyle: "bold" },
+          { token: "string", foreground: "fdd663" },
+          { token: "number", foreground: "8ab4f8" },
+          { token: "comment", foreground: "9aa0a6", fontStyle: "italic" },
+        ],
+        colors: {
+          "editor.background": "#202124",
+          "editor.foreground": "#e8eaed",
+          "editor.lineHighlightBackground": "#292a2d",
+          "editorLineNumber.foreground": "#5f6368",
+          "editorGutter.background": "#202124",
+          "editorCursor.foreground": "#e8eaed",
+          "editor.selectionBackground": "#3c4043",
+          "editor.inactiveSelectionBackground": "#303134",
+          "editorWidget.background": "#292a2d",
+          "editorWidget.border": "#3c4043",
+          "input.background": "#1a1b1e",
+          "dropdown.background": "#292a2d",
+        },
+      });
+
+      const common = {
+        theme: "dql-dark",
+        minimap: { enabled: false },
+        automaticLayout: true,
+        fontFamily: "IBM Plex Mono, ui-monospace, monospace",
+        fontSize: 12.5,
+        lineHeight: 20,
+        scrollBeyondLastLine: false,
+        renderLineHighlight: "line",
+        overviewRulerLanes: 0,
+        hideCursorInOverviewRuler: true,
+        scrollbar: { verticalScrollbarSize: 8, horizontalScrollbarSize: 8 },
+        padding: { top: 12, bottom: 12 },
+        wordWrap: "on",
+      };
+
+      // GraphQL grammar is the closest built-in match for DQL.
+      dqlEditor = monaco.editor.create($("dqlEditor"), {
+        ...common,
+        readOnly: false,
+        value: queryText,
+        language: "graphql",
+        contextmenu: true,
+        ariaLabel: "DQL editor",
+      });
+      varsEditor = monaco.editor.create($("varsEditor"), {
+        ...common,
+        readOnly: true,
+        value: varsText,
+        language: "json",
+        lineNumbers: "off",
+        contextmenu: false,
+        renderLineHighlight: "none",
+      });
+
+      dqlEditor.onDidChangeModelContent(() => {
+        if (!writingDql) markDqlDirty();
+      });
+
+      dqlEditor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+        applyDqlFromEditor({ reason: "shortcut" });
+      });
+
+      dqlEditor.onDidBlurEditorWidget(() => {
+        // Defer so a click on Apply/Revert is processed first.
+        setTimeout(() => {
+          if (document.activeElement?.closest?.("#applyDqlBtn, #revertDqlBtn")) return;
+          applyDqlFromEditor({ reason: "blur", soft: true });
+        }, 0);
+      });
+    });
+  }
+
+  /* ---------- Helpers ---------- */
+
+  function uid() {
+    nodeSeq += 1;
+    return `node-${nodeSeq}`;
+  }
+
+  function paramUid() {
+    paramSeq += 1;
+    return `param-${paramSeq}`;
+  }
+
+  function filterUid() {
+    filterSeq += 1;
+    return `filter-${filterSeq}`;
+  }
+
+  function emptyFilterGroup(op = "AND") {
+    return { op: op === "OR" ? "OR" : "AND", conditions: [] };
+  }
+
+  function newFilterCondition(predicate = "", typeHint = "string") {
+    return {
+      id: filterUid(),
+      func: "eq",
+      predicate,
+      valueMode: "literal",
+      literal: defaultParamValue(typeHint),
+      paramName: "",
+    };
+  }
+
+  function ensureFilterGroup(group) {
+    if (!group || typeof group !== "object") return emptyFilterGroup();
+    return {
+      op: group.op === "OR" ? "OR" : "AND",
+      conditions: Array.isArray(group.conditions) ? group.conditions : [],
+    };
+  }
+
+  /** Migrate legacy param-bound filters → rootFilter / edgeFilters. */
+  function migrateNode(node) {
+    if (!node.rootFilter) node.rootFilter = emptyFilterGroup();
+    else node.rootFilter = ensureFilterGroup(node.rootFilter);
+    if (!node.edgeFilters || typeof node.edgeFilters !== "object") node.edgeFilters = {};
+
+    const legacy = [];
+    const kept = [];
+    (node.params || []).forEach((p) => {
+      if (p && p.func && p.predicate) legacy.push(p);
+      else if (p) {
+        kept.push({
+          id: p.id || paramUid(),
+          name: p.name,
+          type: PARAM_TYPES.includes(p.type) ? p.type : "string",
+          value: p.value ?? "",
+          mode: p.mode === "default" ? "default" : "var",
+        });
+      }
+    });
+
+    legacy.forEach((p) => {
+      const walk = splitPredicatePath(node.type, p.predicate) || {
+        edgeParts: [],
+        leaf: p.predicate,
+        edgePath: "",
+      };
+      const unary = isUnaryFilter(p.func);
+      const cond = {
+        id: filterUid(),
+        func: p.func,
+        predicate: walk.leaf,
+        valueMode: p.mode === "literal" || unary ? "literal" : "param",
+        literal: p.mode === "literal" ? String(p.value ?? "") : "",
+        paramName: p.mode === "literal" || unary ? "" : p.name,
+      };
+      if (!walk.edgePath) {
+        node.rootFilter.conditions.push(cond);
+      } else {
+        if (!node.edgeFilters[walk.edgePath]) {
+          node.edgeFilters[walk.edgePath] = emptyFilterGroup();
+        }
+        node.edgeFilters[walk.edgePath].conditions.push(cond);
+      }
+      if (!unary && p.mode !== "literal") {
+        if (!kept.some((k) => k.name === p.name)) {
+          kept.push({
+            id: p.id || paramUid(),
+            name: p.name,
+            type: PARAM_TYPES.includes(p.type) ? p.type : "string",
+            value: p.value ?? "",
+            mode: p.mode === "default" ? "default" : "var",
+          });
+        }
+      }
+    });
+
+    node.params = kept;
+    if (node.width != null) node.width = Math.max(300, Number(node.width) || 380);
+    if (node.height != null) node.height = Math.max(240, Number(node.height) || 520);
+    return node;
+  }
+
+  function typeAtEdgePath(rootType, edgePath) {
+    if (!edgePath) return rootType;
+    const walk = splitPredicatePath(rootType, edgePath);
+    if (!walk) return rootType;
+    let typeName = rootType;
+    for (const edge of walk.edgeParts) {
+      const field = (schema[typeName]?.fields || []).find((f) => f.name === edge);
+      if (!field?.ofType) return typeName;
+      typeName = field.ofType;
+    }
+    const leaf = (schema[typeName]?.fields || []).find((f) => f.name === walk.leaf);
+    return leaf?.ofType || typeName;
+  }
+
+  function fieldDisplayName(name) {
+    const raw = String(name || "");
+    const i = raw.lastIndexOf(".");
+    return i >= 0 ? raw.slice(i + 1) : raw;
+  }
+
+  function scalarOptionsForType(typeName) {
+    return scalarPredicates(typeName).map((f) => ({
+      value: f.name,
+      label: fieldDisplayName(f.name),
+    }));
+  }
+
+  function defaultName(typeName) {
+    const base = `get${typeName}`;
+    if (!nodes.some((n) => n.name === base)) return base;
+    let i = 2;
+    while (nodes.some((n) => n.name === `${base}${i}`)) i += 1;
+    return `${base}${i}`;
+  }
+
+  function sanitizeName(raw, fallback) {
+    let name = String(raw || "")
+      .trim()
+      .replace(/^\$/, "")
+      .replace(/[^A-Za-z0-9_]/g, "_")
+      .replace(/^([^A-Za-z_])/, "_$1");
+    if (!name) name = fallback;
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) name = fallback;
+    return name;
+  }
+
+  function defaultSelection(typeName) {
+    const def = schema[typeName];
+    const selection = {};
+    def.fields
+      .filter((f) => f.kind === "scalar")
+      .slice(0, 2)
+      .forEach((f) => {
+        selection[f.name] = null;
+      });
+    return selection;
+  }
+
+  function scalarPredicates(typeName) {
+    return (schema[typeName]?.fields || []).filter(
+      (f) => f.kind === "scalar" && f.name !== "uid"
+    );
+  }
+
+  function defaultParamValue(type) {
+    if (type === "int" || type === "float") return "0";
+    if (type === "bool") return "false";
+    return "";
+  }
+
+  /** Resolve a predicate path to its schema field, respecting dotted field names. */
+  function resolvePredicateField(typeName, pathStr) {
+    const walk = splitPredicatePath(typeName, pathStr);
+    if (!walk) return null;
+    let currentType = typeName;
+    for (const edge of walk.edgeParts) {
+      const field = (schema[currentType]?.fields || []).find((f) => f.name === edge);
+      if (!field?.ofType) return null;
+      currentType = field.ofType;
+    }
+    return (schema[currentType]?.fields || []).find((f) => f.name === walk.leaf) || null;
+  }
+
+  /**
+   * Split "posts.published" or a namespaced "User.email" into edge parts + leaf,
+   * matching longest field names on the schema at each step.
+   */
+  function splitPredicatePath(typeName, pathStr) {
+    const raw = String(pathStr || "");
+    if (!raw) return null;
+
+    const fieldsAt = (t) => schema[t]?.fields || [];
+    if (fieldsAt(typeName).some((f) => f.name === raw)) {
+      return { edgeParts: [], leaf: raw, edgePath: "" };
+    }
+
+    const segments = raw.split(".");
+    const edgeParts = [];
+    let currentType = typeName;
+    let i = 0;
+
+    while (i < segments.length) {
+      const fields = fieldsAt(currentType);
+      let matched = null;
+      let matchedEnd = -1;
+      for (let j = segments.length; j > i; j -= 1) {
+        const candidate = segments.slice(i, j).join(".");
+        const field = fields.find((f) => f.name === candidate);
+        if (field) {
+          matched = field;
+          matchedEnd = j;
+          break;
+        }
+      }
+
+      if (!matched) {
+        return {
+          edgeParts,
+          leaf: segments.slice(i).join("."),
+          edgePath: edgeParts.join("."),
+        };
+      }
+
+      const start = i;
+      i = matchedEnd;
+
+      if (i >= segments.length) {
+        return { edgeParts, leaf: matched.name, edgePath: edgeParts.join(".") };
+      }
+
+      if (matched.kind === "object" && matched.ofType) {
+        edgeParts.push(matched.name);
+        currentType = matched.ofType;
+        continue;
+      }
+
+      // Scalar matched but path continues — keep the unmatched remainder as one leaf.
+      return {
+        edgeParts,
+        leaf: segments.slice(start).join("."),
+        edgePath: edgeParts.join("."),
+      };
+    }
+
+    return null;
+  }
+
+  function paramTypeForPredicate(typeName, predicate) {
+    const field = resolvePredicateField(typeName, predicate);
+    return PARAM_TYPES.includes(field?.type) ? field.type : "string";
+  }
+
+  /**
+   * Filter targets for a block: its own scalar predicates plus, for every
+   * expanded object edge, the nested type's scalars as dotted paths
+   * ("posts.published"). Nested targets produce an @filter on that edge.
+   */
+  function filterTargets(typeName, selection, prefix = []) {
+    let targets = scalarPredicates(typeName).map((f) => {
+      const parts = [...prefix, f.name];
+      return {
+        value: parts.join("."),
+        label: parts.map(fieldDisplayName).join("."),
+      };
+    });
+
+    if (prefix.length >= 6) return targets;
+
+    (schema[typeName]?.fields || [])
+      .filter(
+        (f) =>
+          f.kind === "object" &&
+          f.ofType &&
+          schema[f.ofType] &&
+          selection &&
+          typeof selection[f.name] === "object" &&
+          selection[f.name] !== null
+      )
+      .forEach((f) => {
+        targets = targets.concat(
+          filterTargets(f.ofType, selection[f.name], [...prefix, f.name])
+        );
+      });
+
+    return targets;
+  }
+
+  function getAtPath(selection, path) {
+    let cursor = selection;
+    for (const key of path) {
+      if (!cursor || typeof cursor !== "object" || !(key in cursor)) return undefined;
+      cursor = cursor[key];
+    }
+    return cursor;
+  }
+
+  function setAtPath(selection, path, value) {
+    if (path.length === 0) return value;
+    const [head, ...rest] = path;
+    const next = { ...selection };
+    if (rest.length === 0) {
+      if (value === undefined) delete next[head];
+      else next[head] = value;
+      return next;
+    }
+    const child =
+      next[head] && typeof next[head] === "object" ? { ...next[head] } : {};
+    next[head] = setAtPath(child, rest, value);
+    return next;
+  }
+
+  function isSelected(selection, path) {
+    return getAtPath(selection, path) !== undefined;
+  }
+
+  /** Encode a field-name path for data attributes (names may contain dots). */
+  function encodePath(path) {
+    return JSON.stringify(path);
+  }
+
+  function decodePath(raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed.map(String);
+    } catch {
+      /* legacy dotted paths */
+    }
+    return String(raw || "").split(".").filter((p) => p.length);
+  }
+
+  function pathKey(path) {
+    return path.join(".");
+  }
+
+  function escapeAttr(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;");
+  }
+
+  function updateEmptyState() {
+    canvasEmptyEl.classList.toggle("hidden", nodes.length > 0);
+    if (!nodes.length) {
+      canvasEmptyEl.textContent =
+        "Edit DQL on the left, or add an entity from + Add entity above.";
+    }
+  }
+
+  function stopDragPropagation(el) {
+    ["pointerdown", "mousedown", "click"].forEach((evt) => {
+      el.addEventListener(evt, (e) => e.stopPropagation());
+    });
+  }
+
+  function getNode(id) {
+    return nodes.find((n) => n.id === id);
+  }
+
+  function setSelected(id) {
+    selectedNodeId = id;
+    canvasEl.querySelectorAll(".entity-node").forEach((nodeEl) => {
+      nodeEl.classList.toggle("selected", nodeEl.dataset.id === id);
+      nodeEl.style.zIndex = nodeEl.dataset.id === id ? "5" : "2";
+    });
+  }
+
+  /* ---------- Entity menu (canvas header) ---------- */
+
+  const DEFAULT_NODE_W = 420;
+  const DEFAULT_NODE_H = 520;
+  const NODE_GAP = 28;
+  const CANVAS_PAD = 48;
+  const CANVAS_MIN_W = 3200;
+  const CANVAS_MIN_H = 2400;
+
+  function estimateNodeSize(node) {
+    return {
+      w: Math.max(300, Number(node.width) || DEFAULT_NODE_W),
+      h: Math.max(220, Number(node.height) || DEFAULT_NODE_H),
+    };
+  }
+
+  function rectsOverlap(a, b, gap = NODE_GAP) {
+    return !(
+      a.x + a.w + gap <= b.x ||
+      b.x + b.w + gap <= a.x ||
+      a.y + a.h + gap <= b.y ||
+      b.y + b.h + gap <= a.y
+    );
+  }
+
+  function findFreePosition(width, height, preferred, excludeId) {
+    const w = width || DEFAULT_NODE_W;
+    const h = height || DEFAULT_NODE_H;
+    const others = nodes
+      .filter((n) => n.id !== excludeId)
+      .map((n) => {
+        const s = estimateNodeSize(n);
+        return { x: n.x, y: n.y, w: s.w, h: s.h };
+      });
+
+    const tryPos = (x, y) => {
+      const cand = { x: Math.max(CANVAS_PAD, x), y: Math.max(CANVAS_PAD, y), w, h };
+      if (!others.some((o) => rectsOverlap(cand, o))) return cand;
+      return null;
+    };
+
+    if (preferred) {
+      const hit = tryPos(preferred.x, preferred.y);
+      if (hit) return hit;
+    }
+
+    // Scan a grid across a generous canvas.
+    const stepX = Math.floor(w + NODE_GAP);
+    const stepY = Math.floor(Math.min(h, 280) + NODE_GAP);
+    for (let row = 0; row < 40; row += 1) {
+      for (let col = 0; col < 24; col += 1) {
+        const hit = tryPos(CANVAS_PAD + col * stepX, CANVAS_PAD + row * stepY);
+        if (hit) return hit;
+      }
+    }
+    return {
+      x: CANVAS_PAD + nodes.length * 24,
+      y: CANVAS_PAD + nodes.length * 24,
+      w,
+      h,
+    };
+  }
+
+  /** Push overlapping cards onto free slots (session restore / imports). */
+  function resolveOverlaps() {
+    nodes.forEach((n) => {
+      const s = estimateNodeSize(n);
+      const self = { x: n.x, y: n.y, w: s.w, h: s.h };
+      const hit = nodes.some((o) => {
+        if (o.id === n.id) return false;
+        const os = estimateNodeSize(o);
+        return rectsOverlap(self, { x: o.x, y: o.y, w: os.w, h: os.h });
+      });
+      if (!hit) return;
+      const pos = findFreePosition(s.w, s.h, null, n.id);
+      n.x = pos.x;
+      n.y = pos.y;
+    });
+  }
+
+  function updateCanvasSurface() {
+    if (!canvasSurfaceEl) return;
+    let maxR = CANVAS_MIN_W;
+    let maxB = CANVAS_MIN_H;
+    nodes.forEach((n) => {
+      const s = estimateNodeSize(n);
+      maxR = Math.max(maxR, n.x + s.w + 600);
+      maxB = Math.max(maxB, n.y + s.h + 600);
+    });
+    // Also account for live DOM sizes when available.
+    canvasEl.querySelectorAll(".entity-node").forEach((el) => {
+      const x = parseFloat(el.style.left) || 0;
+      const y = parseFloat(el.style.top) || 0;
+      maxR = Math.max(maxR, x + el.offsetWidth + 600);
+      maxB = Math.max(maxB, y + el.offsetHeight + 600);
+    });
+    canvasSurfaceEl.style.width = `${Math.ceil(maxR)}px`;
+    canvasSurfaceEl.style.height = `${Math.ceil(maxB)}px`;
+  }
+
+  function closeEntityMenu() {
+    if (!entityMenuEl || !addEntityBtn) return;
+    entityMenuEl.hidden = true;
+    addEntityBtn.setAttribute("aria-expanded", "false");
+  }
+
+  function toggleEntityMenu() {
+    if (!entityMenuEl || !addEntityBtn) return;
+    const open = entityMenuEl.hidden;
+    entityMenuEl.hidden = !open;
+    addEntityBtn.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+
+  function renderDock() {
+    renderEntityMenu();
+  }
+
+  function renderEntityMenu() {
+    if (!entityMenuEl) return;
+    entityMenuEl.innerHTML = "";
+    const list = document.createElement("div");
+    list.className = "entity-menu-list";
+
+    Object.entries(schema).forEach(([typeName, def]) => {
+      const item = document.createElement("button");
+      item.type = "button";
+      item.className = "entity-menu-item";
+      item.role = "menuitem";
+      item.draggable = true;
+      item.dataset.type = typeName;
+      item.title = `Add ${typeName} query block — drag onto canvas or click`;
+      item.innerHTML = `
+        <span class="palette-dot" style="background:${def.color}"></span>
+        <span class="entity-menu-name">${typeName}</span>
+        <span class="entity-menu-hint">+</span>
+      `;
+      item.addEventListener("click", () => {
+        closeEntityMenu();
+        const pos = findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H);
+        placeEntity(typeName, pos.x, pos.y);
+      });
+      item.addEventListener("dragstart", (e) => {
+        dragPaletteType = typeName;
+        item.classList.add("dragging");
+        e.dataTransfer.effectAllowed = "copy";
+        e.dataTransfer.setData("text/plain", typeName);
+      });
+      item.addEventListener("dragend", () => {
+        dragPaletteType = null;
+        item.classList.remove("dragging");
+      });
+      list.appendChild(item);
+    });
+
+    entityMenuEl.appendChild(list);
+  }
+
+  /* ---------- Query block rendering ---------- */
+
+  function renderFilterValueControls(cond, params) {
+    const unary = isUnaryFilter(cond.func);
+    if (unary) return `<span class="filter-value-blank">—</span>`;
+
+    const mode = cond.valueMode === "param" ? "param" : "literal";
+    const modeOpts = optionsHtml(
+      [
+        { value: "literal", label: "literal" },
+        { value: "param", label: "$param" },
+      ],
+      mode
+    );
+
+    if (mode === "param") {
+      const paramOpts = (params || []).map((p) => ({
+        value: p.name,
+        label: `$${p.name}`,
+      }));
+      return `
+        <select class="filter-value-mode" title="Value source">${modeOpts}</select>
+        <select class="filter-param" title="Parameter">${optionsHtml(
+          paramOpts.length ? paramOpts : [{ value: "", label: "— add a $param" }],
+          cond.paramName || ""
+        )}</select>
+      `;
+    }
+
+    return `
+      <select class="filter-value-mode" title="Value source">${modeOpts}</select>
+      <input type="text" class="filter-literal" value="${escapeAttr(cond.literal || "")}" placeholder="value" spellcheck="false" title="Literal value" />
+    `;
+  }
+
+  function renderFilterGroupPanel(group, typeName, params, { edgePath = "", compact = false } = {}) {
+    const g = ensureFilterGroup(group);
+    const preds = scalarOptionsForType(typeName);
+    const rows = g.conditions
+      .map((cond) => {
+        const unary = isUnaryFilter(cond.func);
+        return `
+          <div class="filter-row" data-filter-id="${cond.id}">
+            <select class="filter-func" title="Filter function">${optionsHtml(FILTER_FUNCS, cond.func || "eq")}</select>
+            <select class="filter-predicate" title="Predicate">${optionsHtml(
+              preds.length ? preds : [{ value: "", label: "—" }],
+              cond.predicate || ""
+            )}</select>
+            ${renderFilterValueControls(cond, params)}
+            <button type="button" class="filter-remove" title="Remove filter" aria-label="Remove filter">×</button>
+          </div>
+        `;
+      })
+      .join("");
+
+    const cls = compact ? "filter-panel is-edge" : "filter-panel is-root";
+    return `
+      <div class="${cls}" data-edge-path="${escapeAttr(edgePath)}">
+        <div class="filter-panel-head">
+          <span class="filter-panel-label">@filter</span>
+          <div class="filter-op-toggle" role="group" aria-label="Combine filters with">
+            <button type="button" class="filter-op-btn${g.op !== "OR" ? " active" : ""}" data-op="AND">AND</button>
+            <button type="button" class="filter-op-btn${g.op === "OR" ? " active" : ""}" data-op="OR">OR</button>
+          </div>
+          <button type="button" class="btn-mini add-filter">+ Add</button>
+        </div>
+        ${rows || '<p class="filter-empty">No conditions</p>'}
+      </div>
+    `;
+  }
+
+  function renderFieldTree(typeName, selection, path, depth, aliases, node) {
+    const def = schema[typeName];
+    if (!def) return "";
+
+    return def.fields
+      .map((field) => {
+        const fieldPath = [...path, field.name];
+        const key = pathKey(fieldPath);
+        const checked = isSelected(selection, fieldPath);
+        const isObject = field.kind === "object";
+        const objectClass = isObject ? " is-object" : "";
+
+        let edgeFilterHtml = "";
+        let nestedHtml = "";
+        if (isObject && checked && field.ofType && schema[field.ofType] && depth < 8) {
+          const edgeGroup = node.edgeFilters?.[key] || emptyFilterGroup();
+          edgeFilterHtml = renderFilterGroupPanel(edgeGroup, field.ofType, node.params, {
+            edgePath: key,
+            compact: true,
+          });
+          nestedHtml = `
+            <ul class="nested-fields" data-depth="${depth + 1}">
+              ${renderFieldTree(field.ofType, selection, fieldPath, depth + 1, aliases, node)}
+            </ul>
+          `;
+        }
+
+        const aliasValue = aliases[key] || "";
+        const aliasHtml = checked
+          ? `<input
+              type="text"
+              class="alias-input"
+              data-alias-path="${escapeAttr(encodePath(fieldPath))}"
+              value="${escapeAttr(aliasValue)}"
+              placeholder="alias"
+              spellcheck="false"
+              title="Alias — result key for this predicate"
+            />`
+          : `<span class="field-type" title="${escapeAttr(field.type)}">${field.type}</span>`;
+
+        const label = fieldDisplayName(field.name);
+        return `
+          <li>
+            <div class="field-row${objectClass}" style="padding-left:${0.35 + depth * 0.4}rem">
+              <label class="field-check">
+                <input
+                  type="checkbox"
+                  data-path="${escapeAttr(encodePath(fieldPath))}"
+                  data-kind="${field.kind}"
+                  data-oftype="${field.ofType || ""}"
+                  ${checked ? "checked" : ""}
+                />
+                <span class="field-name" title="${escapeAttr(field.name)}">${escapeAttr(label)}</span>
+              </label>
+              ${aliasHtml}
+            </div>
+            ${edgeFilterHtml}
+            ${nestedHtml}
+          </li>
+        `;
+      })
+      .join("");
+  }
+
+  function optionsHtml(items, selected) {
+    const list = items.slice();
+    if (selected != null && selected !== "" && !list.some((item) => item.value === selected)) {
+      list.push({ value: selected, label: selected });
+    }
+    return list
+      .map(
+        (item) =>
+          `<option value="${item.value}" ${item.value === selected ? "selected" : ""}>${item.label}</option>`
+      )
+      .join("");
+  }
+
+  function renderParamsSection(node) {
+    const rows = (node.params || [])
+      .map((param) => {
+        const typeOpts = PARAM_TYPES.map((t) => ({ value: t, label: t }));
+        return `
+          <div class="param-card" data-param-id="${param.id}">
+            <div class="param-main">
+              <input type="text" class="param-name" value="${escapeAttr(param.name)}" placeholder="name" spellcheck="false" title="Parameter name" />
+              <select class="param-type" title="Parameter type">${optionsHtml(typeOpts, param.type)}</select>
+              <input type="text" class="param-value" value="${escapeAttr(param.value)}" placeholder="sample" spellcheck="false" title="Sample value for Variables JSON" />
+              <select class="param-mode" title="$variable, or $variable with a default in the signature">
+                ${optionsHtml(
+                  [
+                    { value: "var", label: "$var" },
+                    { value: "default", label: "$ = def" },
+                  ],
+                  param.mode || "var"
+                )}
+              </select>
+              <button type="button" class="param-remove" title="Remove parameter" aria-label="Remove parameter">×</button>
+            </div>
+          </div>
+        `;
+      })
+      .join("");
+
+    return `
+      <div class="block-section params-section">
+        <div class="block-section-head">
+          <span class="block-section-title">Parameters</span>
+          <button type="button" class="btn-mini add-param">+ Add</button>
+        </div>
+        ${rows || '<p class="param-empty">$variables for filters to reference</p>'}
+      </div>
+    `;
+  }
+
+  function renderRootFiltersSection(node) {
+    return `
+      <div class="block-section filters-section">
+        <div class="block-section-head no-margin">
+          <span class="block-section-title">Root filters</span>
+        </div>
+        ${renderFilterGroupPanel(node.rootFilter, node.type, node.params, { edgePath: "" })}
+      </div>
+    `;
+  }
+
+  function renderDirectivesSection(node) {
+    const toggle = (key) => `
+      <button
+        type="button"
+        class="directive-toggle${node.directives?.[key] ? " active" : ""}"
+        data-directive="${key}"
+        title="Toggle @${key} on this query block"
+      >@${key}</button>
+    `;
+    return `
+      <div class="block-section directives-section">
+        <div class="block-section-head no-margin">
+          <span class="block-section-title">Directives</span>
+          <div class="directive-toggles">
+            ${toggle("cascade")}
+            ${toggle("normalize")}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderNodes() {
+    // Full re-render replaces the DOM — keep field-list scroll so toggling
+    // a property near the bottom doesn't jump back to the top.
+    const fieldScroll = new Map();
+    canvasEl.querySelectorAll(".entity-node").forEach((el) => {
+      const id = el.dataset.id;
+      const body = el.querySelector(".entity-node-body");
+      if (id && body) {
+        fieldScroll.set(id, { top: body.scrollTop, left: body.scrollLeft });
+      }
+    });
+
+    canvasEl.querySelectorAll(".entity-node").forEach((el) => el.remove());
+
+    nodes.forEach((node) => {
+      const def = schema[node.type];
+      const el = document.createElement("article");
+      el.className = `entity-node${selectedNodeId === node.id ? " selected" : ""}`;
+      el.dataset.id = node.id;
+      el.style.left = `${node.x}px`;
+      el.style.top = `${node.y}px`;
+      el.style.zIndex = selectedNodeId === node.id ? "5" : "2";
+      const size = estimateNodeSize(node);
+      el.style.width = `${size.w}px`;
+      el.style.height = `${size.h}px`;
+      if (!node.width) node.width = size.w;
+      if (!node.height) node.height = size.h;
+
+      // Pop-in only on first appearance, not on every re-render.
+      if (animatedNodes.has(node.id)) el.style.animation = "none";
+      else animatedNodes.add(node.id);
+
+      el.innerHTML = `
+        <header class="entity-node-header" data-drag-handle>
+          <span class="dot" style="background:${def.color}"></span>
+          <div class="entity-node-meta">
+            <span class="entity-type-label">${node.type}</span>
+            <input
+              type="text"
+              class="query-name-input"
+              value="${escapeAttr(node.name)}"
+              spellcheck="false"
+              aria-label="Query name"
+              title="Operation name (query <name>)"
+            />
+            <input
+              type="text"
+              class="result-name-input"
+              value="${escapeAttr(node.resultName || "")}"
+              placeholder="${escapeAttr(innerBlockName(sanitizeName(node.name, `get${node.type}`)))}"
+              spellcheck="false"
+              aria-label="Result key"
+              title="Result key — the inner block name (defaults to the operation name without 'get')"
+            />
+          </div>
+          <button type="button" class="entity-node-remove" title="Remove" aria-label="Remove ${node.type}">×</button>
+        </header>
+        <div class="entity-node-body">
+          ${renderDirectivesSection(node)}
+          ${renderParamsSection(node)}
+          ${renderRootFiltersSection(node)}
+          <ul class="entity-fields">${renderFieldTree(node.type, node.selection, [], 0, node.aliases || {}, node)}</ul>
+        </div>
+        <div class="entity-resize" data-resize-handle title="Drag to resize"></div>
+      `;
+
+      const header = el.querySelector(".entity-node-header");
+      const nameInput = el.querySelector(".query-name-input");
+
+      header.addEventListener("pointerdown", (e) => {
+        if (e.target.closest(".entity-node-remove, .query-name-input, .result-name-input")) return;
+        e.preventDefault();
+        setSelected(node.id);
+        const rect = el.getBoundingClientRect();
+        moveState = {
+          id: node.id,
+          offsetX: e.clientX - rect.left,
+          offsetY: e.clientY - rect.top,
+        };
+        el.classList.add("dragging");
+        document.body.classList.add("is-dragging-node");
+      });
+
+      const resizeHandle = el.querySelector("[data-resize-handle]");
+      if (resizeHandle) {
+        resizeHandle.addEventListener("pointerdown", (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setSelected(node.id);
+          resizeState = {
+            id: node.id,
+            startX: e.clientX,
+            startY: e.clientY,
+            startW: el.offsetWidth,
+            startH: el.offsetHeight,
+          };
+          el.classList.add("resizing");
+          document.body.classList.add("is-resizing-node");
+          resizeHandle.setPointerCapture?.(e.pointerId);
+        });
+      }
+
+      stopDragPropagation(nameInput);
+      nameInput.addEventListener("input", () => {
+        node.name = nameInput.value;
+        refreshQuery();
+      });
+      nameInput.addEventListener("change", () => {
+        node.name = sanitizeName(nameInput.value, defaultName(node.type));
+        nameInput.value = node.name;
+        refreshQuery();
+      });
+      nameInput.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          nameInput.blur();
+        }
+        e.stopPropagation();
+      });
+
+      const resultInput = el.querySelector(".result-name-input");
+      stopDragPropagation(resultInput);
+      resultInput.addEventListener("input", () => {
+        node.resultName = resultInput.value;
+        refreshQuery();
+      });
+      resultInput.addEventListener("change", () => {
+        node.resultName = resultInput.value.trim()
+          ? sanitizeName(resultInput.value, "")
+          : "";
+        resultInput.value = node.resultName;
+        refreshQuery();
+      });
+      resultInput.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          resultInput.blur();
+        }
+        e.stopPropagation();
+      });
+
+      el.querySelectorAll(".alias-input").forEach((input) => {
+        stopDragPropagation(input);
+        const syncAliasSize = () => {
+          const len = Math.max(5, Math.min(28, (input.value || "alias").length + 1));
+          input.size = len;
+        };
+        syncAliasSize();
+        input.addEventListener("input", () => {
+          const key = pathKey(decodePath(input.dataset.aliasPath));
+          const value = input.value.trim();
+          if (value) node.aliases[key] = value;
+          else delete node.aliases[key];
+          syncAliasSize();
+          refreshQuery();
+        });
+        input.addEventListener("change", () => {
+          const key = pathKey(decodePath(input.dataset.aliasPath));
+          if (node.aliases[key]) {
+            // Aliases may be dotted (Author.Name), so keep dots.
+            node.aliases[key] = node.aliases[key].replace(/[^A-Za-z0-9_.]/g, "_");
+            input.value = node.aliases[key];
+            syncAliasSize();
+            refreshQuery();
+          }
+        });
+        input.addEventListener("keydown", (e) => e.stopPropagation());
+      });
+
+      el.querySelector(".entity-node-remove").addEventListener("click", (e) => {
+        e.stopPropagation();
+        nodes = nodes.filter((n) => n.id !== node.id);
+        if (selectedNodeId === node.id) selectedNodeId = null;
+        renderNodes();
+        refreshQuery();
+      });
+
+      el.querySelectorAll(".directive-toggle").forEach((btn) => {
+        stopDragPropagation(btn);
+        btn.addEventListener("click", () => {
+          const key = btn.dataset.directive;
+          node.directives[key] = !node.directives[key];
+          btn.classList.toggle("active", node.directives[key]);
+          refreshQuery();
+        });
+      });
+
+      el.querySelector(".add-param").addEventListener("click", (e) => {
+        e.stopPropagation();
+        let name = `param${node.params.length + 1}`;
+        let i = 2;
+        while (node.params.some((p) => p.name === name)) {
+          name = `param${i}`;
+          i += 1;
+        }
+        node.params.push({
+          id: paramUid(),
+          name,
+          type: "string",
+          value: "",
+          mode: "var",
+        });
+        renderNodes();
+        refreshQuery();
+      });
+
+      el.querySelectorAll(".param-card").forEach((card) => {
+        const param = node.params.find((p) => p.id === card.dataset.paramId);
+        if (!param) return;
+
+        const nameEl = card.querySelector(".param-name");
+        const typeEl = card.querySelector(".param-type");
+        const valueEl = card.querySelector(".param-value");
+        const modeEl = card.querySelector(".param-mode");
+        const removeBtn = card.querySelector(".param-remove");
+
+        [nameEl, typeEl, valueEl, modeEl, removeBtn].forEach(stopDragPropagation);
+
+        modeEl.addEventListener("change", () => {
+          param.mode = modeEl.value === "default" ? "default" : "var";
+          refreshQuery();
+        });
+        nameEl.addEventListener("input", () => {
+          const prev = param.name;
+          param.name = nameEl.value.replace(/^\$/, "");
+          // Keep filter references in sync while typing.
+          const renameIn = (group) => {
+            (group?.conditions || []).forEach((c) => {
+              if (c.valueMode === "param" && c.paramName === prev) c.paramName = param.name;
+            });
+          };
+          renameIn(node.rootFilter);
+          Object.values(node.edgeFilters || {}).forEach(renameIn);
+          refreshQuery();
+        });
+        nameEl.addEventListener("change", () => {
+          const prev = param.name;
+          param.name = sanitizeName(param.name, "param");
+          nameEl.value = param.name;
+          const renameIn = (group) => {
+            (group?.conditions || []).forEach((c) => {
+              if (c.valueMode === "param" && c.paramName === prev) c.paramName = param.name;
+            });
+          };
+          renameIn(node.rootFilter);
+          Object.values(node.edgeFilters || {}).forEach(renameIn);
+          renderNodes();
+          refreshQuery();
+        });
+        typeEl.addEventListener("change", () => {
+          param.type = typeEl.value;
+          if (!param.value) param.value = defaultParamValue(param.type);
+          refreshQuery();
+        });
+        valueEl.addEventListener("input", () => {
+          param.value = valueEl.value;
+          refreshQuery();
+        });
+        removeBtn.addEventListener("click", () => {
+          const removed = param.name;
+          node.params = node.params.filter((p) => p.id !== param.id);
+          const clearRef = (group) => {
+            (group?.conditions || []).forEach((c) => {
+              if (c.valueMode === "param" && c.paramName === removed) {
+                c.paramName = "";
+              }
+            });
+          };
+          clearRef(node.rootFilter);
+          Object.values(node.edgeFilters || {}).forEach(clearRef);
+          renderNodes();
+          refreshQuery();
+        });
+      });
+
+      const getFilterGroup = (edgePath) => {
+        if (!edgePath) {
+          if (!node.rootFilter) node.rootFilter = emptyFilterGroup();
+          return node.rootFilter;
+        }
+        if (!node.edgeFilters) node.edgeFilters = {};
+        if (!node.edgeFilters[edgePath]) node.edgeFilters[edgePath] = emptyFilterGroup();
+        return node.edgeFilters[edgePath];
+      };
+
+      el.querySelectorAll(".filter-panel").forEach((panel) => {
+        const edgePath = panel.dataset.edgePath || "";
+        const group = getFilterGroup(edgePath);
+        const typeName = typeAtEdgePath(node.type, edgePath);
+
+        panel.querySelectorAll(".filter-op-btn").forEach((btn) => {
+          stopDragPropagation(btn);
+          btn.addEventListener("click", () => {
+            group.op = btn.dataset.op === "OR" ? "OR" : "AND";
+            renderNodes();
+            refreshQuery();
+          });
+        });
+
+        panel.querySelector(".add-filter")?.addEventListener("click", (e) => {
+          e.stopPropagation();
+          const preds = scalarPredicates(typeName);
+          const used = new Set(group.conditions.map((c) => c.predicate));
+          const next = preds.find((p) => !used.has(p.name)) || preds[0];
+          const predName = next?.name || "";
+          const type = paramTypeForPredicate(typeName, predName);
+          group.conditions.push(newFilterCondition(predName, type));
+          renderNodes();
+          refreshQuery();
+        });
+
+        panel.querySelectorAll(".filter-row").forEach((row) => {
+          const cond = group.conditions.find((c) => c.id === row.dataset.filterId);
+          if (!cond) return;
+
+          const funcEl = row.querySelector(".filter-func");
+          const predEl = row.querySelector(".filter-predicate");
+          const modeEl = row.querySelector(".filter-value-mode");
+          const literalEl = row.querySelector(".filter-literal");
+          const paramEl = row.querySelector(".filter-param");
+          const removeBtn = row.querySelector(".filter-remove");
+
+          [funcEl, predEl, modeEl, literalEl, paramEl, removeBtn]
+            .filter(Boolean)
+            .forEach(stopDragPropagation);
+
+          funcEl?.addEventListener("change", () => {
+            cond.func = funcEl.value;
+            if (isUnaryFilter(cond.func)) {
+              cond.valueMode = "literal";
+              cond.literal = "";
+              cond.paramName = "";
+            }
+            renderNodes();
+            refreshQuery();
+          });
+          predEl?.addEventListener("change", () => {
+            cond.predicate = predEl.value;
+            const type = paramTypeForPredicate(typeName, cond.predicate);
+            if (cond.valueMode === "literal" && !isUnaryFilter(cond.func)) {
+              cond.literal = defaultParamValue(type);
+            }
+            refreshQuery();
+          });
+          modeEl?.addEventListener("change", () => {
+            cond.valueMode = modeEl.value === "param" ? "param" : "literal";
+            if (cond.valueMode === "param") {
+              if (!cond.paramName && node.params[0]) cond.paramName = node.params[0].name;
+              if (!cond.paramName) {
+                // Auto-create a param from the predicate leaf.
+                const seed = sanitizeName(
+                  (cond.predicate || "param").replace(/\./g, "_"),
+                  "param"
+                );
+                let name = seed;
+                let i = 2;
+                while (node.params.some((p) => p.name === name)) {
+                  name = `${seed}${i}`;
+                  i += 1;
+                }
+                const type = paramTypeForPredicate(typeName, cond.predicate);
+                node.params.push({
+                  id: paramUid(),
+                  name,
+                  type,
+                  value: defaultParamValue(type),
+                  mode: "var",
+                });
+                cond.paramName = name;
+              }
+            }
+            renderNodes();
+            refreshQuery();
+          });
+          literalEl?.addEventListener("input", () => {
+            cond.literal = literalEl.value;
+            refreshQuery();
+          });
+          paramEl?.addEventListener("change", () => {
+            cond.paramName = paramEl.value;
+            refreshQuery();
+          });
+          removeBtn?.addEventListener("click", () => {
+            group.conditions = group.conditions.filter((c) => c.id !== cond.id);
+            if (edgePath && !group.conditions.length) {
+              delete node.edgeFilters[edgePath];
+            }
+            renderNodes();
+            refreshQuery();
+          });
+        });
+      });
+
+      el.querySelectorAll('input[type="checkbox"]').forEach((input) => {
+        input.addEventListener("change", () => {
+          const path = decodePath(input.dataset.path);
+          const kind = input.dataset.kind;
+          const current = getNode(node.id);
+          if (!current) return;
+
+          if (input.checked) {
+            if (kind === "object") {
+              current.selection = setAtPath(current.selection, path, {});
+            } else {
+              current.selection = setAtPath(current.selection, path, null);
+            }
+          } else {
+            current.selection = setAtPath(current.selection, path, undefined);
+            const pathStr = pathKey(path);
+            Object.keys(current.aliases || {}).forEach((key) => {
+              if (key === pathStr || key.startsWith(`${pathStr}.`)) {
+                delete current.aliases[key];
+              }
+            });
+            // Drop edge filters on this edge and anything nested under it.
+            Object.keys(current.edgeFilters || {}).forEach((key) => {
+              if (key === pathStr || key.startsWith(`${pathStr}.`)) {
+                delete current.edgeFilters[key];
+              }
+            });
+          }
+          renderNodes();
+          refreshQuery();
+        });
+      });
+
+      el.addEventListener("mousedown", (e) => {
+        if (e.target.closest("input, label, button, select")) return;
+        setSelected(node.id);
+      });
+
+      canvasEl.appendChild(el);
+
+      const savedScroll = fieldScroll.get(node.id);
+      if (savedScroll) {
+        const body = el.querySelector(".entity-node-body");
+        if (body) {
+          body.scrollTop = savedScroll.top;
+          body.scrollLeft = savedScroll.left;
+        }
+      }
+    });
+
+    updateEmptyState();
+    updateCanvasSurface();
+  }
+
+  function placeEntity(typeName, x, y) {
+    if (!schema[typeName]) return;
+
+    const pos =
+      x != null && y != null
+        ? findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H, { x, y })
+        : findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H);
+
+    nodes.push({
+      id: uid(),
+      type: typeName,
+      name: defaultName(typeName),
+      x: pos.x,
+      y: pos.y,
+      width: DEFAULT_NODE_W,
+      height: DEFAULT_NODE_H,
+      selection: defaultSelection(typeName),
+      params: [],
+      rootFilter: emptyFilterGroup(),
+      edgeFilters: {},
+      directives: { cascade: false, normalize: false },
+      aliases: {},
+      resultName: "",
+    });
+    selectedNodeId = nodes[nodes.length - 1].id;
+    renderNodes();
+    refreshQuery();
+  }
+
+  /* ---------- DQL generation ---------- */
+
+  function indent(level) {
+    return "  ".repeat(level);
+  }
+
+  function hasAnySelection(selection) {
+    return selection && typeof selection === "object" && Object.keys(selection).length > 0;
+  }
+
+  function renderSelection(typeName, selection, depth, node, pathPrefix, aliases) {
+    const def = schema[typeName];
+    if (!def || !hasAnySelection(selection)) return "";
+
+    const lines = [];
+    def.fields.forEach((field) => {
+      if (!(field.name in selection)) return;
+
+      const fieldPath = pathPrefix ? `${pathPrefix}.${field.name}` : field.name;
+      const alias = aliases[fieldPath] ? `${aliases[fieldPath]}: ` : "";
+
+      if (field.kind === "scalar") {
+        lines.push(`${indent(depth)}${alias}${field.name}`);
+        return;
+      }
+
+      const nestedType = field.ofType;
+      const filterStr = formatFilterDirective(
+        node.edgeFilters?.[fieldPath],
+        nestedType || typeName
+      );
+
+      const nestedSel = selection[field.name];
+
+      // Depth cap only — allow the same type to reappear on a nested edge
+      // (e.g. User → posts → author → User) so long as the selection is finite.
+      if (!nestedType || !schema[nestedType] || depth >= 14) {
+        lines.push(`${indent(depth)}${alias}${field.name}${filterStr} {`);
+        lines.push(`${indent(depth)}}`);
+        return;
+      }
+
+      const nestedBody = renderSelection(
+        nestedType,
+        nestedSel && typeof nestedSel === "object" ? nestedSel : {},
+        depth + 1,
+        node,
+        fieldPath,
+        aliases
+      );
+      lines.push(`${indent(depth)}${alias}${field.name}${filterStr} {`);
+      if (nestedBody) lines.push(nestedBody);
+      lines.push(`${indent(depth)}}`);
+    });
+
+    return lines.join("\n");
+  }
+
+  function uniqueBlockNames(roots) {
+    const seen = new Map();
+    return roots.map((node) => {
+      const fallback = `get${node.type}`;
+      let name = sanitizeName(node.name, fallback);
+      if (seen.has(name)) {
+        const count = seen.get(name) + 1;
+        seen.set(name, count);
+        name = `${name}_${count}`;
+      } else {
+        seen.set(name, 1);
+      }
+      return name;
+    });
+  }
+
+  function collectParams(roots) {
+    const map = new Map();
+    roots.forEach((node) => {
+      (node.params || []).forEach((param) => {
+        if (param.mode === "literal") return;
+        const name = sanitizeName(param.name, "");
+        if (!name || map.has(name)) return;
+        map.set(name, { ...param, name });
+      });
+    });
+    return [...map.values()];
+  }
+
+  /** Format a param's value as a DQL literal ("Alice", 42, true). */
+  function formatDqlLiteral(param) {
+    if (param.type === "int") {
+      const n = parseInt(param.value, 10);
+      return String(Number.isFinite(n) ? n : 0);
+    }
+    if (param.type === "float") {
+      const n = parseFloat(param.value);
+      return String(Number.isFinite(n) ? n : 0);
+    }
+    if (param.type === "bool") {
+      return String(String(param.value).toLowerCase() === "true");
+    }
+    return JSON.stringify(String(param.value ?? ""));
+  }
+
+  function formatParamValue(param) {
+    if (param.type === "int") {
+      const n = parseInt(param.value, 10);
+      return Number.isFinite(n) ? n : 0;
+    }
+    if (param.type === "float") {
+      const n = parseFloat(param.value);
+      return Number.isFinite(n) ? n : 0;
+    }
+    if (param.type === "bool") {
+      return String(param.value).toLowerCase() === "true";
+    }
+    return String(param.value ?? "");
+  }
+
+  function formatFilterCondition(cond, typeName) {
+    if (!cond?.func || !cond?.predicate) return null;
+    if (isUnaryFilter(cond.func)) return `${cond.func}(${cond.predicate})`;
+
+    if (cond.valueMode === "param") {
+      const name = sanitizeName(cond.paramName, "");
+      if (!name) return null;
+      return `${cond.func}(${cond.predicate}, $${name})`;
+    }
+
+    const type = paramTypeForPredicate(typeName, cond.predicate);
+    const valuePart = formatDqlLiteral({ type, value: cond.literal });
+    return `${cond.func}(${cond.predicate}, ${valuePart})`;
+  }
+
+  function formatFilterDirective(group, typeName) {
+    const g = ensureFilterGroup(group);
+    const parts = g.conditions
+      .map((c) => formatFilterCondition(c, typeName))
+      .filter(Boolean);
+    if (!parts.length) return "";
+    return ` @filter(${parts.join(` ${g.op} `)})`;
+  }
+
+  /**
+   * Result key inside the operation: "query getUser { User(...) }".
+   * Strip a leading "get" when the remainder is a valid identifier,
+   * otherwise reuse the operation name.
+   */
+  function innerBlockName(opName) {
+    if (/^get./.test(opName)) {
+      const rest = opName.slice(3);
+      if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(rest)) return rest;
+    }
+    return opName;
+  }
+
+  function blockParams(node) {
+    const seen = new Set();
+    const result = [];
+    (node.params || []).forEach((param) => {
+      const name = sanitizeName(param.name, "");
+      if (!name || seen.has(name)) return;
+      seen.add(name);
+      result.push({ ...param, name });
+    });
+    return result;
+  }
+
+  function refreshQuery() {
+    try {
+      const roots = nodes.filter((n) => hasAnySelection(n.selection));
+      if (!roots.length) {
+        setOutputs(
+          nodes.length ? "# Pick at least one predicate on a query block." : "",
+          ""
+        );
+        return;
+      }
+
+      const names = uniqueBlockNames(roots);
+      const allParams = collectParams(roots);
+
+      // One named operation per canvas block, each with its own signature.
+      const operations = roots.map((node, i) => {
+        const filter = formatFilterDirective(node.rootFilter, node.type);
+        const directives =
+          (node.directives?.cascade ? " @cascade" : "") +
+          (node.directives?.normalize ? " @normalize" : "");
+        const body = renderSelection(
+          node.type,
+          node.selection,
+          2,
+          node,
+          "",
+          node.aliases || {}
+        );
+
+        const params = blockParams(node);
+        const signature = params.length
+          ? `(${params
+              .map(
+                (p) =>
+                  `$${p.name}: ${p.type}${p.mode === "default" ? ` = ${formatDqlLiteral(p)}` : ""}`
+              )
+              .join(", ")})`
+          : "";
+        const inner = sanitizeName(node.resultName, "") || innerBlockName(names[i]);
+
+        return (
+          `query ${names[i]}${signature} {\n` +
+          `${indent(1)}${inner}(func: type("${node.type}"))${filter}${directives} {\n` +
+          `${body}\n${indent(1)}}\n}`
+        );
+      });
+
+      // Single block → flat vars object; multiple → grouped per operation,
+      // since each operation is executed separately with its own variables.
+      let vars = "";
+      if (allParams.length) {
+        const varsFor = (node) => {
+          const obj = {};
+          blockParams(node).forEach((p) => {
+            obj[`$${p.name}`] = formatParamValue(p);
+          });
+          return obj;
+        };
+
+        if (roots.length === 1) {
+          vars = JSON.stringify(varsFor(roots[0]), null, 2);
+        } else {
+          const grouped = {};
+          roots.forEach((node, i) => {
+            if (blockParams(node).length) grouped[names[i]] = varsFor(node);
+          });
+          vars = JSON.stringify(grouped, null, 2);
+        }
+      }
+
+      setOutputs(operations.join("\n\n"), vars);
+    } catch (err) {
+      consoleError(err.message || String(err), "query-build");
+      setOutputs(`# Query build failed:\n# ${err.message || err}`, "");
+    } finally {
+      scheduleSaveWorkspace();
+    }
+  }
+
+  /* ---------- Copy ---------- */
+
+  async function copyText(text, button) {
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      const prev = button.textContent;
+      button.textContent = "Copied";
+      setTimeout(() => {
+        button.textContent = prev;
+      }, 1200);
+    } catch {
+      /* clipboard unavailable */
+    }
+  }
+
+  /* ---------- Canvas drag & drop ---------- */
+
+  window.addEventListener("pointermove", (e) => {
+    if (resizeState) {
+      const node = getNode(resizeState.id);
+      const el = canvasEl.querySelector(`.entity-node[data-id="${resizeState.id}"]`);
+      if (!node || !el) return;
+      const nextW = Math.max(300, resizeState.startW + (e.clientX - resizeState.startX));
+      const nextH = Math.max(240, resizeState.startH + (e.clientY - resizeState.startY));
+      node.width = nextW;
+      node.height = nextH;
+      el.style.width = `${nextW}px`;
+      el.style.height = `${nextH}px`;
+      updateCanvasSurface();
+      return;
+    }
+
+    if (!moveState) return;
+    const node = getNode(moveState.id);
+    const el = canvasEl.querySelector(`.entity-node[data-id="${moveState.id}"]`);
+    if (!node || !el) return;
+
+    const canvasRect = canvasEl.getBoundingClientRect();
+    node.x = Math.max(
+      0,
+      e.clientX - canvasRect.left - moveState.offsetX + canvasEl.scrollLeft
+    );
+    node.y = Math.max(
+      0,
+      e.clientY - canvasRect.top - moveState.offsetY + canvasEl.scrollTop
+    );
+    el.style.left = `${node.x}px`;
+    el.style.top = `${node.y}px`;
+    updateCanvasSurface();
+  });
+
+  window.addEventListener("pointerup", () => {
+    if (resizeState) {
+      const el = canvasEl.querySelector(`.entity-node[data-id="${resizeState.id}"]`);
+      if (el) el.classList.remove("resizing");
+      document.body.classList.remove("is-resizing-node");
+      resizeState = null;
+      scheduleSaveWorkspace();
+      return;
+    }
+    if (!moveState) return;
+    const el = canvasEl.querySelector(`.entity-node[data-id="${moveState.id}"]`);
+    if (el) el.classList.remove("dragging");
+    document.body.classList.remove("is-dragging-node");
+    moveState = null;
+    scheduleSaveWorkspace();
+  });
+
+  canvasEl.addEventListener("dragover", (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+    canvasEl.classList.add("drag-over");
+  });
+
+  canvasEl.addEventListener("dragleave", (e) => {
+    if (!canvasEl.contains(e.relatedTarget)) {
+      canvasEl.classList.remove("drag-over");
+    }
+  });
+
+  canvasEl.addEventListener("drop", (e) => {
+    e.preventDefault();
+    canvasEl.classList.remove("drag-over");
+    closeEntityMenu();
+    const typeName = dragPaletteType || e.dataTransfer.getData("text/plain");
+    if (!typeName || !schema[typeName]) return;
+
+    const rect = canvasEl.getBoundingClientRect();
+    const x = e.clientX - rect.left + canvasEl.scrollLeft - DEFAULT_NODE_W / 2;
+    const y = e.clientY - rect.top + canvasEl.scrollTop - 24;
+    placeEntity(typeName, x, y);
+  });
+
+  if (addEntityBtn) {
+    addEntityBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleEntityMenu();
+    });
+  }
+  document.addEventListener("click", (e) => {
+    if (!entityMenuWrap?.contains(e.target)) closeEntityMenu();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeEntityMenu();
+  });
+
+  if (clearBtn) {
+    clearBtn.addEventListener("click", () => {
+      nodes = [];
+      selectedNodeId = null;
+      clearDqlDirty();
+      clearWorkspace();
+      renderNodes();
+      refreshQuery();
+    });
+  }
+
+  if (copyBtn) copyBtn.addEventListener("click", () => copyText(getDqlText(), copyBtn));
+  if (copyVarsBtn) copyVarsBtn.addEventListener("click", () => copyText(varsText, copyVarsBtn));
+
+  /* ---------- DQL editor → canvas ---------- */
+
+  /**
+   * Parse DQL text into canvas nodes. Extends the live schema when the query
+   * references types/fields that are not loaded yet.
+   */
+  function importQueryText(raw, { source = "import" } = {}) {
+    if (!window.DQLQueryParser) {
+      throw new Error("Query parser is not loaded");
+    }
+    const operations = window.DQLQueryParser.parse(raw);
+    const { schema: nextSchema, warnings } = window.DQLQueryParser.ensureSchema(
+      schema,
+      operations
+    );
+    const drafts = window.DQLQueryParser.toNodes(operations, nextSchema);
+
+    schema = nextSchema;
+    schemaIsSample = false;
+    nodes = [];
+    selectedNodeId = null;
+    animatedNodes.clear();
+
+    drafts.forEach((draft, i) => {
+      const withIds = (group) => {
+        const g = ensureFilterGroup(group);
+        return {
+          op: g.op,
+          conditions: g.conditions.map((c) => ({
+            id: filterUid(),
+            func: c.func || "eq",
+            predicate: c.predicate || "",
+            valueMode: c.valueMode === "param" ? "param" : "literal",
+            literal: c.literal ?? "",
+            paramName: c.paramName || "",
+          })),
+        };
+      };
+      const edgeFilters = {};
+      Object.entries(draft.edgeFilters || {}).forEach(([key, group]) => {
+        edgeFilters[key] = withIds(group);
+      });
+
+      const pos = findFreePosition(DEFAULT_NODE_W, DEFAULT_NODE_H);
+      nodes.push({
+        id: uid(),
+        type: draft.type,
+        name: draft.name,
+        x: pos.x,
+        y: pos.y,
+        width: DEFAULT_NODE_W,
+        height: DEFAULT_NODE_H,
+        selection: draft.selection,
+        params: (draft.params || []).map((p) => ({
+          id: paramUid(),
+          name: p.name,
+          type: PARAM_TYPES.includes(p.type) ? p.type : "string",
+          value: p.value ?? "",
+          mode: p.mode === "default" ? "default" : "var",
+        })),
+        rootFilter: withIds(draft.rootFilter),
+        edgeFilters,
+        directives: {
+          cascade: !!draft.directives?.cascade,
+          normalize: !!draft.directives?.normalize,
+        },
+        aliases: { ...(draft.aliases || {}) },
+        resultName: draft.resultName || "",
+      });
+    });
+
+    if (nodes.length) selectedNodeId = nodes[0].id;
+    resolveOverlaps();
+
+    // Clear dirty before refresh so generated DQL can write back into the editor.
+    clearDqlDirty();
+    renderDock();
+    renderNodes();
+    refreshQuery();
+
+    consoleInfo(
+      `Applied ${nodes.length} query block${nodes.length === 1 ? "" : "s"}`,
+      source
+    );
+    (warnings || []).forEach((w) => consoleWarn(w, source));
+    return `Loaded ${nodes.length} query block${nodes.length === 1 ? "" : "s"}`;
+  }
+
+  /**
+   * Commit the DQL editor buffer to the canvas.
+   * @param {{ reason?: string, soft?: boolean }} [opts]
+   *   soft — used on blur: skip if not dirty / not a complete-looking query,
+   *   and don't log errors for empty buffers.
+   */
+  function applyDqlFromEditor({ reason = "apply", soft = false } = {}) {
+    if (soft && !dqlDirty) return false;
+
+    const text = getDqlText().trim();
+    if (!text) {
+      if (soft) return false;
+      nodes = [];
+      selectedNodeId = null;
+      clearDqlDirty();
+      renderNodes();
+      refreshQuery();
+      consoleInfo("Cleared canvas from empty DQL editor", "editor");
+      return true;
+    }
+
+    if (!looksLikeDql(text)) {
+      if (soft) return false;
+      consoleError(
+        "Expected one or more `query Name { … }` operations before applying",
+        "editor"
+      );
+      return false;
+    }
+
+    // No-op if the buffer still matches the last generated output.
+    if (text === queryText.trim()) {
+      clearDqlDirty();
+      return true;
+    }
+
+    try {
+      importQueryText(text, { source: "editor" });
+      return true;
+    } catch (err) {
+      // Soft blur: stay dirty quietly while the user is still typing.
+      if (!soft) consoleError(err.message || String(err), "editor");
+      if (!dqlDirty) {
+        dqlDirty = true;
+        updateDqlChrome();
+      }
+      return false;
+    }
+  }
+
+  function revertDqlEditor() {
+    clearDqlDirty();
+    writeDqlEditor(queryText);
+    if (copyBtn) copyBtn.disabled = !queryText;
+    consoleInfo("Reverted DQL editor to last canvas output", "editor");
+  }
+
+  if (applyDqlBtn) applyDqlBtn.addEventListener("click", () => applyDqlFromEditor({ reason: "button" }));
+  if (revertDqlBtn) revertDqlBtn.addEventListener("click", () => revertDqlEditor());
+
+  // Ctrl/Cmd+V on the canvas loads a pasted query directly.
+  canvasEl.addEventListener("paste", (e) => {
+    const text = e.clipboardData?.getData("text/plain") || "";
+    if (!looksLikeDql(text)) return;
+    if (e.target.closest("input, textarea, select, .monaco-editor")) return;
+    e.preventDefault();
+    try {
+      const msg = importQueryText(text, { source: "paste" });
+      canvasEmptyEl.textContent = msg;
+      setTimeout(() => updateEmptyState(), 1600);
+    } catch (err) {
+      // Drop the text into the DQL editor so the user can fix it.
+      clearDqlDirty();
+      writeDqlEditor(text);
+      markDqlDirty();
+      consoleError(err.message || String(err), "paste");
+    }
+  });
+
+  /* ---------- Schema API (Ratel supplies schema; no Load-schema modal) ---------- */
+
+  function setSchema(next, { isSample = false, clearCanvas = true } = {}) {
+    schema = next || {};
+    schemaIsSample = isSample;
+    if (clearCanvas) {
+      nodes = [];
+      selectedNodeId = null;
+      animatedNodes.clear();
+      clearDqlDirty();
+    }
+    renderDock();
+    renderNodes();
+    refreshQuery();
+  }
+
+  function applyLoadedSchema(next, sourceLabel) {
+    const count = Object.keys(next || {}).length;
+    if (!count) {
+      consoleError('Schema parsed, but it contains no usable object types.', 'schema');
+      return;
+    }
+    setSchema(next, { isSample: false });
+    consoleInfo('Loaded ' + count + ' entit' + (count === 1 ? 'y' : 'ies') + ' from ' + sourceLabel, 'schema');
+  }
+
+  const loadSchemaBtn = $('loadSchemaBtn');
+  if (loadSchemaBtn) loadSchemaBtn.hidden = true;
+
+  /* ---------- Init ---------- */
+
+  const restored = opts.persistWorkspace ? restoreWorkspace() : false;
+  if (opts.schema && (!restored || schemaIsSample)) {
+    schema = opts.schema;
+    schemaIsSample = false;
+  }
+  renderDock();
+  if (restored) {
+    renderNodes();
+    consoleInfo('Restored canvas from previous session', 'workspace');
+  } else {
+    updateEmptyState();
+  }
+  initEditors();
+  refreshQuery();
+
+  function destroy() {
+    try {
+      dqlEditor?.dispose?.();
+      varsEditor?.dispose?.();
+    } catch (_) {}
+    dqlEditor = null;
+    varsEditor = null;
+    clearTimeout(saveWorkspaceTimer);
+  }
+
+  function clearCanvas() {
+    nodes = [];
+    selectedNodeId = null;
+    clearDqlDirty();
+    clearWorkspace();
+    renderNodes();
+    refreshQuery();
+  }
+
+  function importExternalQuery(text) {
+    const raw = String(text || "").trim();
+    if (!raw) {
+      clearCanvas();
+      return true;
+    }
+    try {
+      importQueryText(raw, { source: "ratel-editor" });
+      return true;
+    } catch (err) {
+      consoleError(err.message || String(err), "editor");
+      return false;
+    }
+  }
+
+  return {
+    setSchema,
+    applyLoadedSchema,
+    getQuery: () => (dqlDirty ? getDqlText() : queryText),
+    getVars: () => varsText,
+    refresh: refreshQuery,
+    clearCanvas,
+    importQuery: importExternalQuery,
+    destroy,
+  };
+  }
+
+  return { mount };
+})();

--- a/client/src/components/QueryBuilder/lib/app.js
+++ b/client/src/components/QueryBuilder/lib/app.js
@@ -1657,6 +1657,17 @@ window.DQLBuilder = (() => {
                   delete current.edgeFilters[key]
                 }
               })
+              // Drop preserved comments for removed predicates.
+              Object.keys(current.comments?.fields || {}).forEach((key) => {
+                if (key === pathStr || key.startsWith(`${pathStr}.`)) {
+                  delete current.comments.fields[key]
+                }
+              })
+              Object.keys(current.comments?.blocks || {}).forEach((key) => {
+                if (key === pathStr || key.startsWith(`${pathStr}.`)) {
+                  delete current.comments.blocks[key]
+                }
+              })
             }
             renderNodes()
             refreshQuery()
@@ -1706,6 +1717,13 @@ window.DQLBuilder = (() => {
         edgeFilters: {},
         directives: { cascade: false, normalize: false },
         aliases: {},
+        comments: {
+          leading: [],
+          trailing: null,
+          rootLeading: [],
+          fields: {},
+          blocks: {},
+        },
         resultName: '',
       })
       selectedNodeId = nodes[nodes.length - 1].id
@@ -1717,6 +1735,16 @@ window.DQLBuilder = (() => {
 
     function indent(level) {
       return '  '.repeat(level)
+    }
+
+    function emitCommentLines(lines, comments, depth) {
+      ;(comments || []).forEach((text) => {
+        String(text)
+          .split('\n')
+          .forEach((line) => {
+            lines.push(`${indent(depth)}${line}`)
+          })
+      })
     }
 
     function hasAnySelection(selection) {
@@ -1755,9 +1783,14 @@ window.DQLBuilder = (() => {
           ? `${pathPrefix}.${field.name}`
           : field.name
         const alias = aliases[fieldPath] ? `${aliases[fieldPath]}: ` : ''
+        const meta = node.comments?.fields?.[fieldPath]
+
+        emitCommentLines(lines, meta?.leading, depth)
 
         if (field.kind === 'scalar') {
-          lines.push(`${indent(depth)}${alias}${field.name}`)
+          let line = `${indent(depth)}${alias}${field.name}`
+          if (meta?.trailing) line += ` ${meta.trailing}`
+          lines.push(line)
           return
         }
 
@@ -1773,7 +1806,10 @@ window.DQLBuilder = (() => {
         // (e.g. User → posts → author → User) so long as the selection is finite.
         if (!nestedType || !schema[nestedType] || depth >= 14) {
           lines.push(`${indent(depth)}${alias}${field.name}${filterStr} {`)
-          lines.push(`${indent(depth)}}`)
+          emitCommentLines(lines, node.comments?.blocks?.[fieldPath], depth + 1)
+          let close = `${indent(depth)}}`
+          if (meta?.trailing) close += ` ${meta.trailing}`
+          lines.push(close)
           return
         }
 
@@ -1787,7 +1823,10 @@ window.DQLBuilder = (() => {
         )
         lines.push(`${indent(depth)}${alias}${field.name}${filterStr} {`)
         if (nestedBody) lines.push(nestedBody)
-        lines.push(`${indent(depth)}}`)
+        emitCommentLines(lines, node.comments?.blocks?.[fieldPath], depth + 1)
+        let close = `${indent(depth)}}`
+        if (meta?.trailing) close += ` ${meta.trailing}`
+        lines.push(close)
       })
 
       return lines.join('\n')
@@ -1945,11 +1984,20 @@ window.DQLBuilder = (() => {
           const inner =
             sanitizeName(node.resultName, '') || innerBlockName(names[i])
 
-          return (
-            `query ${names[i]}${signature} {\n` +
-            `${indent(1)}${inner}(func: type("${node.type}"))${filter}${directives} {\n` +
-            `${body}\n${indent(1)}}\n}`
+          const lines = []
+          emitCommentLines(lines, node.comments?.leading, 0)
+          lines.push(`query ${names[i]}${signature} {`)
+          emitCommentLines(lines, node.comments?.rootLeading, 1)
+          lines.push(
+            `${indent(1)}${inner}(func: type("${node.type}"))${filter}${directives} {`,
           )
+          if (body) lines.push(body)
+          emitCommentLines(lines, node.comments?.blocks?.[''], 2)
+          lines.push(`${indent(1)}}`)
+          let close = '}'
+          if (node.comments?.trailing) close += ` ${node.comments.trailing}`
+          lines.push(close)
+          return lines.join('\n')
         })
 
         // Single block → flat vars object; multiple → grouped per operation,
@@ -2188,6 +2236,13 @@ window.DQLBuilder = (() => {
             normalize: !!draft.directives?.normalize,
           },
           aliases: { ...(draft.aliases || {}) },
+          comments: {
+            leading: [...(draft.comments?.leading || [])],
+            trailing: draft.comments?.trailing || null,
+            rootLeading: [...(draft.comments?.rootLeading || [])],
+            fields: { ...(draft.comments?.fields || {}) },
+            blocks: { ...(draft.comments?.blocks || {}) },
+          },
           resultName: draft.resultName || '',
         })
       })

--- a/client/src/components/QueryBuilder/lib/query-parser.js
+++ b/client/src/components/QueryBuilder/lib/query-parser.js
@@ -9,215 +9,218 @@
  *   }
  */
 window.DQLQueryParser = (() => {
-  const PARAM_TYPES = ["string", "int", "float", "bool"];
+  const PARAM_TYPES = ['string', 'int', 'float', 'bool']
 
   /** Strip block, line (//), and hash (#) comments without touching string literals. */
   function stripComments(src) {
-    const input = String(src || "");
-    let out = "";
+    const input = String(src || '')
+    let out = ''
     for (let i = 0; i < input.length; i += 1) {
-      const ch = input[i];
-      const next = input[i + 1];
+      const ch = input[i]
+      const next = input[i + 1]
 
       if (ch === '"' || ch === "'") {
-        const q = ch;
-        out += ch;
-        i += 1;
+        const q = ch
+        out += ch
+        i += 1
         while (i < input.length && input[i] !== q) {
-          if (input[i] === "\\") {
-            out += input[i];
-            i += 1;
-            if (i < input.length) out += input[i];
-            i += 1;
-            continue;
+          if (input[i] === '\\') {
+            out += input[i]
+            i += 1
+            if (i < input.length) out += input[i]
+            i += 1
+            continue
           }
-          out += input[i];
-          i += 1;
+          out += input[i]
+          i += 1
         }
-        if (i < input.length) out += input[i];
-        continue;
+        if (i < input.length) out += input[i]
+        continue
       }
 
-      if (ch === "/" && next === "*") {
-        i += 2;
-        while (i < input.length && !(input[i] === "*" && input[i + 1] === "/")) i += 1;
-        i += 1; // land on '/'
-        out += " ";
-        continue;
+      if (ch === '/' && next === '*') {
+        i += 2
+        while (i < input.length && !(input[i] === '*' && input[i + 1] === '/'))
+          i += 1
+        i += 1 // land on '/'
+        out += ' '
+        continue
       }
 
-      if ((ch === "/" && next === "/") || ch === "#") {
-        while (i < input.length && input[i] !== "\n") i += 1;
-        i -= 1;
-        out += " ";
-        continue;
+      if ((ch === '/' && next === '/') || ch === '#') {
+        while (i < input.length && input[i] !== '\n') i += 1
+        i -= 1
+        out += ' '
+        continue
       }
 
-      out += ch;
+      out += ch
     }
-    return out;
+    return out
   }
 
   function skipWs(src, i) {
-    while (i < src.length && /\s/.test(src[i])) i += 1;
-    return i;
+    while (i < src.length && /\s/.test(src[i])) i += 1
+    return i
   }
 
-  function extractBalanced(src, openIdx, openCh = "{", closeCh = "}") {
-    if (src[openIdx] !== openCh) throw new Error(`Expected '${openCh}'`);
-    let depth = 0;
+  function extractBalanced(src, openIdx, openCh = '{', closeCh = '}') {
+    if (src[openIdx] !== openCh) throw new Error(`Expected '${openCh}'`)
+    let depth = 0
     for (let i = openIdx; i < src.length; i += 1) {
-      const ch = src[i];
+      const ch = src[i]
       if (ch === '"' || ch === "'") {
-        const q = ch;
-        i += 1;
+        const q = ch
+        i += 1
         while (i < src.length && src[i] !== q) {
-          if (src[i] === "\\") i += 1;
-          i += 1;
+          if (src[i] === '\\') i += 1
+          i += 1
         }
-        continue;
+        continue
       }
-      if (ch === openCh) depth += 1;
+      if (ch === openCh) depth += 1
       else if (ch === closeCh) {
-        depth -= 1;
-        if (depth === 0) return { inner: src.slice(openIdx + 1, i), end: i + 1 };
+        depth -= 1
+        if (depth === 0) return { inner: src.slice(openIdx + 1, i), end: i + 1 }
       }
     }
-    throw new Error(`Unbalanced '${openCh}${closeCh}'`);
+    throw new Error(`Unbalanced '${openCh}${closeCh}'`)
   }
 
   function readIdent(src, i) {
-    i = skipWs(src, i);
-    const m = src.slice(i).match(/^[A-Za-z_][A-Za-z0-9_]*/);
-    if (!m) return null;
-    return { value: m[0], end: i + m[0].length };
+    i = skipWs(src, i)
+    const m = src.slice(i).match(/^[A-Za-z_][A-Za-z0-9_]*/)
+    if (!m) return null
+    return { value: m[0], end: i + m[0].length }
   }
 
   /** Dotted predicate: User.email / Post.title */
   function readPredicate(src, i) {
-    i = skipWs(src, i);
-    const m = src.slice(i).match(/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*/);
-    if (!m) return null;
-    return { value: m[0], end: i + m[0].length };
+    i = skipWs(src, i)
+    const m = src
+      .slice(i)
+      .match(/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*/)
+    if (!m) return null
+    return { value: m[0], end: i + m[0].length }
   }
 
   function parseStringLiteral(raw) {
-    const t = String(raw || "").trim();
+    const t = String(raw || '').trim()
     if (
       (t.startsWith('"') && t.endsWith('"')) ||
       (t.startsWith("'") && t.endsWith("'"))
     ) {
       try {
         // Prefer JSON for double-quoted; fall back for single-quoted.
-        if (t[0] === '"') return JSON.parse(t);
-        return t.slice(1, -1).replace(/\\'/g, "'");
+        if (t[0] === '"') return JSON.parse(t)
+        return t.slice(1, -1).replace(/\\'/g, "'")
       } catch {
-        return t.slice(1, -1);
+        return t.slice(1, -1)
       }
     }
-    return t;
+    return t
   }
 
   function inferTypeFromLiteral(raw) {
-    const t = String(raw ?? "").trim();
-    if (/^(true|false)$/i.test(t)) return "bool";
-    if (/^-?\d+$/.test(t)) return "int";
-    if (/^-?\d+\.\d+$/.test(t)) return "float";
-    return "string";
+    const t = String(raw ?? '').trim()
+    if (/^(true|false)$/i.test(t)) return 'bool'
+    if (/^-?\d+$/.test(t)) return 'int'
+    if (/^-?\d+\.\d+$/.test(t)) return 'float'
+    return 'string'
   }
 
   /** Parse `$name: type` / `$name: type = <literal>` with string-aware defaults. */
   function parseSignature(sig) {
-    if (!sig) return [];
-    const params = [];
-    let i = 0;
-    const src = String(sig).replace(/^\(/, "").replace(/\)$/, "");
+    if (!sig) return []
+    const params = []
+    let i = 0
+    const src = String(sig).replace(/^\(/, '').replace(/\)$/, '')
 
     while (i < src.length) {
-      i = skipWs(src, i);
-      if (i >= src.length) break;
-      if (src[i] === ",") {
-        i += 1;
-        continue;
+      i = skipWs(src, i)
+      if (i >= src.length) break
+      if (src[i] === ',') {
+        i += 1
+        continue
       }
-      if (src[i] !== "$") break;
-      i += 1;
-      const name = readIdent(src, i);
-      if (!name) break;
-      i = name.end;
-      i = skipWs(src, i);
-      if (src[i] !== ":") break;
-      i += 1;
-      const typeTok = readIdent(src, i);
-      if (!typeTok) break;
-      i = typeTok.end;
-      i = skipWs(src, i);
+      if (src[i] !== '$') break
+      i += 1
+      const name = readIdent(src, i)
+      if (!name) break
+      i = name.end
+      i = skipWs(src, i)
+      if (src[i] !== ':') break
+      i += 1
+      const typeTok = readIdent(src, i)
+      if (!typeTok) break
+      i = typeTok.end
+      i = skipWs(src, i)
 
-      let mode = "var";
-      let value = "";
-      if (src[i] === "=") {
-        i += 1;
-        i = skipWs(src, i);
-        const start = i;
+      let mode = 'var'
+      let value = ''
+      if (src[i] === '=') {
+        i += 1
+        i = skipWs(src, i)
+        const start = i
         if (src[i] === '"' || src[i] === "'") {
-          const q = src[i];
-          i += 1;
+          const q = src[i]
+          i += 1
           while (i < src.length && src[i] !== q) {
-            if (src[i] === "\\") i += 1;
-            i += 1;
+            if (src[i] === '\\') i += 1
+            i += 1
           }
-          if (i < src.length) i += 1;
-          mode = "default";
-          value = String(parseStringLiteral(src.slice(start, i)));
+          if (i < src.length) i += 1
+          mode = 'default'
+          value = String(parseStringLiteral(src.slice(start, i)))
         } else {
-          while (i < src.length && src[i] !== ",") i += 1;
-          mode = "default";
-          value = String(parseStringLiteral(src.slice(start, i).trim()));
+          while (i < src.length && src[i] !== ',') i += 1
+          mode = 'default'
+          value = String(parseStringLiteral(src.slice(start, i).trim()))
         }
       }
 
       params.push({
         name: name.value,
-        type: PARAM_TYPES.includes(typeTok.value) ? typeTok.value : "string",
+        type: PARAM_TYPES.includes(typeTok.value) ? typeTok.value : 'string',
         mode,
         value,
-      });
+      })
     }
-    return params;
+    return params
   }
 
   /** Split filter body on top-level AND / OR. */
   function splitFilterConnectors(filterInner) {
-    const parts = [];
-    let depth = 0;
-    let start = 0;
-    let sawOr = false;
-    const s = String(filterInner || "");
+    const parts = []
+    let depth = 0
+    let start = 0
+    let sawOr = false
+    const s = String(filterInner || '')
     for (let i = 0; i < s.length; i += 1) {
-      const ch = s[i];
-      if (ch === "(") depth += 1;
-      else if (ch === ")") depth -= 1;
+      const ch = s[i]
+      if (ch === '(') depth += 1
+      else if (ch === ')') depth -= 1
       else if (ch === '"' || ch === "'") {
-        const q = ch;
-        i += 1;
+        const q = ch
+        i += 1
         while (i < s.length && s[i] !== q) {
-          if (s[i] === "\\") i += 1;
-          i += 1;
+          if (s[i] === '\\') i += 1
+          i += 1
         }
       } else if (depth === 0) {
-        const andMatch = s.slice(i).match(/^\s+AND\s+/i);
-        const orMatch = s.slice(i).match(/^\s+OR\s+/i);
-        const match = andMatch || orMatch;
+        const andMatch = s.slice(i).match(/^\s+AND\s+/i)
+        const orMatch = s.slice(i).match(/^\s+OR\s+/i)
+        const match = andMatch || orMatch
         if (match) {
-          if (orMatch) sawOr = true;
-          parts.push(s.slice(start, i).trim());
-          i += match[0].length - 1;
-          start = i + 1;
+          if (orMatch) sawOr = true
+          parts.push(s.slice(start, i).trim())
+          i += match[0].length - 1
+          start = i + 1
         }
       }
     }
-    parts.push(s.slice(start).trim());
-    return { parts: parts.filter(Boolean), sawOr };
+    parts.push(s.slice(start).trim())
+    return { parts: parts.filter(Boolean), sawOr }
   }
 
   /**
@@ -225,61 +228,61 @@ window.DQLQueryParser = (() => {
    * Returns { func, predicate, valueRaw, isVar, varName, literal, unary } | null
    */
   function parseOneFilterCondition(part) {
-    const s = String(part || "").trim();
-    if (!s) return null;
+    const s = String(part || '').trim()
+    if (!s) return null
 
-    const notMatch = s.match(/^(not)\s+/i);
-    let rest = s;
-    let notPrefix = "";
+    const notMatch = s.match(/^(not)\s+/i)
+    let rest = s
+    let notPrefix = ''
     if (notMatch) {
-      notPrefix = "not ";
-      rest = s.slice(notMatch[0].length).trim();
+      notPrefix = 'not '
+      rest = s.slice(notMatch[0].length).trim()
     }
 
-    const nameMatch = rest.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*\(/);
-    if (!nameMatch) return null;
-    const funcName = nameMatch[1];
-    const openIdx = rest.indexOf("(");
-    let bal;
+    const nameMatch = rest.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
+    if (!nameMatch) return null
+    const funcName = nameMatch[1]
+    const openIdx = rest.indexOf('(')
+    let bal
     try {
-      bal = extractBalanced(rest, openIdx, "(", ")");
+      bal = extractBalanced(rest, openIdx, '(', ')')
     } catch {
-      return null;
+      return null
     }
     // Reject trailing junk after the closing paren.
-    if (rest.slice(bal.end).trim()) return null;
+    if (rest.slice(bal.end).trim()) return null
 
-    const argsInner = bal.inner.trim();
-    if (!argsInner) return null;
+    const argsInner = bal.inner.trim()
+    if (!argsInner) return null
 
     // Split args on top-level comma.
-    const args = [];
-    let depth = 0;
-    let start = 0;
+    const args = []
+    let depth = 0
+    let start = 0
     for (let i = 0; i < argsInner.length; i += 1) {
-      const ch = argsInner[i];
-      if (ch === "(") depth += 1;
-      else if (ch === ")") depth -= 1;
+      const ch = argsInner[i]
+      if (ch === '(') depth += 1
+      else if (ch === ')') depth -= 1
       else if (ch === '"' || ch === "'") {
-        const q = ch;
-        i += 1;
+        const q = ch
+        i += 1
         while (i < argsInner.length && argsInner[i] !== q) {
-          if (argsInner[i] === "\\") i += 1;
-          i += 1;
+          if (argsInner[i] === '\\') i += 1
+          i += 1
         }
-      } else if (ch === "," && depth === 0) {
-        args.push(argsInner.slice(start, i).trim());
-        start = i + 1;
+      } else if (ch === ',' && depth === 0) {
+        args.push(argsInner.slice(start, i).trim())
+        start = i + 1
       }
     }
-    args.push(argsInner.slice(start).trim());
+    args.push(argsInner.slice(start).trim())
 
-    const predicate = args[0];
-    if (!predicate || !/^[A-Za-z_][A-Za-z0-9_.]*$/.test(predicate)) return null;
+    const predicate = args[0]
+    if (!predicate || !/^[A-Za-z_][A-Za-z0-9_.]*$/.test(predicate)) return null
 
-    const unary = args.length === 1;
-    const valueRaw = unary ? "" : args.slice(1).join(", ").trim();
-    const isVar = !unary && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(valueRaw);
+    const unary = args.length === 1
+    const valueRaw = unary ? '' : args.slice(1).join(', ').trim()
+    const isVar = !unary && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(valueRaw)
 
     return {
       func: `${notPrefix}${funcName}`,
@@ -289,7 +292,7 @@ window.DQLQueryParser = (() => {
       varName: isVar ? valueRaw.slice(1) : null,
       literal: unary || isVar ? null : String(parseStringLiteral(valueRaw)),
       unary,
-    };
+    }
   }
 
   /**
@@ -298,9 +301,9 @@ window.DQLQueryParser = (() => {
    * Mixed AND/OR without parentheses is not modeled — OR wins if any OR appears.
    */
   function parseFilterArgs(filterInner) {
-    const { parts, sawOr } = splitFilterConnectors(filterInner);
-    const filters = parts.map(parseOneFilterCondition).filter(Boolean);
-    return { op: sawOr ? "OR" : "AND", filters };
+    const { parts, sawOr } = splitFilterConnectors(filterInner)
+    const filters = parts.map(parseOneFilterCondition).filter(Boolean)
+    return { op: sawOr ? 'OR' : 'AND', filters }
   }
 
   function parseDirectivesAndFilter(src, i) {
@@ -309,72 +312,74 @@ window.DQLQueryParser = (() => {
       normalize: false,
       filterGroup: null,
       end: i,
-    };
+    }
     while (true) {
-      i = skipWs(src, i);
-      if (src[i] !== "@") break;
-      const name = readIdent(src, i + 1);
-      if (!name) break;
-      i = name.end;
-      if (name.value === "cascade") result.cascade = true;
-      else if (name.value === "normalize") result.normalize = true;
-      else if (name.value === "filter") {
-        i = skipWs(src, i);
-        const bal = extractBalanced(src, i, "(", ")");
-        const group = parseFilterArgs(bal.inner);
+      i = skipWs(src, i)
+      if (src[i] !== '@') break
+      const name = readIdent(src, i + 1)
+      if (!name) break
+      i = name.end
+      if (name.value === 'cascade') result.cascade = true
+      else if (name.value === 'normalize') result.normalize = true
+      else if (name.value === 'filter') {
+        i = skipWs(src, i)
+        const bal = extractBalanced(src, i, '(', ')')
+        const group = parseFilterArgs(bal.inner)
         // Multiple @filter directives on one block are AND-merged.
         if (!result.filterGroup) {
-          result.filterGroup = group;
+          result.filterGroup = group
         } else if (group.filters.length) {
-          result.filterGroup.op = "AND";
-          result.filterGroup.filters = result.filterGroup.filters.concat(group.filters);
+          result.filterGroup.op = 'AND'
+          result.filterGroup.filters = result.filterGroup.filters.concat(
+            group.filters,
+          )
         }
-        i = bal.end;
+        i = bal.end
       } else {
         // Unknown directive with optional (...): skip args.
-        i = skipWs(src, i);
-        if (src[i] === "(") i = extractBalanced(src, i, "(", ")").end;
+        i = skipWs(src, i)
+        if (src[i] === '(') i = extractBalanced(src, i, '(', ')').end
       }
     }
-    result.end = i;
-    return result;
+    result.end = i
+    return result
   }
 
   function parseSelection(body) {
-    const fields = [];
-    let i = 0;
-    const src = String(body || "");
+    const fields = []
+    let i = 0
+    const src = String(body || '')
     while (i < src.length) {
-      i = skipWs(src, i);
-      if (i >= src.length) break;
+      i = skipWs(src, i)
+      if (i >= src.length) break
 
-      let alias = null;
-      let pred = readPredicate(src, i);
+      let alias = null
+      let pred = readPredicate(src, i)
       if (!pred) {
         // Skip unknown tokens to avoid infinite loops.
-        i += 1;
-        continue;
+        i += 1
+        continue
       }
-      i = pred.end;
-      i = skipWs(src, i);
+      i = pred.end
+      i = skipWs(src, i)
 
-      if (src[i] === ":") {
-        alias = pred.value;
-        i += 1;
-        pred = readPredicate(src, i);
-        if (!pred) throw new Error(`Expected predicate after alias '${alias}:'`);
-        i = pred.end;
+      if (src[i] === ':') {
+        alias = pred.value
+        i += 1
+        pred = readPredicate(src, i)
+        if (!pred) throw new Error(`Expected predicate after alias '${alias}:'`)
+        i = pred.end
       }
 
-      const dirs = parseDirectivesAndFilter(src, i);
-      i = dirs.end;
-      i = skipWs(src, i);
+      const dirs = parseDirectivesAndFilter(src, i)
+      i = dirs.end
+      i = skipWs(src, i)
 
-      let children = null;
-      if (src[i] === "{") {
-        const bal = extractBalanced(src, i);
-        children = parseSelection(bal.inner);
-        i = bal.end;
+      let children = null
+      if (src[i] === '{') {
+        const bal = extractBalanced(src, i)
+        children = parseSelection(bal.inner)
+        i = bal.end
       }
 
       fields.push({
@@ -384,35 +389,37 @@ window.DQLQueryParser = (() => {
         cascade: dirs.cascade,
         normalize: dirs.normalize,
         children,
-      });
+      })
     }
-    return fields;
+    return fields
   }
 
   function parseRootBlock(body) {
-    let i = skipWs(body, 0);
-    const resultName = readIdent(body, i);
-    if (!resultName) throw new Error("Expected result key after query '{'");
-    i = resultName.end;
-    i = skipWs(body, i);
-    if (body[i] !== "(") throw new Error("Expected (func: type(...)) on root block");
+    let i = skipWs(body, 0)
+    const resultName = readIdent(body, i)
+    if (!resultName) throw new Error("Expected result key after query '{'")
+    i = resultName.end
+    i = skipWs(body, i)
+    if (body[i] !== '(')
+      throw new Error('Expected (func: type(...)) on root block')
 
-    const argsBal = extractBalanced(body, i, "(", ")");
-    const args = argsBal.inner;
-    i = argsBal.end;
+    const argsBal = extractBalanced(body, i, '(', ')')
+    const args = argsBal.inner
+    i = argsBal.end
 
     const typeMatch =
       args.match(/func\s*:\s*type\s*\(\s*"([^"]+)"\s*\)/i) ||
       args.match(/func\s*:\s*type\s*\(\s*'([^']+)'\s*\)/i) ||
-      args.match(/func\s*:\s*type\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/i);
-    if (!typeMatch) throw new Error('Expected func: type("TypeName") on root block');
-    const typeName = typeMatch[1];
+      args.match(/func\s*:\s*type\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/i)
+    if (!typeMatch)
+      throw new Error('Expected func: type("TypeName") on root block')
+    const typeName = typeMatch[1]
 
-    const dirs = parseDirectivesAndFilter(body, i);
-    i = dirs.end;
-    i = skipWs(body, i);
-    if (body[i] !== "{") throw new Error("Expected selection '{' on root block");
-    const sel = extractBalanced(body, i);
+    const dirs = parseDirectivesAndFilter(body, i)
+    i = dirs.end
+    i = skipWs(body, i)
+    if (body[i] !== '{') throw new Error("Expected selection '{' on root block")
+    const sel = extractBalanced(body, i)
 
     return {
       resultName: resultName.value,
@@ -421,52 +428,53 @@ window.DQLQueryParser = (() => {
       normalize: dirs.normalize,
       filterGroup: dirs.filterGroup,
       selection: parseSelection(sel.inner),
-    };
+    }
   }
 
   function parse(text) {
-    const src = stripComments(text).trim();
-    if (!src) throw new Error("Nothing to parse");
+    const src = stripComments(text).trim()
+    if (!src) throw new Error('Nothing to parse')
     if (!/\bquery\b/i.test(src)) {
-      throw new Error("Expected one or more `query Name { ... }` operations");
+      throw new Error('Expected one or more `query Name { ... }` operations')
     }
 
-    const operations = [];
-    const re = /\bquery\s+([A-Za-z_][A-Za-z0-9_]*)\s*(\((?:[^()"']|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')*\))?\s*\{/gi;
-    let m;
+    const operations = []
+    const re =
+      /\bquery\s+([A-Za-z_][A-Za-z0-9_]*)\s*(\((?:[^()"']|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')*\))?\s*\{/gi
+    let m
     while ((m = re.exec(src))) {
-      const opName = m[1];
-      const signature = m[2] || "";
-      const openIdx = m.index + m[0].length - 1;
-      const bal = extractBalanced(src, openIdx);
-      const root = parseRootBlock(bal.inner);
+      const opName = m[1]
+      const signature = m[2] || ''
+      const openIdx = m.index + m[0].length - 1
+      const bal = extractBalanced(src, openIdx)
+      const root = parseRootBlock(bal.inner)
       operations.push({
         opName,
         params: parseSignature(signature),
         ...root,
-      });
-      re.lastIndex = bal.end;
+      })
+      re.lastIndex = bal.end
     }
 
     if (!operations.length) {
-      throw new Error("Could not find a parseable query operation");
+      throw new Error('Could not find a parseable query operation')
     }
-    return operations;
+    return operations
   }
 
   /** Guess a nested type name from an edge when the schema has no binding. */
   function guessNestedType(edgeName, parentType, schema) {
-    let base = String(edgeName || "");
-    if (base.includes(".")) base = base.split(".").pop();
-    if (/ies$/i.test(base)) base = `${base.slice(0, -3)}y`;
-    else if (/ses$/i.test(base)) base = base.slice(0, -2);
-    else if (/s$/i.test(base) && !/ss$/i.test(base)) base = base.slice(0, -1);
-    base = base.charAt(0).toUpperCase() + base.slice(1);
-    if (schema[base] && base !== parentType) return base;
-    if (base === parentType) return `${parentType}_${edgeName}`;
+    let base = String(edgeName || '')
+    if (base.includes('.')) base = base.split('.').pop()
+    if (/ies$/i.test(base)) base = `${base.slice(0, -3)}y`
+    else if (/ses$/i.test(base)) base = base.slice(0, -2)
+    else if (/s$/i.test(base) && !/ss$/i.test(base)) base = base.slice(0, -1)
+    base = base.charAt(0).toUpperCase() + base.slice(1)
+    if (schema[base] && base !== parentType) return base
+    if (base === parentType) return `${parentType}_${edgeName}`
     // Prefer an unused name; if taken by something unrelated, rename.
-    if (!schema[base]) return base;
-    return `${parentType}_${edgeName}`;
+    if (!schema[base]) return base
+    return `${parentType}_${edgeName}`
   }
 
   /**
@@ -475,17 +483,17 @@ window.DQLQueryParser = (() => {
    * field ("name" → "User.name") so we keep the schema's real predicate.
    */
   function findField(typeDef, predName) {
-    if (!typeDef) return null;
-    const fields = typeDef.fields || [];
-    const exact = fields.find((f) => f.name === predName);
-    if (exact) return exact;
+    if (!typeDef) return null
+    const fields = typeDef.fields || []
+    const exact = fields.find((f) => f.name === predName)
+    if (exact) return exact
 
     // "name" → unique "User.name" (do not invent short aliases for dotted preds).
-    if (predName && !String(predName).includes(".")) {
-      const matches = fields.filter((f) => f.name.endsWith(`.${predName}`));
-      if (matches.length === 1) return matches[0];
+    if (predName && !String(predName).includes('.')) {
+      const matches = fields.filter((f) => f.name.endsWith(`.${predName}`))
+      if (matches.length === 1) return matches[0]
     }
-    return null;
+    return null
   }
 
   /**
@@ -493,64 +501,64 @@ window.DQLQueryParser = (() => {
    * names at each step so "User.posts.Post.title" stays intact.
    */
   function splitPredicatePath(schema, typeName, pathStr) {
-    const raw = String(pathStr || "");
-    if (!raw) return null;
+    const raw = String(pathStr || '')
+    if (!raw) return null
 
-    const fieldsAt = (t) => schema[t]?.fields || [];
+    const fieldsAt = (t) => schema[t]?.fields || []
     if (fieldsAt(typeName).some((f) => f.name === raw)) {
-      return { edgeParts: [], leaf: raw, edgePath: "" };
+      return { edgeParts: [], leaf: raw, edgePath: '' }
     }
 
-    const segments = raw.split(".");
-    const edgeParts = [];
-    let currentType = typeName;
-    let i = 0;
+    const segments = raw.split('.')
+    const edgeParts = []
+    let currentType = typeName
+    let i = 0
 
     while (i < segments.length) {
-      const fields = fieldsAt(currentType);
-      let matched = null;
-      let matchedEnd = -1;
+      const fields = fieldsAt(currentType)
+      let matched = null
+      let matchedEnd = -1
       for (let j = segments.length; j > i; j -= 1) {
-        const candidate = segments.slice(i, j).join(".");
-        const field = fields.find((f) => f.name === candidate);
+        const candidate = segments.slice(i, j).join('.')
+        const field = fields.find((f) => f.name === candidate)
         if (field) {
-          matched = field;
-          matchedEnd = j;
-          break;
+          matched = field
+          matchedEnd = j
+          break
         }
       }
 
       if (!matched) {
-        const rest = segments.slice(i).join(".");
-        const short = findField({ fields }, rest);
+        const rest = segments.slice(i).join('.')
+        const short = findField({ fields }, rest)
         return {
           edgeParts,
           leaf: short?.name || rest,
-          edgePath: edgeParts.join("."),
-        };
+          edgePath: edgeParts.join('.'),
+        }
       }
 
-      const start = i;
-      i = matchedEnd;
+      const start = i
+      i = matchedEnd
 
       if (i >= segments.length) {
-        return { edgeParts, leaf: matched.name, edgePath: edgeParts.join(".") };
+        return { edgeParts, leaf: matched.name, edgePath: edgeParts.join('.') }
       }
 
-      if (matched.kind === "object" && matched.ofType) {
-        edgeParts.push(matched.name);
-        currentType = matched.ofType;
-        continue;
+      if (matched.kind === 'object' && matched.ofType) {
+        edgeParts.push(matched.name)
+        currentType = matched.ofType
+        continue
       }
 
       return {
         edgeParts,
-        leaf: segments.slice(start).join("."),
-        edgePath: edgeParts.join("."),
-      };
+        leaf: segments.slice(start).join('.'),
+        edgePath: edgeParts.join('.'),
+      }
     }
 
-    return null;
+    return null
   }
 
   /**
@@ -558,77 +566,93 @@ window.DQLQueryParser = (() => {
    * Mutates a shallow copy of schema; returns { schema, warnings }.
    */
   function ensureSchema(schema, operations) {
-    const next = { ...schema };
+    const next = { ...schema }
     Object.keys(schema).forEach((k) => {
-      next[k] = { ...schema[k], fields: [...(schema[k].fields || [])] };
-    });
-    const warnings = [];
+      next[k] = { ...schema[k], fields: [...(schema[k].fields || [])] }
+    })
+    const warnings = []
     const COLORS = [
-      "#1f8a5a", "#d97706", "#2563eb", "#0f766e", "#b91c1c", "#7c3aed",
-      "#be185d", "#4d7c0f", "#0e7490", "#a16207",
-    ];
+      '#1f8a5a',
+      '#d97706',
+      '#2563eb',
+      '#0f766e',
+      '#b91c1c',
+      '#7c3aed',
+      '#be185d',
+      '#4d7c0f',
+      '#0e7490',
+      '#a16207',
+    ]
 
     function ensureType(name) {
       if (!next[name]) {
         next[name] = {
           color: COLORS[Object.keys(next).length % COLORS.length],
-          fields: [{ name: "uid", type: "uid", kind: "scalar" }],
-        };
-        warnings.push(`Inferred type "${name}" (not in schema)`);
+          fields: [{ name: 'uid', type: 'uid', kind: 'scalar' }],
+        }
+        warnings.push(`Inferred type "${name}" (not in schema)`)
       }
-      return next[name];
+      return next[name]
     }
 
     function ensureField(typeName, fieldAst, pathPrefix) {
-      const def = ensureType(typeName);
-      const predName = fieldAst.name;
-      let field = findField(def, predName);
-      const storedName = field ? field.name : predName;
+      const def = ensureType(typeName)
+      const predName = fieldAst.name
+      let field = findField(def, predName)
+      const storedName = field ? field.name : predName
 
       if (fieldAst.children) {
-        let ofType = field?.ofType;
+        let ofType = field?.ofType
         if (!ofType) {
-          ofType = guessNestedType(predName.includes(".") ? predName.split(".").pop() : predName, typeName, next);
+          ofType = guessNestedType(
+            predName.includes('.') ? predName.split('.').pop() : predName,
+            typeName,
+            next,
+          )
         }
-        ensureType(ofType);
+        ensureType(ofType)
         if (!field) {
           def.fields.push({
             name: storedName,
-            type: "[uid]",
-            kind: "object",
+            type: '[uid]',
+            kind: 'object',
             ofType,
-          });
-          field = def.fields[def.fields.length - 1];
-        } else if (field.kind !== "object") {
-          field.kind = "object";
-          field.type = "[uid]";
-          field.ofType = ofType;
+          })
+          field = def.fields[def.fields.length - 1]
+        } else if (field.kind !== 'object') {
+          field.kind = 'object'
+          field.type = '[uid]'
+          field.ofType = ofType
         } else if (!field.ofType) {
-          field.ofType = ofType;
+          field.ofType = ofType
         }
-        ofType = field.ofType;
-        const childPrefix = pathPrefix ? `${pathPrefix}.${storedName}` : storedName;
-        fieldAst.children.forEach((child) => ensureField(ofType, child, childPrefix));
+        ofType = field.ofType
+        const childPrefix = pathPrefix
+          ? `${pathPrefix}.${storedName}`
+          : storedName
+        fieldAst.children.forEach((child) =>
+          ensureField(ofType, child, childPrefix),
+        )
       } else if (!field) {
         def.fields.push({
           name: storedName,
-          type: "string",
-          kind: "scalar",
-        });
+          type: 'string',
+          kind: 'scalar',
+        })
       }
 
       // Rewrite AST name to the schema field name for later selection mapping.
-      fieldAst.schemaName = storedName;
+      fieldAst.schemaName = storedName
     }
 
     operations.forEach((op) => {
-      ensureType(op.typeName);
-      (op.selection || []).forEach((f) => ensureField(op.typeName, f, ""));
+      ensureType(op.typeName)
+      ;(op.selection || []).forEach((f) => ensureField(op.typeName, f, ''))
 
       // Filter groups (AND/OR) are preserved on the canvas; nothing to warn about.
-    });
+    })
 
-    return { schema: next, warnings };
+    return { schema: next, warnings }
   }
 
   /**
@@ -637,143 +661,145 @@ window.DQLQueryParser = (() => {
    */
   function toNodes(operations, schema) {
     function resolveFieldType(rootType, predicatePath) {
-      const walk = splitPredicatePath(schema, rootType, predicatePath);
-      if (!walk) return null;
-      let typeName = rootType;
+      const walk = splitPredicatePath(schema, rootType, predicatePath)
+      if (!walk) return null
+      let typeName = rootType
       for (const edge of walk.edgeParts) {
-        const field = findField(schema[typeName], edge);
-        if (!field?.ofType) return null;
-        typeName = field.ofType;
+        const field = findField(schema[typeName], edge)
+        if (!field?.ofType) return null
+        typeName = field.ofType
       }
-      const field = findField(schema[typeName], walk.leaf);
-      if (!field) return null;
-      return PARAM_TYPES.includes(field.type) ? field.type : null;
+      const field = findField(schema[typeName], walk.leaf)
+      if (!field) return null
+      return PARAM_TYPES.includes(field.type) ? field.type : null
     }
 
     return operations.map((op) => {
-      const aliases = {};
-      const params = [];
-      const paramByName = new Map();
-      const rootFilter = { op: "AND", conditions: [] };
-      const edgeFilters = {};
-
-      (op.params || []).forEach((p) => {
+      const aliases = {}
+      const params = []
+      const paramByName = new Map()
+      const rootFilter = { op: 'AND', conditions: [] }
+      const edgeFilters = {}
+      ;(op.params || []).forEach((p) => {
         const entry = {
           name: p.name,
-          type: PARAM_TYPES.includes(p.type) ? p.type : "string",
-          value: p.value ?? "",
-          mode: p.mode === "default" ? "default" : "var",
-        };
-        params.push(entry);
-        paramByName.set(p.name, entry);
-      });
+          type: PARAM_TYPES.includes(p.type) ? p.type : 'string',
+          value: p.value ?? '',
+          mode: p.mode === 'default' ? 'default' : 'var',
+        }
+        params.push(entry)
+        paramByName.set(p.name, entry)
+      })
 
       function ensureParam(name, type, value) {
-        let entry = paramByName.get(name);
+        let entry = paramByName.get(name)
         if (!entry) {
           entry = {
             name,
-            type: PARAM_TYPES.includes(type) ? type : "string",
-            value: value ?? "",
-            mode: "var",
-          };
-          params.push(entry);
-          paramByName.set(name, entry);
-        } else if (entry.type === "string" && type && type !== "string") {
-          entry.type = type;
+            type: PARAM_TYPES.includes(type) ? type : 'string',
+            value: value ?? '',
+            mode: 'var',
+          }
+          params.push(entry)
+          paramByName.set(name, entry)
+        } else if (entry.type === 'string' && type && type !== 'string') {
+          entry.type = type
         }
-        return entry;
+        return entry
       }
 
       function resolveEdgeType(edgePath) {
-        let typeName = op.typeName;
-        if (!edgePath) return typeName;
-        const edgeWalk = splitPredicatePath(schema, op.typeName, edgePath);
-        if (!edgeWalk) return typeName;
+        let typeName = op.typeName
+        if (!edgePath) return typeName
+        const edgeWalk = splitPredicatePath(schema, op.typeName, edgePath)
+        if (!edgeWalk) return typeName
         for (const edge of edgeWalk.edgeParts) {
-          const f = findField(schema[typeName], edge);
-          if (!f?.ofType) break;
-          typeName = f.ofType;
+          const f = findField(schema[typeName], edge)
+          if (!f?.ofType) break
+          typeName = f.ofType
         }
-        const edgeField = findField(schema[typeName], edgeWalk.leaf);
-        if (edgeField?.ofType) typeName = edgeField.ofType;
-        return typeName;
+        const edgeField = findField(schema[typeName], edgeWalk.leaf)
+        if (edgeField?.ofType) typeName = edgeField.ofType
+        return typeName
       }
 
       function ingestFilterGroup(edgePath, group) {
-        if (!group?.filters?.length) return;
-        const typeName = resolveEdgeType(edgePath);
+        if (!group?.filters?.length) return
+        const typeName = resolveEdgeType(edgePath)
         const target = edgePath
-          ? (edgeFilters[edgePath] || (edgeFilters[edgePath] = { op: group.op || "AND", conditions: [] }))
-          : rootFilter;
-        if (edgePath) target.op = group.op || target.op || "AND";
-        else rootFilter.op = group.op || rootFilter.op || "AND";
+          ? edgeFilters[edgePath] ||
+            (edgeFilters[edgePath] = { op: group.op || 'AND', conditions: [] })
+          : rootFilter
+        if (edgePath) target.op = group.op || target.op || 'AND'
+        else rootFilter.op = group.op || rootFilter.op || 'AND'
 
         group.filters.forEach((filter) => {
-          const leafField = findField(schema[typeName], filter.predicate);
-          const leaf = leafField?.name || filter.predicate;
+          const leafField = findField(schema[typeName], filter.predicate)
+          const leaf = leafField?.name || filter.predicate
           const schemaType = resolveFieldType(
             op.typeName,
-            edgePath ? `${edgePath}.${leaf}` : leaf
-          );
+            edgePath ? `${edgePath}.${leaf}` : leaf,
+          )
           const literalType =
             filter.literal != null
               ? inferTypeFromLiteral(filter.valueRaw || filter.literal)
-              : null;
-          const inferredType = schemaType || literalType || "string";
+              : null
+          const inferredType = schemaType || literalType || 'string'
 
           const cond = {
             func: filter.func,
             predicate: leaf,
-            valueMode: "literal",
-            literal: "",
-            paramName: "",
-          };
+            valueMode: 'literal',
+            literal: '',
+            paramName: '',
+          }
 
           if (filter.unary) {
-            cond.valueMode = "literal";
-            cond.literal = "";
+            cond.valueMode = 'literal'
+            cond.literal = ''
           } else if (filter.isVar && filter.varName) {
-            ensureParam(filter.varName, inferredType, "");
-            cond.valueMode = "param";
-            cond.paramName = filter.varName;
+            ensureParam(filter.varName, inferredType, '')
+            cond.valueMode = 'param'
+            cond.paramName = filter.varName
           } else {
-            cond.valueMode = "literal";
-            cond.literal = filter.literal ?? "";
+            cond.valueMode = 'literal'
+            cond.literal = filter.literal ?? ''
           }
 
-          target.conditions.push(cond);
-        });
+          target.conditions.push(cond)
+        })
       }
 
-      ingestFilterGroup("", op.filterGroup);
+      ingestFilterGroup('', op.filterGroup)
 
       function buildSelection(typeName, fieldAsts, pathPrefix) {
-        const selection = {};
-        (fieldAsts || []).forEach((f) => {
-          const name = f.schemaName || findField(schema[typeName], f.name)?.name || f.name;
-          const path = pathPrefix ? `${pathPrefix}.${name}` : name;
-          if (f.alias) aliases[path] = f.alias;
-          if (f.filterGroup) ingestFilterGroup(path, f.filterGroup);
+        const selection = {}
+        ;(fieldAsts || []).forEach((f) => {
+          const name =
+            f.schemaName || findField(schema[typeName], f.name)?.name || f.name
+          const path = pathPrefix ? `${pathPrefix}.${name}` : name
+          if (f.alias) aliases[path] = f.alias
+          if (f.filterGroup) ingestFilterGroup(path, f.filterGroup)
 
           if (f.children) {
-            const field = findField(schema[typeName], name);
-            const ofType = field?.ofType || guessNestedType(name, typeName, schema);
-            selection[name] = buildSelection(ofType, f.children, path);
+            const field = findField(schema[typeName], name)
+            const ofType =
+              field?.ofType || guessNestedType(name, typeName, schema)
+            selection[name] = buildSelection(ofType, f.children, path)
           } else {
-            selection[name] = null;
+            selection[name] = null
           }
-        });
-        return selection;
+        })
+        return selection
       }
 
-      const selection = buildSelection(op.typeName, op.selection, "");
+      const selection = buildSelection(op.typeName, op.selection, '')
 
       // Result key only stored when it differs from the default derived from op name.
-      let resultName = op.resultName || "";
-      const derived = /^get./i.test(op.opName) ? op.opName.slice(3) : op.opName;
+      let resultName = op.resultName || ''
+      const derived = /^get./i.test(op.opName) ? op.opName.slice(3) : op.opName
       if (resultName === derived || resultName === op.typeName) {
-        if (resultName === derived) resultName = "";
+        if (resultName === derived) resultName = ''
       }
 
       return {
@@ -789,9 +815,9 @@ window.DQLQueryParser = (() => {
           cascade: !!op.cascade,
           normalize: !!op.normalize,
         },
-      };
-    });
+      }
+    })
   }
 
-  return { parse, ensureSchema, toNodes };
-})();
+  return { parse, ensureSchema, toNodes }
+})()

--- a/client/src/components/QueryBuilder/lib/query-parser.js
+++ b/client/src/components/QueryBuilder/lib/query-parser.js
@@ -7,56 +7,33 @@
  *       edge @filter(...) { ... }
  *     }
  *   }
+ *
+ * Line (#, //) and block (/* *\/) comments are preserved on operations and
+ * fields so canvas regeneration can round-trip them back into the editor.
  */
 window.DQLQueryParser = (() => {
   const PARAM_TYPES = ['string', 'int', 'float', 'bool']
 
-  /** Strip block, line (//), and hash (#) comments without touching string literals. */
-  function stripComments(src) {
-    const input = String(src || '')
-    let out = ''
-    for (let i = 0; i < input.length; i += 1) {
-      const ch = input[i]
-      const next = input[i + 1]
-
-      if (ch === '"' || ch === "'") {
-        const q = ch
-        out += ch
-        i += 1
-        while (i < input.length && input[i] !== q) {
-          if (input[i] === '\\') {
-            out += input[i]
-            i += 1
-            if (i < input.length) out += input[i]
-            i += 1
-            continue
-          }
-          out += input[i]
-          i += 1
-        }
-        if (i < input.length) out += input[i]
-        continue
-      }
-
-      if (ch === '/' && next === '*') {
-        i += 2
-        while (i < input.length && !(input[i] === '*' && input[i + 1] === '/'))
-          i += 1
-        i += 1 // land on '/'
-        out += ' '
-        continue
-      }
-
-      if ((ch === '/' && next === '/') || ch === '#') {
-        while (i < input.length && input[i] !== '\n') i += 1
-        i -= 1
-        out += ' '
-        continue
-      }
-
-      out += ch
+  /**
+   * Read a # / // / /* *\/ comment at `i`, or null.
+   * Line comments exclude the terminating newline; block comments keep interior newlines.
+   */
+  function tryReadComment(src, i) {
+    if (i >= src.length) return null
+    const ch = src[i]
+    const next = src[i + 1]
+    if (ch === '/' && next === '*') {
+      let j = i + 2
+      while (j < src.length && !(src[j] === '*' && src[j + 1] === '/')) j += 1
+      if (j < src.length) j += 2
+      return { text: src.slice(i, j), end: j }
     }
-    return out
+    if ((ch === '/' && next === '/') || ch === '#') {
+      let j = i
+      while (j < src.length && src[j] !== '\n') j += 1
+      return { text: src.slice(i, j).replace(/\s+$/, ''), end: j }
+    }
+    return null
   }
 
   function skipWs(src, i) {
@@ -64,11 +41,38 @@ window.DQLQueryParser = (() => {
     return i
   }
 
+  /** Skip whitespace and comments; optionally collect comment texts. */
+  function skipTrivia(src, i, { collect = true } = {}) {
+    const comments = []
+    while (i < src.length) {
+      if (/\s/.test(src[i])) {
+        i += 1
+        continue
+      }
+      const comment = tryReadComment(src, i)
+      if (!comment) break
+      if (collect) comments.push(comment.text)
+      i = comment.end
+    }
+    return { end: i, comments }
+  }
+
+  /** Same-line trailing comment after a field (spaces/tabs only, not newlines). */
+  function readTrailingComment(src, i) {
+    let j = i
+    while (j < src.length && (src[j] === ' ' || src[j] === '\t')) j += 1
+    const comment = tryReadComment(src, j)
+    if (!comment) return { end: i, comment: null }
+    return { end: comment.end, comment: comment.text }
+  }
+
   function extractBalanced(src, openIdx, openCh = '{', closeCh = '}') {
     if (src[openIdx] !== openCh) throw new Error(`Expected '${openCh}'`)
     let depth = 0
     for (let i = openIdx; i < src.length; i += 1) {
       const ch = src[i]
+      const next = src[i + 1]
+
       if (ch === '"' || ch === "'") {
         const q = ch
         i += 1
@@ -78,6 +82,19 @@ window.DQLQueryParser = (() => {
         }
         continue
       }
+
+      // Do not count braces / parens inside comments.
+      if (ch === '/' && next === '*') {
+        i += 2
+        while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i += 1
+        if (i < src.length) i += 1 // land on '/'
+        continue
+      }
+      if ((ch === '/' && next === '/') || ch === '#') {
+        while (i < src.length && src[i] !== '\n') i += 1
+        continue
+      }
+
       if (ch === openCh) depth += 1
       else if (ch === closeCh) {
         depth -= 1
@@ -314,10 +331,20 @@ window.DQLQueryParser = (() => {
       end: i,
     }
     while (true) {
-      i = skipWs(src, i)
-      if (src[i] !== '@') break
+      const atStart = i
+      // Only consume trivia when the next token is a directive; otherwise leave
+      // comments/newlines for the selection parser (next field / trailing).
+      const peek = skipTrivia(src, i, { collect: false })
+      if (src[peek.end] !== '@') {
+        result.end = atStart
+        break
+      }
+      i = peek.end
       const name = readIdent(src, i + 1)
-      if (!name) break
+      if (!name) {
+        result.end = atStart
+        break
+      }
       i = name.end
       if (name.value === 'cascade') result.cascade = true
       else if (name.value === 'normalize') result.normalize = true
@@ -340,28 +367,46 @@ window.DQLQueryParser = (() => {
         i = skipWs(src, i)
         if (src[i] === '(') i = extractBalanced(src, i, '(', ')').end
       }
+      result.end = i
     }
-    result.end = i
     return result
   }
 
+  /** Skip spaces and tabs only (not newlines). */
+  function skipSpacesTabs(src, i) {
+    while (i < src.length && (src[i] === ' ' || src[i] === '\t')) i += 1
+    return i
+  }
+
+  /**
+   * Parse a selection set into fields with attached comments.
+   * Returns { fields, trailingComments } where trailingComments are after the last field.
+   */
   function parseSelection(body) {
     const fields = []
     let i = 0
     const src = String(body || '')
+    const trailingComments = []
+
     while (i < src.length) {
-      i = skipWs(src, i)
-      if (i >= src.length) break
+      const lead = skipTrivia(src, i)
+      i = lead.end
+      if (i >= src.length) {
+        trailingComments.push(...lead.comments)
+        break
+      }
 
       let alias = null
       let pred = readPredicate(src, i)
       if (!pred) {
-        // Skip unknown tokens to avoid infinite loops.
+        if (lead.comments.length) trailingComments.push(...lead.comments)
         i += 1
         continue
       }
+
+      const leading = lead.comments
       i = pred.end
-      i = skipWs(src, i)
+      i = skipSpacesTabs(src, i)
 
       if (src[i] === ':') {
         alias = pred.value
@@ -369,17 +414,52 @@ window.DQLQueryParser = (() => {
         pred = readPredicate(src, i)
         if (!pred) throw new Error(`Expected predicate after alias '${alias}:'`)
         i = pred.end
+        i = skipSpacesTabs(src, i)
       }
 
       const dirs = parseDirectivesAndFilter(src, i)
       i = dirs.end
-      i = skipWs(src, i)
 
       let children = null
-      if (src[i] === '{') {
-        const bal = extractBalanced(src, i)
+      let trailing = null
+
+      // Prefer a same-line `{` / trailing comment so next-line comments stay
+      // attached to the following field (not this one).
+      const j = skipSpacesTabs(src, i)
+      if (src[j] === '{') {
+        const bal = extractBalanced(src, j)
         children = parseSelection(bal.inner)
         i = bal.end
+        const trail = readTrailingComment(src, i)
+        trailing = trail.comment
+        i = trail.end
+      } else {
+        const trail = readTrailingComment(src, i)
+        trailing = trail.comment
+        i = trail.end
+
+        // `{` may start on a later line; comments before it lead the nested body.
+        const beforeBrace = skipTrivia(src, i)
+        if (src[beforeBrace.end] === '{') {
+          const bal = extractBalanced(src, beforeBrace.end)
+          children = parseSelection(bal.inner)
+          if (beforeBrace.comments.length) {
+            if (children.fields.length) {
+              children.fields[0].comments.leading = beforeBrace.comments.concat(
+                children.fields[0].comments.leading || [],
+              )
+            } else {
+              children.trailingComments = beforeBrace.comments.concat(
+                children.trailingComments || [],
+              )
+            }
+          }
+          i = bal.end
+          const trail2 = readTrailingComment(src, i)
+          if (trail2.comment) trailing = trailing || trail2.comment
+          i = trail2.end
+        }
+        // else: leave `i` before those comments so the next field claims them
       }
 
       fields.push({
@@ -389,13 +469,18 @@ window.DQLQueryParser = (() => {
         cascade: dirs.cascade,
         normalize: dirs.normalize,
         children,
+        comments: {
+          leading,
+          trailing,
+        },
       })
     }
-    return fields
+    return { fields, trailingComments }
   }
 
   function parseRootBlock(body) {
-    let i = skipWs(body, 0)
+    const lead = skipTrivia(body, 0)
+    let i = lead.end
     const resultName = readIdent(body, i)
     if (!resultName) throw new Error("Expected result key after query '{'")
     i = resultName.end
@@ -427,33 +512,59 @@ window.DQLQueryParser = (() => {
       cascade: dirs.cascade,
       normalize: dirs.normalize,
       filterGroup: dirs.filterGroup,
+      rootLeadingComments: lead.comments,
       selection: parseSelection(sel.inner),
     }
   }
 
   function parse(text) {
-    const src = stripComments(text).trim()
-    if (!src) throw new Error('Nothing to parse')
-    if (!/\bquery\b/i.test(src)) {
-      throw new Error('Expected one or more `query Name { ... }` operations')
-    }
-
+    const src = String(text || '')
     const operations = []
-    const re =
-      /\bquery\s+([A-Za-z_][A-Za-z0-9_]*)\s*(\((?:[^()"']|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')*\))?\s*\{/gi
-    let m
-    while ((m = re.exec(src))) {
-      const opName = m[1]
-      const signature = m[2] || ''
-      const openIdx = m.index + m[0].length - 1
-      const bal = extractBalanced(src, openIdx)
+    let i = 0
+
+    while (i < src.length) {
+      const trivia = skipTrivia(src, i)
+      i = trivia.end
+      if (i >= src.length) break
+
+      const kw = readIdent(src, i)
+      if (!kw || kw.value.toLowerCase() !== 'query') {
+        throw new Error('Expected one or more `query Name { ... }` operations')
+      }
+      i = kw.end
+
+      const name = readIdent(src, i)
+      if (!name) throw new Error('Expected query operation name')
+      i = name.end
+      i = skipWs(src, i)
+
+      let signature = ''
+      if (src[i] === '(') {
+        const sigBal = extractBalanced(src, i, '(', ')')
+        signature = src.slice(i, sigBal.end)
+        i = sigBal.end
+      }
+
+      const beforeBrace = skipTrivia(src, i)
+      i = beforeBrace.end
+      if (src[i] !== '{') {
+        throw new Error(`Expected '{' after query ${name.value}`)
+      }
+
+      const bal = extractBalanced(src, i)
       const root = parseRootBlock(bal.inner)
+      i = bal.end
+
+      const after = readTrailingComment(src, i)
+      i = after.end
+
       operations.push({
-        opName,
+        opName: name.value,
         params: parseSignature(signature),
+        leadingComments: trivia.comments.concat(beforeBrace.comments),
+        trailingComment: after.comment,
         ...root,
       })
-      re.lastIndex = bal.end
     }
 
     if (!operations.length) {
@@ -630,9 +741,10 @@ window.DQLQueryParser = (() => {
         const childPrefix = pathPrefix
           ? `${pathPrefix}.${storedName}`
           : storedName
-        fieldAst.children.forEach((child) =>
-          ensureField(ofType, child, childPrefix),
-        )
+        const childFields = Array.isArray(fieldAst.children)
+          ? fieldAst.children
+          : fieldAst.children?.fields || []
+        childFields.forEach((child) => ensureField(ofType, child, childPrefix))
       } else if (!field) {
         def.fields.push({
           name: storedName,
@@ -647,7 +759,10 @@ window.DQLQueryParser = (() => {
 
     operations.forEach((op) => {
       ensureType(op.typeName)
-      ;(op.selection || []).forEach((f) => ensureField(op.typeName, f, ''))
+      const rootFields = Array.isArray(op.selection)
+        ? op.selection
+        : op.selection?.fields || []
+      rootFields.forEach((f) => ensureField(op.typeName, f, ''))
 
       // Filter groups (AND/OR) are preserved on the canvas; nothing to warn about.
     })
@@ -772,28 +887,60 @@ window.DQLQueryParser = (() => {
 
       ingestFilterGroup('', op.filterGroup)
 
-      function buildSelection(typeName, fieldAsts, pathPrefix) {
+      function selectionFields(sel) {
+        if (!sel) return []
+        if (Array.isArray(sel)) return sel
+        return sel.fields || []
+      }
+
+      function selectionTrailing(sel) {
+        if (!sel || Array.isArray(sel)) return []
+        return sel.trailingComments || []
+      }
+
+      function buildSelection(typeName, sel, pathPrefix) {
         const selection = {}
-        ;(fieldAsts || []).forEach((f) => {
+        const fieldComments = {}
+        const blockComments = {}
+
+        selectionFields(sel).forEach((f) => {
           const name =
             f.schemaName || findField(schema[typeName], f.name)?.name || f.name
           const path = pathPrefix ? `${pathPrefix}.${name}` : name
           if (f.alias) aliases[path] = f.alias
           if (f.filterGroup) ingestFilterGroup(path, f.filterGroup)
 
+          const leading = f.comments?.leading || []
+          const trailing = f.comments?.trailing || null
+          if (leading.length || trailing) {
+            fieldComments[path] = {
+              leading: [...leading],
+              trailing,
+            }
+          }
+
           if (f.children) {
             const field = findField(schema[typeName], name)
             const ofType =
               field?.ofType || guessNestedType(name, typeName, schema)
-            selection[name] = buildSelection(ofType, f.children, path)
+            const nested = buildSelection(ofType, f.children, path)
+            selection[name] = nested.selection
+            Object.assign(fieldComments, nested.fieldComments)
+            Object.assign(blockComments, nested.blockComments)
           } else {
             selection[name] = null
           }
         })
-        return selection
+
+        const trailing = selectionTrailing(sel)
+        if (trailing.length) {
+          blockComments[pathPrefix || ''] = [...trailing]
+        }
+
+        return { selection, fieldComments, blockComments }
       }
 
-      const selection = buildSelection(op.typeName, op.selection, '')
+      const built = buildSelection(op.typeName, op.selection, '')
 
       // Result key only stored when it differs from the default derived from op name.
       let resultName = op.resultName || ''
@@ -806,7 +953,7 @@ window.DQLQueryParser = (() => {
         type: op.typeName,
         name: op.opName,
         resultName,
-        selection,
+        selection: built.selection,
         aliases,
         params,
         rootFilter,
@@ -814,6 +961,13 @@ window.DQLQueryParser = (() => {
         directives: {
           cascade: !!op.cascade,
           normalize: !!op.normalize,
+        },
+        comments: {
+          leading: [...(op.leadingComments || [])],
+          trailing: op.trailingComment || null,
+          rootLeading: [...(op.rootLeadingComments || [])],
+          fields: built.fieldComments,
+          blocks: built.blockComments,
         },
       }
     })

--- a/client/src/components/QueryBuilder/lib/query-parser.js
+++ b/client/src/components/QueryBuilder/lib/query-parser.js
@@ -1,0 +1,797 @@
+/**
+ * Parse DQL query text into canvas-ready blocks.
+ * Supports the subset the builder emits (and common hand-written variants):
+ *   query Name($p: string = "x") {
+ *     Result(func: type("Type")) @filter(...) @cascade @normalize {
+ *       alias: predicate
+ *       edge @filter(...) { ... }
+ *     }
+ *   }
+ */
+window.DQLQueryParser = (() => {
+  const PARAM_TYPES = ["string", "int", "float", "bool"];
+
+  /** Strip block, line (//), and hash (#) comments without touching string literals. */
+  function stripComments(src) {
+    const input = String(src || "");
+    let out = "";
+    for (let i = 0; i < input.length; i += 1) {
+      const ch = input[i];
+      const next = input[i + 1];
+
+      if (ch === '"' || ch === "'") {
+        const q = ch;
+        out += ch;
+        i += 1;
+        while (i < input.length && input[i] !== q) {
+          if (input[i] === "\\") {
+            out += input[i];
+            i += 1;
+            if (i < input.length) out += input[i];
+            i += 1;
+            continue;
+          }
+          out += input[i];
+          i += 1;
+        }
+        if (i < input.length) out += input[i];
+        continue;
+      }
+
+      if (ch === "/" && next === "*") {
+        i += 2;
+        while (i < input.length && !(input[i] === "*" && input[i + 1] === "/")) i += 1;
+        i += 1; // land on '/'
+        out += " ";
+        continue;
+      }
+
+      if ((ch === "/" && next === "/") || ch === "#") {
+        while (i < input.length && input[i] !== "\n") i += 1;
+        i -= 1;
+        out += " ";
+        continue;
+      }
+
+      out += ch;
+    }
+    return out;
+  }
+
+  function skipWs(src, i) {
+    while (i < src.length && /\s/.test(src[i])) i += 1;
+    return i;
+  }
+
+  function extractBalanced(src, openIdx, openCh = "{", closeCh = "}") {
+    if (src[openIdx] !== openCh) throw new Error(`Expected '${openCh}'`);
+    let depth = 0;
+    for (let i = openIdx; i < src.length; i += 1) {
+      const ch = src[i];
+      if (ch === '"' || ch === "'") {
+        const q = ch;
+        i += 1;
+        while (i < src.length && src[i] !== q) {
+          if (src[i] === "\\") i += 1;
+          i += 1;
+        }
+        continue;
+      }
+      if (ch === openCh) depth += 1;
+      else if (ch === closeCh) {
+        depth -= 1;
+        if (depth === 0) return { inner: src.slice(openIdx + 1, i), end: i + 1 };
+      }
+    }
+    throw new Error(`Unbalanced '${openCh}${closeCh}'`);
+  }
+
+  function readIdent(src, i) {
+    i = skipWs(src, i);
+    const m = src.slice(i).match(/^[A-Za-z_][A-Za-z0-9_]*/);
+    if (!m) return null;
+    return { value: m[0], end: i + m[0].length };
+  }
+
+  /** Dotted predicate: User.email / Post.title */
+  function readPredicate(src, i) {
+    i = skipWs(src, i);
+    const m = src.slice(i).match(/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*/);
+    if (!m) return null;
+    return { value: m[0], end: i + m[0].length };
+  }
+
+  function parseStringLiteral(raw) {
+    const t = String(raw || "").trim();
+    if (
+      (t.startsWith('"') && t.endsWith('"')) ||
+      (t.startsWith("'") && t.endsWith("'"))
+    ) {
+      try {
+        // Prefer JSON for double-quoted; fall back for single-quoted.
+        if (t[0] === '"') return JSON.parse(t);
+        return t.slice(1, -1).replace(/\\'/g, "'");
+      } catch {
+        return t.slice(1, -1);
+      }
+    }
+    return t;
+  }
+
+  function inferTypeFromLiteral(raw) {
+    const t = String(raw ?? "").trim();
+    if (/^(true|false)$/i.test(t)) return "bool";
+    if (/^-?\d+$/.test(t)) return "int";
+    if (/^-?\d+\.\d+$/.test(t)) return "float";
+    return "string";
+  }
+
+  /** Parse `$name: type` / `$name: type = <literal>` with string-aware defaults. */
+  function parseSignature(sig) {
+    if (!sig) return [];
+    const params = [];
+    let i = 0;
+    const src = String(sig).replace(/^\(/, "").replace(/\)$/, "");
+
+    while (i < src.length) {
+      i = skipWs(src, i);
+      if (i >= src.length) break;
+      if (src[i] === ",") {
+        i += 1;
+        continue;
+      }
+      if (src[i] !== "$") break;
+      i += 1;
+      const name = readIdent(src, i);
+      if (!name) break;
+      i = name.end;
+      i = skipWs(src, i);
+      if (src[i] !== ":") break;
+      i += 1;
+      const typeTok = readIdent(src, i);
+      if (!typeTok) break;
+      i = typeTok.end;
+      i = skipWs(src, i);
+
+      let mode = "var";
+      let value = "";
+      if (src[i] === "=") {
+        i += 1;
+        i = skipWs(src, i);
+        const start = i;
+        if (src[i] === '"' || src[i] === "'") {
+          const q = src[i];
+          i += 1;
+          while (i < src.length && src[i] !== q) {
+            if (src[i] === "\\") i += 1;
+            i += 1;
+          }
+          if (i < src.length) i += 1;
+          mode = "default";
+          value = String(parseStringLiteral(src.slice(start, i)));
+        } else {
+          while (i < src.length && src[i] !== ",") i += 1;
+          mode = "default";
+          value = String(parseStringLiteral(src.slice(start, i).trim()));
+        }
+      }
+
+      params.push({
+        name: name.value,
+        type: PARAM_TYPES.includes(typeTok.value) ? typeTok.value : "string",
+        mode,
+        value,
+      });
+    }
+    return params;
+  }
+
+  /** Split filter body on top-level AND / OR. */
+  function splitFilterConnectors(filterInner) {
+    const parts = [];
+    let depth = 0;
+    let start = 0;
+    let sawOr = false;
+    const s = String(filterInner || "");
+    for (let i = 0; i < s.length; i += 1) {
+      const ch = s[i];
+      if (ch === "(") depth += 1;
+      else if (ch === ")") depth -= 1;
+      else if (ch === '"' || ch === "'") {
+        const q = ch;
+        i += 1;
+        while (i < s.length && s[i] !== q) {
+          if (s[i] === "\\") i += 1;
+          i += 1;
+        }
+      } else if (depth === 0) {
+        const andMatch = s.slice(i).match(/^\s+AND\s+/i);
+        const orMatch = s.slice(i).match(/^\s+OR\s+/i);
+        const match = andMatch || orMatch;
+        if (match) {
+          if (orMatch) sawOr = true;
+          parts.push(s.slice(start, i).trim());
+          i += match[0].length - 1;
+          start = i + 1;
+        }
+      }
+    }
+    parts.push(s.slice(start).trim());
+    return { parts: parts.filter(Boolean), sawOr };
+  }
+
+  /**
+   * Parse one filter condition: `eq(pred, val)`, `has(pred)`, `not eq(...)`.
+   * Returns { func, predicate, valueRaw, isVar, varName, literal, unary } | null
+   */
+  function parseOneFilterCondition(part) {
+    const s = String(part || "").trim();
+    if (!s) return null;
+
+    const notMatch = s.match(/^(not)\s+/i);
+    let rest = s;
+    let notPrefix = "";
+    if (notMatch) {
+      notPrefix = "not ";
+      rest = s.slice(notMatch[0].length).trim();
+    }
+
+    const nameMatch = rest.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*\(/);
+    if (!nameMatch) return null;
+    const funcName = nameMatch[1];
+    const openIdx = rest.indexOf("(");
+    let bal;
+    try {
+      bal = extractBalanced(rest, openIdx, "(", ")");
+    } catch {
+      return null;
+    }
+    // Reject trailing junk after the closing paren.
+    if (rest.slice(bal.end).trim()) return null;
+
+    const argsInner = bal.inner.trim();
+    if (!argsInner) return null;
+
+    // Split args on top-level comma.
+    const args = [];
+    let depth = 0;
+    let start = 0;
+    for (let i = 0; i < argsInner.length; i += 1) {
+      const ch = argsInner[i];
+      if (ch === "(") depth += 1;
+      else if (ch === ")") depth -= 1;
+      else if (ch === '"' || ch === "'") {
+        const q = ch;
+        i += 1;
+        while (i < argsInner.length && argsInner[i] !== q) {
+          if (argsInner[i] === "\\") i += 1;
+          i += 1;
+        }
+      } else if (ch === "," && depth === 0) {
+        args.push(argsInner.slice(start, i).trim());
+        start = i + 1;
+      }
+    }
+    args.push(argsInner.slice(start).trim());
+
+    const predicate = args[0];
+    if (!predicate || !/^[A-Za-z_][A-Za-z0-9_.]*$/.test(predicate)) return null;
+
+    const unary = args.length === 1;
+    const valueRaw = unary ? "" : args.slice(1).join(", ").trim();
+    const isVar = !unary && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(valueRaw);
+
+    return {
+      func: `${notPrefix}${funcName}`,
+      predicate,
+      valueRaw,
+      isVar,
+      varName: isVar ? valueRaw.slice(1) : null,
+      literal: unary || isVar ? null : String(parseStringLiteral(valueRaw)),
+      unary,
+    };
+  }
+
+  /**
+   * Split `@filter(...)` conditions on top-level AND/OR.
+   * Returns { op: "AND"|"OR", filters: [...] }.
+   * Mixed AND/OR without parentheses is not modeled — OR wins if any OR appears.
+   */
+  function parseFilterArgs(filterInner) {
+    const { parts, sawOr } = splitFilterConnectors(filterInner);
+    const filters = parts.map(parseOneFilterCondition).filter(Boolean);
+    return { op: sawOr ? "OR" : "AND", filters };
+  }
+
+  function parseDirectivesAndFilter(src, i) {
+    const result = {
+      cascade: false,
+      normalize: false,
+      filterGroup: null,
+      end: i,
+    };
+    while (true) {
+      i = skipWs(src, i);
+      if (src[i] !== "@") break;
+      const name = readIdent(src, i + 1);
+      if (!name) break;
+      i = name.end;
+      if (name.value === "cascade") result.cascade = true;
+      else if (name.value === "normalize") result.normalize = true;
+      else if (name.value === "filter") {
+        i = skipWs(src, i);
+        const bal = extractBalanced(src, i, "(", ")");
+        const group = parseFilterArgs(bal.inner);
+        // Multiple @filter directives on one block are AND-merged.
+        if (!result.filterGroup) {
+          result.filterGroup = group;
+        } else if (group.filters.length) {
+          result.filterGroup.op = "AND";
+          result.filterGroup.filters = result.filterGroup.filters.concat(group.filters);
+        }
+        i = bal.end;
+      } else {
+        // Unknown directive with optional (...): skip args.
+        i = skipWs(src, i);
+        if (src[i] === "(") i = extractBalanced(src, i, "(", ")").end;
+      }
+    }
+    result.end = i;
+    return result;
+  }
+
+  function parseSelection(body) {
+    const fields = [];
+    let i = 0;
+    const src = String(body || "");
+    while (i < src.length) {
+      i = skipWs(src, i);
+      if (i >= src.length) break;
+
+      let alias = null;
+      let pred = readPredicate(src, i);
+      if (!pred) {
+        // Skip unknown tokens to avoid infinite loops.
+        i += 1;
+        continue;
+      }
+      i = pred.end;
+      i = skipWs(src, i);
+
+      if (src[i] === ":") {
+        alias = pred.value;
+        i += 1;
+        pred = readPredicate(src, i);
+        if (!pred) throw new Error(`Expected predicate after alias '${alias}:'`);
+        i = pred.end;
+      }
+
+      const dirs = parseDirectivesAndFilter(src, i);
+      i = dirs.end;
+      i = skipWs(src, i);
+
+      let children = null;
+      if (src[i] === "{") {
+        const bal = extractBalanced(src, i);
+        children = parseSelection(bal.inner);
+        i = bal.end;
+      }
+
+      fields.push({
+        alias: alias || null,
+        name: pred.value,
+        filterGroup: dirs.filterGroup,
+        cascade: dirs.cascade,
+        normalize: dirs.normalize,
+        children,
+      });
+    }
+    return fields;
+  }
+
+  function parseRootBlock(body) {
+    let i = skipWs(body, 0);
+    const resultName = readIdent(body, i);
+    if (!resultName) throw new Error("Expected result key after query '{'");
+    i = resultName.end;
+    i = skipWs(body, i);
+    if (body[i] !== "(") throw new Error("Expected (func: type(...)) on root block");
+
+    const argsBal = extractBalanced(body, i, "(", ")");
+    const args = argsBal.inner;
+    i = argsBal.end;
+
+    const typeMatch =
+      args.match(/func\s*:\s*type\s*\(\s*"([^"]+)"\s*\)/i) ||
+      args.match(/func\s*:\s*type\s*\(\s*'([^']+)'\s*\)/i) ||
+      args.match(/func\s*:\s*type\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/i);
+    if (!typeMatch) throw new Error('Expected func: type("TypeName") on root block');
+    const typeName = typeMatch[1];
+
+    const dirs = parseDirectivesAndFilter(body, i);
+    i = dirs.end;
+    i = skipWs(body, i);
+    if (body[i] !== "{") throw new Error("Expected selection '{' on root block");
+    const sel = extractBalanced(body, i);
+
+    return {
+      resultName: resultName.value,
+      typeName,
+      cascade: dirs.cascade,
+      normalize: dirs.normalize,
+      filterGroup: dirs.filterGroup,
+      selection: parseSelection(sel.inner),
+    };
+  }
+
+  function parse(text) {
+    const src = stripComments(text).trim();
+    if (!src) throw new Error("Nothing to parse");
+    if (!/\bquery\b/i.test(src)) {
+      throw new Error("Expected one or more `query Name { ... }` operations");
+    }
+
+    const operations = [];
+    const re = /\bquery\s+([A-Za-z_][A-Za-z0-9_]*)\s*(\((?:[^()"']|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')*\))?\s*\{/gi;
+    let m;
+    while ((m = re.exec(src))) {
+      const opName = m[1];
+      const signature = m[2] || "";
+      const openIdx = m.index + m[0].length - 1;
+      const bal = extractBalanced(src, openIdx);
+      const root = parseRootBlock(bal.inner);
+      operations.push({
+        opName,
+        params: parseSignature(signature),
+        ...root,
+      });
+      re.lastIndex = bal.end;
+    }
+
+    if (!operations.length) {
+      throw new Error("Could not find a parseable query operation");
+    }
+    return operations;
+  }
+
+  /** Guess a nested type name from an edge when the schema has no binding. */
+  function guessNestedType(edgeName, parentType, schema) {
+    let base = String(edgeName || "");
+    if (base.includes(".")) base = base.split(".").pop();
+    if (/ies$/i.test(base)) base = `${base.slice(0, -3)}y`;
+    else if (/ses$/i.test(base)) base = base.slice(0, -2);
+    else if (/s$/i.test(base) && !/ss$/i.test(base)) base = base.slice(0, -1);
+    base = base.charAt(0).toUpperCase() + base.slice(1);
+    if (schema[base] && base !== parentType) return base;
+    if (base === parentType) return `${parentType}_${edgeName}`;
+    // Prefer an unused name; if taken by something unrelated, rename.
+    if (!schema[base]) return base;
+    return `${parentType}_${edgeName}`;
+  }
+
+  /**
+   * Resolve a field on a type. Prefer exact predicate names (including dots
+   * like "User.name"). Short DQL names uniquely match a namespaced schema
+   * field ("name" → "User.name") so we keep the schema's real predicate.
+   */
+  function findField(typeDef, predName) {
+    if (!typeDef) return null;
+    const fields = typeDef.fields || [];
+    const exact = fields.find((f) => f.name === predName);
+    if (exact) return exact;
+
+    // "name" → unique "User.name" (do not invent short aliases for dotted preds).
+    if (predName && !String(predName).includes(".")) {
+      const matches = fields.filter((f) => f.name.endsWith(`.${predName}`));
+      if (matches.length === 1) return matches[0];
+    }
+    return null;
+  }
+
+  /**
+   * Split a dotted path into edge parts + leaf, matching longest schema field
+   * names at each step so "User.posts.Post.title" stays intact.
+   */
+  function splitPredicatePath(schema, typeName, pathStr) {
+    const raw = String(pathStr || "");
+    if (!raw) return null;
+
+    const fieldsAt = (t) => schema[t]?.fields || [];
+    if (fieldsAt(typeName).some((f) => f.name === raw)) {
+      return { edgeParts: [], leaf: raw, edgePath: "" };
+    }
+
+    const segments = raw.split(".");
+    const edgeParts = [];
+    let currentType = typeName;
+    let i = 0;
+
+    while (i < segments.length) {
+      const fields = fieldsAt(currentType);
+      let matched = null;
+      let matchedEnd = -1;
+      for (let j = segments.length; j > i; j -= 1) {
+        const candidate = segments.slice(i, j).join(".");
+        const field = fields.find((f) => f.name === candidate);
+        if (field) {
+          matched = field;
+          matchedEnd = j;
+          break;
+        }
+      }
+
+      if (!matched) {
+        const rest = segments.slice(i).join(".");
+        const short = findField({ fields }, rest);
+        return {
+          edgeParts,
+          leaf: short?.name || rest,
+          edgePath: edgeParts.join("."),
+        };
+      }
+
+      const start = i;
+      i = matchedEnd;
+
+      if (i >= segments.length) {
+        return { edgeParts, leaf: matched.name, edgePath: edgeParts.join(".") };
+      }
+
+      if (matched.kind === "object" && matched.ofType) {
+        edgeParts.push(matched.name);
+        currentType = matched.ofType;
+        continue;
+      }
+
+      return {
+        edgeParts,
+        leaf: segments.slice(start).join("."),
+        edgePath: edgeParts.join("."),
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Ensure schema contains every type/field referenced by the parsed ops.
+   * Mutates a shallow copy of schema; returns { schema, warnings }.
+   */
+  function ensureSchema(schema, operations) {
+    const next = { ...schema };
+    Object.keys(schema).forEach((k) => {
+      next[k] = { ...schema[k], fields: [...(schema[k].fields || [])] };
+    });
+    const warnings = [];
+    const COLORS = [
+      "#1f8a5a", "#d97706", "#2563eb", "#0f766e", "#b91c1c", "#7c3aed",
+      "#be185d", "#4d7c0f", "#0e7490", "#a16207",
+    ];
+
+    function ensureType(name) {
+      if (!next[name]) {
+        next[name] = {
+          color: COLORS[Object.keys(next).length % COLORS.length],
+          fields: [{ name: "uid", type: "uid", kind: "scalar" }],
+        };
+        warnings.push(`Inferred type "${name}" (not in schema)`);
+      }
+      return next[name];
+    }
+
+    function ensureField(typeName, fieldAst, pathPrefix) {
+      const def = ensureType(typeName);
+      const predName = fieldAst.name;
+      let field = findField(def, predName);
+      const storedName = field ? field.name : predName;
+
+      if (fieldAst.children) {
+        let ofType = field?.ofType;
+        if (!ofType) {
+          ofType = guessNestedType(predName.includes(".") ? predName.split(".").pop() : predName, typeName, next);
+        }
+        ensureType(ofType);
+        if (!field) {
+          def.fields.push({
+            name: storedName,
+            type: "[uid]",
+            kind: "object",
+            ofType,
+          });
+          field = def.fields[def.fields.length - 1];
+        } else if (field.kind !== "object") {
+          field.kind = "object";
+          field.type = "[uid]";
+          field.ofType = ofType;
+        } else if (!field.ofType) {
+          field.ofType = ofType;
+        }
+        ofType = field.ofType;
+        const childPrefix = pathPrefix ? `${pathPrefix}.${storedName}` : storedName;
+        fieldAst.children.forEach((child) => ensureField(ofType, child, childPrefix));
+      } else if (!field) {
+        def.fields.push({
+          name: storedName,
+          type: "string",
+          kind: "scalar",
+        });
+      }
+
+      // Rewrite AST name to the schema field name for later selection mapping.
+      fieldAst.schemaName = storedName;
+    }
+
+    operations.forEach((op) => {
+      ensureType(op.typeName);
+      (op.selection || []).forEach((f) => ensureField(op.typeName, f, ""));
+
+      // Filter groups (AND/OR) are preserved on the canvas; nothing to warn about.
+    });
+
+    return { schema: next, warnings };
+  }
+
+  /**
+   * Convert parsed operations + schema into canvas node objects
+   * (without ids / positions — caller assigns those).
+   */
+  function toNodes(operations, schema) {
+    function resolveFieldType(rootType, predicatePath) {
+      const walk = splitPredicatePath(schema, rootType, predicatePath);
+      if (!walk) return null;
+      let typeName = rootType;
+      for (const edge of walk.edgeParts) {
+        const field = findField(schema[typeName], edge);
+        if (!field?.ofType) return null;
+        typeName = field.ofType;
+      }
+      const field = findField(schema[typeName], walk.leaf);
+      if (!field) return null;
+      return PARAM_TYPES.includes(field.type) ? field.type : null;
+    }
+
+    return operations.map((op) => {
+      const aliases = {};
+      const params = [];
+      const paramByName = new Map();
+      const rootFilter = { op: "AND", conditions: [] };
+      const edgeFilters = {};
+
+      (op.params || []).forEach((p) => {
+        const entry = {
+          name: p.name,
+          type: PARAM_TYPES.includes(p.type) ? p.type : "string",
+          value: p.value ?? "",
+          mode: p.mode === "default" ? "default" : "var",
+        };
+        params.push(entry);
+        paramByName.set(p.name, entry);
+      });
+
+      function ensureParam(name, type, value) {
+        let entry = paramByName.get(name);
+        if (!entry) {
+          entry = {
+            name,
+            type: PARAM_TYPES.includes(type) ? type : "string",
+            value: value ?? "",
+            mode: "var",
+          };
+          params.push(entry);
+          paramByName.set(name, entry);
+        } else if (entry.type === "string" && type && type !== "string") {
+          entry.type = type;
+        }
+        return entry;
+      }
+
+      function resolveEdgeType(edgePath) {
+        let typeName = op.typeName;
+        if (!edgePath) return typeName;
+        const edgeWalk = splitPredicatePath(schema, op.typeName, edgePath);
+        if (!edgeWalk) return typeName;
+        for (const edge of edgeWalk.edgeParts) {
+          const f = findField(schema[typeName], edge);
+          if (!f?.ofType) break;
+          typeName = f.ofType;
+        }
+        const edgeField = findField(schema[typeName], edgeWalk.leaf);
+        if (edgeField?.ofType) typeName = edgeField.ofType;
+        return typeName;
+      }
+
+      function ingestFilterGroup(edgePath, group) {
+        if (!group?.filters?.length) return;
+        const typeName = resolveEdgeType(edgePath);
+        const target = edgePath
+          ? (edgeFilters[edgePath] || (edgeFilters[edgePath] = { op: group.op || "AND", conditions: [] }))
+          : rootFilter;
+        if (edgePath) target.op = group.op || target.op || "AND";
+        else rootFilter.op = group.op || rootFilter.op || "AND";
+
+        group.filters.forEach((filter) => {
+          const leafField = findField(schema[typeName], filter.predicate);
+          const leaf = leafField?.name || filter.predicate;
+          const schemaType = resolveFieldType(
+            op.typeName,
+            edgePath ? `${edgePath}.${leaf}` : leaf
+          );
+          const literalType =
+            filter.literal != null
+              ? inferTypeFromLiteral(filter.valueRaw || filter.literal)
+              : null;
+          const inferredType = schemaType || literalType || "string";
+
+          const cond = {
+            func: filter.func,
+            predicate: leaf,
+            valueMode: "literal",
+            literal: "",
+            paramName: "",
+          };
+
+          if (filter.unary) {
+            cond.valueMode = "literal";
+            cond.literal = "";
+          } else if (filter.isVar && filter.varName) {
+            ensureParam(filter.varName, inferredType, "");
+            cond.valueMode = "param";
+            cond.paramName = filter.varName;
+          } else {
+            cond.valueMode = "literal";
+            cond.literal = filter.literal ?? "";
+          }
+
+          target.conditions.push(cond);
+        });
+      }
+
+      ingestFilterGroup("", op.filterGroup);
+
+      function buildSelection(typeName, fieldAsts, pathPrefix) {
+        const selection = {};
+        (fieldAsts || []).forEach((f) => {
+          const name = f.schemaName || findField(schema[typeName], f.name)?.name || f.name;
+          const path = pathPrefix ? `${pathPrefix}.${name}` : name;
+          if (f.alias) aliases[path] = f.alias;
+          if (f.filterGroup) ingestFilterGroup(path, f.filterGroup);
+
+          if (f.children) {
+            const field = findField(schema[typeName], name);
+            const ofType = field?.ofType || guessNestedType(name, typeName, schema);
+            selection[name] = buildSelection(ofType, f.children, path);
+          } else {
+            selection[name] = null;
+          }
+        });
+        return selection;
+      }
+
+      const selection = buildSelection(op.typeName, op.selection, "");
+
+      // Result key only stored when it differs from the default derived from op name.
+      let resultName = op.resultName || "";
+      const derived = /^get./i.test(op.opName) ? op.opName.slice(3) : op.opName;
+      if (resultName === derived || resultName === op.typeName) {
+        if (resultName === derived) resultName = "";
+      }
+
+      return {
+        type: op.typeName,
+        name: op.opName,
+        resultName,
+        selection,
+        aliases,
+        params,
+        rootFilter,
+        edgeFilters,
+        directives: {
+          cascade: !!op.cascade,
+          normalize: !!op.normalize,
+        },
+      };
+    });
+  }
+
+  return { parse, ensureSchema, toNodes };
+})();

--- a/client/src/components/QueryBuilder/lib/schema-loader.js
+++ b/client/src/components/QueryBuilder/lib/schema-loader.js
@@ -21,293 +21,320 @@
  */
 window.DQLSchemaLoader = (() => {
   const COLORS = [
-    "#1f8a5a", "#d97706", "#2563eb", "#0f766e", "#b91c1c", "#7c3aed",
-    "#be185d", "#4d7c0f", "#0e7490", "#a16207", "#6d28d9", "#374151",
-  ];
+    '#1f8a5a',
+    '#d97706',
+    '#2563eb',
+    '#0f766e',
+    '#b91c1c',
+    '#7c3aed',
+    '#be185d',
+    '#4d7c0f',
+    '#0e7490',
+    '#a16207',
+    '#6d28d9',
+    '#374151',
+  ]
 
   // Dgraph schema queries are not wrapped in outer `{ … }` like normal DQL queries.
-  const SCHEMA_QUERY = "schema { }";
+  const SCHEMA_QUERY = 'schema { }'
 
   function assignColors(out) {
     Object.values(out).forEach((def, i) => {
-      def.color = COLORS[i % COLORS.length];
-    });
-    return out;
+      def.color = COLORS[i % COLORS.length]
+    })
+    return out
   }
 
   function stripName(raw) {
-    const t = String(raw || "").trim();
-    if (t.startsWith("<") && t.endsWith(">")) return t.slice(1, -1).trim();
-    return t;
+    const t = String(raw || '').trim()
+    if (t.startsWith('<') && t.endsWith('>')) return t.slice(1, -1).trim()
+    return t
   }
 
   function normalizeScalar(typeName) {
-    const t = String(typeName || "string").toLowerCase();
-    if (t === "default" || t === "password") return "string";
-    if (t === "datetime" || t === "dateTime".toLowerCase()) return "datetime";
-    if (t === "float32vector" || t === "bigfloat") return "float";
-    if (["int", "float", "string", "bool", "datetime", "geo", "uid"].includes(t)) {
-      return t;
+    const t = String(typeName || 'string').toLowerCase()
+    if (t === 'default' || t === 'password') return 'string'
+    if (t === 'datetime' || t === 'dateTime'.toLowerCase()) return 'datetime'
+    if (t === 'float32vector' || t === 'bigfloat') return 'float'
+    if (
+      ['int', 'float', 'string', 'bool', 'datetime', 'geo', 'uid'].includes(t)
+    ) {
+      return t
     }
-    return "string";
+    return 'string'
   }
 
   function guessOfType(predName, typeNames, selfType) {
-    let base = String(predName || "");
-    if (base.includes(".")) base = base.split(".").pop();
+    let base = String(predName || '')
+    if (base.includes('.')) base = base.split('.').pop()
 
     const ALIASES = {
-      author: ["Author", "User", "Person"],
-      owner: ["Owner", "User", "Person"],
-      creator: ["Creator", "User", "Person"],
-      user: ["User", "Person"],
-      writer: ["Writer", "User", "Person"],
-    };
+      author: ['Author', 'User', 'Person'],
+      owner: ['Owner', 'User', 'Person'],
+      creator: ['Creator', 'User', 'Person'],
+      user: ['User', 'Person'],
+      writer: ['Writer', 'User', 'Person'],
+    }
 
-    if (/ies$/i.test(base)) base = `${base.slice(0, -3)}y`;
-    else if (/ses$/i.test(base)) base = base.slice(0, -2);
-    else if (/s$/i.test(base) && !/ss$/i.test(base)) base = base.slice(0, -1);
+    if (/ies$/i.test(base)) base = `${base.slice(0, -3)}y`
+    else if (/ses$/i.test(base)) base = base.slice(0, -2)
+    else if (/s$/i.test(base) && !/ss$/i.test(base)) base = base.slice(0, -1)
 
     const candidates = [
       base,
       base.charAt(0).toUpperCase() + base.slice(1),
       ...(ALIASES[base.toLowerCase()] || []),
       predName,
-    ];
+    ]
     for (const c of candidates) {
-      if (typeNames.has(c) && c !== selfType) return c;
+      if (typeNames.has(c) && c !== selfType) return c
     }
     for (const t of typeNames) {
-      if (t !== selfType && t.toLowerCase() === base.toLowerCase()) return t;
+      if (t !== selfType && t.toLowerCase() === base.toLowerCase()) return t
     }
-    return null;
+    return null
   }
 
   function ensureUidField(fields) {
-    if (!fields.some((f) => f.name === "uid")) {
-      fields.unshift({ name: "uid", type: "uid", kind: "scalar" });
+    if (!fields.some((f) => f.name === 'uid')) {
+      fields.unshift({ name: 'uid', type: 'uid', kind: 'scalar' })
     }
-    return fields;
+    return fields
   }
 
   /** Read obj[key] case-insensitively (first match wins). */
   function getCI(obj, key) {
-    if (!obj || typeof obj !== "object") return undefined;
-    if (Object.prototype.hasOwnProperty.call(obj, key)) return obj[key];
-    const want = String(key).toLowerCase();
+    if (!obj || typeof obj !== 'object') return undefined
+    if (Object.prototype.hasOwnProperty.call(obj, key)) return obj[key]
+    const want = String(key).toLowerCase()
     for (const k of Object.keys(obj)) {
-      if (k.toLowerCase() === want) return obj[k];
+      if (k.toLowerCase() === want) return obj[k]
     }
-    return undefined;
+    return undefined
   }
 
   function pickCI(obj, ...keys) {
     for (const key of keys) {
-      const value = getCI(obj, key);
-      if (value !== undefined && value !== null) return value;
+      const value = getCI(obj, key)
+      if (value !== undefined && value !== null) return value
     }
-    return undefined;
+    return undefined
   }
 
   function schemaRoot(payload) {
-    if (!payload || typeof payload !== "object") return null;
-    const nested = getCI(payload, "data");
-    if (nested && typeof nested === "object") {
-      if (Array.isArray(getCI(nested, "schema")) || Array.isArray(getCI(nested, "types"))) {
-        return nested;
+    if (!payload || typeof payload !== 'object') return null
+    const nested = getCI(payload, 'data')
+    if (nested && typeof nested === 'object') {
+      if (
+        Array.isArray(getCI(nested, 'schema')) ||
+        Array.isArray(getCI(nested, 'types'))
+      ) {
+        return nested
       }
     }
-    if (Array.isArray(getCI(payload, "schema")) || Array.isArray(getCI(payload, "types"))) {
-      return payload;
+    if (
+      Array.isArray(getCI(payload, 'schema')) ||
+      Array.isArray(getCI(payload, 'types'))
+    ) {
+      return payload
     }
-    return null;
+    return null
   }
 
   function isSchemaPayload(obj) {
-    return schemaRoot(obj) != null;
+    return schemaRoot(obj) != null
   }
 
   /**
    * @param {object} payload schema query JSON
    */
   function fromSchemaJson(payload) {
-    const data = schemaRoot(payload);
+    const data = schemaRoot(payload)
     if (!data) {
       throw new Error(
-        'Not a Dgraph schema JSON. Expected { "Schema": [...], "Types": [...] } (keys are case-insensitive).'
-      );
+        'Not a Dgraph schema JSON. Expected { "Schema": [...], "Types": [...] } (keys are case-insensitive).',
+      )
     }
 
-    const predicates = new Map();
-    (getCI(data, "schema") || []).forEach((row) => {
-      if (!row || typeof row !== "object") return;
-      const name = stripName(pickCI(row, "predicate", "name"));
-      if (!name || name.toLowerCase().startsWith("dgraph.")) return;
+    const predicates = new Map()
+    ;(getCI(data, 'schema') || []).forEach((row) => {
+      if (!row || typeof row !== 'object') return
+      const name = stripName(pickCI(row, 'predicate', 'name'))
+      if (!name || name.toLowerCase().startsWith('dgraph.')) return
 
-      let type = String(pickCI(row, "type") || "string");
-      let list = !!pickCI(row, "list");
+      let type = String(pickCI(row, 'type') || 'string')
+      let list = !!pickCI(row, 'list')
       // Some exports use type: "[uid]" / "[string]" instead of list: true
-      const listMatch = type.match(/^\[(.+)\]$/);
+      const listMatch = type.match(/^\[(.+)\]$/)
       if (listMatch) {
-        list = true;
-        type = listMatch[1];
+        list = true
+        type = listMatch[1]
       }
-      type = type.toLowerCase();
+      type = type.toLowerCase()
 
-      predicates.set(name, { type, list });
-    });
+      predicates.set(name, { type, list })
+    })
 
-    const types = new Map();
-    (getCI(data, "types") || []).forEach((row) => {
-      if (!row || typeof row !== "object") return;
-      const typeName = stripName(pickCI(row, "name"));
-      if (!typeName || typeName.toLowerCase().startsWith("dgraph.")) return;
+    const types = new Map()
+    ;(getCI(data, 'types') || []).forEach((row) => {
+      if (!row || typeof row !== 'object') return
+      const typeName = stripName(pickCI(row, 'name'))
+      if (!typeName || typeName.toLowerCase().startsWith('dgraph.')) return
 
-      const fields = (getCI(row, "fields") || [])
-        .map((f) =>
-          stripName(typeof f === "string" ? f : pickCI(f, "name"))
-        )
-        .filter((n) => n && !n.toLowerCase().startsWith("dgraph."));
-      if (fields.length) types.set(typeName, fields);
-    });
+      const fields = (getCI(row, 'fields') || [])
+        .map((f) => stripName(typeof f === 'string' ? f : pickCI(f, 'name')))
+        .filter((n) => n && !n.toLowerCase().startsWith('dgraph.'))
+      if (fields.length) types.set(typeName, fields)
+    })
 
     if (!types.size) {
       throw new Error(
-        'Schema JSON has no usable "types". The builder needs type definitions to list entities.'
-      );
+        'Schema JSON has no usable "types". The builder needs type definitions to list entities.',
+      )
     }
 
     // Predicates missing from schema[] (types-only paste): default to string.
     types.forEach((fields) => {
       fields.forEach((f) => {
-        if (!predicates.has(f)) predicates.set(f, { type: "string", list: false });
-      });
-    });
+        if (!predicates.has(f))
+          predicates.set(f, { type: 'string', list: false })
+      })
+    })
 
-    const typeNames = new Set(types.keys());
-    const out = {};
+    const typeNames = new Set(types.keys())
+    const out = {}
 
     types.forEach((fieldNames, typeName) => {
-      const fields = [];
+      const fields = []
       fieldNames.forEach((pred) => {
-        if (!pred || pred === "uid") return;
-        const meta = predicates.get(pred) || { type: "string", list: false };
-        const isUid = meta.type === "uid";
+        if (!pred || pred === 'uid') return
+        const meta = predicates.get(pred) || { type: 'string', list: false }
+        const isUid = meta.type === 'uid'
 
         if (isUid) {
-          const ofType = guessOfType(pred, typeNames, typeName);
+          const ofType = guessOfType(pred, typeNames, typeName)
           if (ofType) {
             fields.push({
               name: pred,
-              type: meta.list ? "[uid]" : "uid",
-              kind: "object",
+              type: meta.list ? '[uid]' : 'uid',
+              kind: 'object',
               ofType,
-            });
+            })
           } else {
             fields.push({
               name: pred,
-              type: meta.list ? "[uid]" : "uid",
-              kind: "scalar",
-            });
+              type: meta.list ? '[uid]' : 'uid',
+              kind: 'scalar',
+            })
           }
         } else {
           fields.push({
             name: pred,
             type: normalizeScalar(meta.type),
-            kind: "scalar",
-          });
+            kind: 'scalar',
+          })
         }
-      });
-      out[typeName] = { color: "", fields: ensureUidField(fields) };
-    });
+      })
+      out[typeName] = { color: '', fields: ensureUidField(fields) }
+    })
 
-    return assignColors(out);
+    return assignColors(out)
   }
 
   function fromText(raw) {
-    const text = String(raw || "").replace(/^\uFEFF/, "").trim();
-    if (!text) throw new Error("Nothing to parse");
-    let json;
+    const text = String(raw || '')
+      .replace(/^\uFEFF/, '')
+      .trim()
+    if (!text) throw new Error('Nothing to parse')
+    let json
     try {
-      json = JSON.parse(text);
+      json = JSON.parse(text)
     } catch (err) {
       throw new Error(
-        `Expected JSON from a Dgraph \`schema { }\` query. ${err.message}`
-      );
+        `Expected JSON from a Dgraph \`schema { }\` query. ${err.message}`,
+      )
     }
-    return fromSchemaJson(json);
+    return fromSchemaJson(json)
   }
 
   function queryEndpoints(url) {
-    const base = String(url || "").trim().replace(/\/$/, "");
-    if (!base) return [];
-    const endpoints = [base];
-    if (!/\/query$/i.test(base)) endpoints.push(`${base}/query`);
-    return [...new Set(endpoints)];
+    const base = String(url || '')
+      .trim()
+      .replace(/\/$/, '')
+    if (!base) return []
+    const endpoints = [base]
+    if (!/\/query$/i.test(base)) endpoints.push(`${base}/query`)
+    return [...new Set(endpoints)]
   }
 
   async function tryQuerySchema(endpoint) {
     const attempts = [
       {
-        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
         body: JSON.stringify({ query: SCHEMA_QUERY }),
       },
       {
-        headers: { "Content-Type": "application/dql", Accept: "application/json" },
+        headers: {
+          'Content-Type': 'application/dql',
+          Accept: 'application/json',
+        },
         body: SCHEMA_QUERY,
       },
       {
-        headers: { "Content-Type": "text/plain", Accept: "application/json" },
+        headers: { 'Content-Type': 'text/plain', Accept: 'application/json' },
         body: SCHEMA_QUERY,
       },
-    ];
+    ]
 
-    const errors = [];
+    const errors = []
     for (const attempt of attempts) {
       try {
-        const res = await fetch(endpoint, { method: "POST", ...attempt });
+        const res = await fetch(endpoint, { method: 'POST', ...attempt })
         if (!res.ok) {
-          errors.push(`POST ${endpoint} → HTTP ${res.status}`);
-          continue;
+          errors.push(`POST ${endpoint} → HTTP ${res.status}`)
+          continue
         }
-        const json = await res.json();
+        const json = await res.json()
         if (json?.errors?.length) {
-          errors.push(json.errors.map((e) => e.message || String(e)).join("; "));
-          continue;
+          errors.push(json.errors.map((e) => e.message || String(e)).join('; '))
+          continue
         }
-        if (isSchemaPayload(json)) return fromSchemaJson(json);
-        errors.push(`POST ${endpoint} returned JSON without schema/types`);
+        if (isSchemaPayload(json)) return fromSchemaJson(json)
+        errors.push(`POST ${endpoint} returned JSON without schema/types`)
       } catch (err) {
-        errors.push(`POST ${endpoint} failed: ${err.message}`);
+        errors.push(`POST ${endpoint} failed: ${err.message}`)
       }
     }
-    throw new Error(errors.join(" · "));
+    throw new Error(errors.join(' · '))
   }
 
   async function fetchSchema(url) {
-    const errors = [];
-    const endpoints = queryEndpoints(url);
-    if (!endpoints.length) throw new Error("Enter a Dgraph Alpha URL first.");
+    const errors = []
+    const endpoints = queryEndpoints(url)
+    if (!endpoints.length) throw new Error('Enter a Dgraph Alpha URL first.')
 
     for (const endpoint of endpoints) {
       try {
-        return await tryQuerySchema(endpoint);
+        return await tryQuerySchema(endpoint)
       } catch (err) {
-        errors.push(err.message);
+        errors.push(err.message)
       }
     }
 
     // Allow fetching a hosted schema JSON file.
     try {
-      const res = await fetch(url);
-      if (res.ok) return fromSchemaJson(await res.json());
-      errors.push(`GET ${url} → HTTP ${res.status}`);
+      const res = await fetch(url)
+      if (res.ok) return fromSchemaJson(await res.json())
+      errors.push(`GET ${url} → HTTP ${res.status}`)
     } catch (err) {
-      errors.push(`GET failed: ${err.message}`);
+      errors.push(`GET failed: ${err.message}`)
     }
 
-    throw new Error(errors.join(" · "));
+    throw new Error(errors.join(' · '))
   }
 
-  return { fromSchemaJson, fromText, fetchSchema };
-})();
+  return { fromSchemaJson, fromText, fetchSchema }
+})()

--- a/client/src/components/QueryBuilder/lib/schema-loader.js
+++ b/client/src/components/QueryBuilder/lib/schema-loader.js
@@ -1,0 +1,313 @@
+/**
+ * Converts Dgraph schema JSON — the result of running `schema { }` — into the
+ * builder's entity format:
+ *   { TypeName: { color, fields: [{ name, type, kind, ofType? }] } }
+ *
+ * Expected shape (keys are case-insensitive; PascalCase shown):
+ * {
+ *   "Schema": [
+ *     { "Predicate": "name", "Type": "string", "Index": true, "Tokenizer": ["term"] },
+ *     { "Predicate": "posts", "Type": "uid", "List": true }
+ *   ],
+ *   "Types": [
+ *     {
+ *       "Name": "User",
+ *       "Fields": [ { "Name": "name" }, { "Name": "posts" } ]
+ *     }
+ *   ]
+ * }
+ *
+ * A `"data"` / `"Data"` wrapper is also accepted.
+ */
+window.DQLSchemaLoader = (() => {
+  const COLORS = [
+    "#1f8a5a", "#d97706", "#2563eb", "#0f766e", "#b91c1c", "#7c3aed",
+    "#be185d", "#4d7c0f", "#0e7490", "#a16207", "#6d28d9", "#374151",
+  ];
+
+  // Dgraph schema queries are not wrapped in outer `{ … }` like normal DQL queries.
+  const SCHEMA_QUERY = "schema { }";
+
+  function assignColors(out) {
+    Object.values(out).forEach((def, i) => {
+      def.color = COLORS[i % COLORS.length];
+    });
+    return out;
+  }
+
+  function stripName(raw) {
+    const t = String(raw || "").trim();
+    if (t.startsWith("<") && t.endsWith(">")) return t.slice(1, -1).trim();
+    return t;
+  }
+
+  function normalizeScalar(typeName) {
+    const t = String(typeName || "string").toLowerCase();
+    if (t === "default" || t === "password") return "string";
+    if (t === "datetime" || t === "dateTime".toLowerCase()) return "datetime";
+    if (t === "float32vector" || t === "bigfloat") return "float";
+    if (["int", "float", "string", "bool", "datetime", "geo", "uid"].includes(t)) {
+      return t;
+    }
+    return "string";
+  }
+
+  function guessOfType(predName, typeNames, selfType) {
+    let base = String(predName || "");
+    if (base.includes(".")) base = base.split(".").pop();
+
+    const ALIASES = {
+      author: ["Author", "User", "Person"],
+      owner: ["Owner", "User", "Person"],
+      creator: ["Creator", "User", "Person"],
+      user: ["User", "Person"],
+      writer: ["Writer", "User", "Person"],
+    };
+
+    if (/ies$/i.test(base)) base = `${base.slice(0, -3)}y`;
+    else if (/ses$/i.test(base)) base = base.slice(0, -2);
+    else if (/s$/i.test(base) && !/ss$/i.test(base)) base = base.slice(0, -1);
+
+    const candidates = [
+      base,
+      base.charAt(0).toUpperCase() + base.slice(1),
+      ...(ALIASES[base.toLowerCase()] || []),
+      predName,
+    ];
+    for (const c of candidates) {
+      if (typeNames.has(c) && c !== selfType) return c;
+    }
+    for (const t of typeNames) {
+      if (t !== selfType && t.toLowerCase() === base.toLowerCase()) return t;
+    }
+    return null;
+  }
+
+  function ensureUidField(fields) {
+    if (!fields.some((f) => f.name === "uid")) {
+      fields.unshift({ name: "uid", type: "uid", kind: "scalar" });
+    }
+    return fields;
+  }
+
+  /** Read obj[key] case-insensitively (first match wins). */
+  function getCI(obj, key) {
+    if (!obj || typeof obj !== "object") return undefined;
+    if (Object.prototype.hasOwnProperty.call(obj, key)) return obj[key];
+    const want = String(key).toLowerCase();
+    for (const k of Object.keys(obj)) {
+      if (k.toLowerCase() === want) return obj[k];
+    }
+    return undefined;
+  }
+
+  function pickCI(obj, ...keys) {
+    for (const key of keys) {
+      const value = getCI(obj, key);
+      if (value !== undefined && value !== null) return value;
+    }
+    return undefined;
+  }
+
+  function schemaRoot(payload) {
+    if (!payload || typeof payload !== "object") return null;
+    const nested = getCI(payload, "data");
+    if (nested && typeof nested === "object") {
+      if (Array.isArray(getCI(nested, "schema")) || Array.isArray(getCI(nested, "types"))) {
+        return nested;
+      }
+    }
+    if (Array.isArray(getCI(payload, "schema")) || Array.isArray(getCI(payload, "types"))) {
+      return payload;
+    }
+    return null;
+  }
+
+  function isSchemaPayload(obj) {
+    return schemaRoot(obj) != null;
+  }
+
+  /**
+   * @param {object} payload schema query JSON
+   */
+  function fromSchemaJson(payload) {
+    const data = schemaRoot(payload);
+    if (!data) {
+      throw new Error(
+        'Not a Dgraph schema JSON. Expected { "Schema": [...], "Types": [...] } (keys are case-insensitive).'
+      );
+    }
+
+    const predicates = new Map();
+    (getCI(data, "schema") || []).forEach((row) => {
+      if (!row || typeof row !== "object") return;
+      const name = stripName(pickCI(row, "predicate", "name"));
+      if (!name || name.toLowerCase().startsWith("dgraph.")) return;
+
+      let type = String(pickCI(row, "type") || "string");
+      let list = !!pickCI(row, "list");
+      // Some exports use type: "[uid]" / "[string]" instead of list: true
+      const listMatch = type.match(/^\[(.+)\]$/);
+      if (listMatch) {
+        list = true;
+        type = listMatch[1];
+      }
+      type = type.toLowerCase();
+
+      predicates.set(name, { type, list });
+    });
+
+    const types = new Map();
+    (getCI(data, "types") || []).forEach((row) => {
+      if (!row || typeof row !== "object") return;
+      const typeName = stripName(pickCI(row, "name"));
+      if (!typeName || typeName.toLowerCase().startsWith("dgraph.")) return;
+
+      const fields = (getCI(row, "fields") || [])
+        .map((f) =>
+          stripName(typeof f === "string" ? f : pickCI(f, "name"))
+        )
+        .filter((n) => n && !n.toLowerCase().startsWith("dgraph."));
+      if (fields.length) types.set(typeName, fields);
+    });
+
+    if (!types.size) {
+      throw new Error(
+        'Schema JSON has no usable "types". The builder needs type definitions to list entities.'
+      );
+    }
+
+    // Predicates missing from schema[] (types-only paste): default to string.
+    types.forEach((fields) => {
+      fields.forEach((f) => {
+        if (!predicates.has(f)) predicates.set(f, { type: "string", list: false });
+      });
+    });
+
+    const typeNames = new Set(types.keys());
+    const out = {};
+
+    types.forEach((fieldNames, typeName) => {
+      const fields = [];
+      fieldNames.forEach((pred) => {
+        if (!pred || pred === "uid") return;
+        const meta = predicates.get(pred) || { type: "string", list: false };
+        const isUid = meta.type === "uid";
+
+        if (isUid) {
+          const ofType = guessOfType(pred, typeNames, typeName);
+          if (ofType) {
+            fields.push({
+              name: pred,
+              type: meta.list ? "[uid]" : "uid",
+              kind: "object",
+              ofType,
+            });
+          } else {
+            fields.push({
+              name: pred,
+              type: meta.list ? "[uid]" : "uid",
+              kind: "scalar",
+            });
+          }
+        } else {
+          fields.push({
+            name: pred,
+            type: normalizeScalar(meta.type),
+            kind: "scalar",
+          });
+        }
+      });
+      out[typeName] = { color: "", fields: ensureUidField(fields) };
+    });
+
+    return assignColors(out);
+  }
+
+  function fromText(raw) {
+    const text = String(raw || "").replace(/^\uFEFF/, "").trim();
+    if (!text) throw new Error("Nothing to parse");
+    let json;
+    try {
+      json = JSON.parse(text);
+    } catch (err) {
+      throw new Error(
+        `Expected JSON from a Dgraph \`schema { }\` query. ${err.message}`
+      );
+    }
+    return fromSchemaJson(json);
+  }
+
+  function queryEndpoints(url) {
+    const base = String(url || "").trim().replace(/\/$/, "");
+    if (!base) return [];
+    const endpoints = [base];
+    if (!/\/query$/i.test(base)) endpoints.push(`${base}/query`);
+    return [...new Set(endpoints)];
+  }
+
+  async function tryQuerySchema(endpoint) {
+    const attempts = [
+      {
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ query: SCHEMA_QUERY }),
+      },
+      {
+        headers: { "Content-Type": "application/dql", Accept: "application/json" },
+        body: SCHEMA_QUERY,
+      },
+      {
+        headers: { "Content-Type": "text/plain", Accept: "application/json" },
+        body: SCHEMA_QUERY,
+      },
+    ];
+
+    const errors = [];
+    for (const attempt of attempts) {
+      try {
+        const res = await fetch(endpoint, { method: "POST", ...attempt });
+        if (!res.ok) {
+          errors.push(`POST ${endpoint} → HTTP ${res.status}`);
+          continue;
+        }
+        const json = await res.json();
+        if (json?.errors?.length) {
+          errors.push(json.errors.map((e) => e.message || String(e)).join("; "));
+          continue;
+        }
+        if (isSchemaPayload(json)) return fromSchemaJson(json);
+        errors.push(`POST ${endpoint} returned JSON without schema/types`);
+      } catch (err) {
+        errors.push(`POST ${endpoint} failed: ${err.message}`);
+      }
+    }
+    throw new Error(errors.join(" · "));
+  }
+
+  async function fetchSchema(url) {
+    const errors = [];
+    const endpoints = queryEndpoints(url);
+    if (!endpoints.length) throw new Error("Enter a Dgraph Alpha URL first.");
+
+    for (const endpoint of endpoints) {
+      try {
+        return await tryQuerySchema(endpoint);
+      } catch (err) {
+        errors.push(err.message);
+      }
+    }
+
+    // Allow fetching a hosted schema JSON file.
+    try {
+      const res = await fetch(url);
+      if (res.ok) return fromSchemaJson(await res.json());
+      errors.push(`GET ${url} → HTTP ${res.status}`);
+    } catch (err) {
+      errors.push(`GET failed: ${err.message}`);
+    }
+
+    throw new Error(errors.join(" · "));
+  }
+
+  return { fromSchemaJson, fromText, fetchSchema };
+})();

--- a/client/src/components/QueryBuilder/lib/schema.js
+++ b/client/src/components/QueryBuilder/lib/schema.js
@@ -1,0 +1,5 @@
+/**
+ * Fallback empty schema for the Query Builder.
+ * Ratel always replaces this with the connected Alpha's schema { }.
+ */
+window.DQL_SCHEMA = {};

--- a/client/src/components/QueryBuilder/lib/schema.js
+++ b/client/src/components/QueryBuilder/lib/schema.js
@@ -2,4 +2,4 @@
  * Fallback empty schema for the Query Builder.
  * Ratel always replaces this with the connected Alpha's schema { }.
  */
-window.DQL_SCHEMA = {};
+window.DQL_SCHEMA = {}

--- a/client/src/components/QueryBuilder/lib/styles.css
+++ b/client/src/components/QueryBuilder/lib/styles.css
@@ -17,7 +17,9 @@
   --sans: "Outfit", system-ui, sans-serif;
 }
 
-.dql-builder *, .dql-builder *::before, .dql-builder *::after {
+.dql-builder *,
+.dql-builder *::before,
+.dql-builder *::after {
   box-sizing: border-box;
 }
 
@@ -31,10 +33,16 @@
   min-height: 0;
   font-family: var(--sans);
   color: var(--ink);
-  background:
-    radial-gradient(ellipse 80% 50% at 10% -10%, rgba(61, 214, 140, 0.1), transparent 55%),
-    radial-gradient(ellipse 60% 40% at 100% 0%, rgba(253, 214, 99, 0.06), transparent 50%),
-    linear-gradient(160deg, #17181b 0%, var(--paper) 45%, #1a1b1e 100%);
+  background: radial-gradient(
+      ellipse 80% 50% at 10% -10%,
+      rgba(61, 214, 140, 0.1),
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 60% 40% at 100% 0%,
+      rgba(253, 214, 99, 0.06),
+      transparent 50%
+    ), linear-gradient(160deg, #17181b 0%, var(--paper) 45%, #1a1b1e 100%);
   overflow: hidden;
   color-scheme: dark;
 }
@@ -49,10 +57,12 @@
   mix-blend-mode: soft-light;
 }
 
-.dql-builder.app, .dql-builder .app {
+.dql-builder.app,
+.dql-builder .app {
   position: relative;
   z-index: 1;
-  height: 100%; min-height: 0;
+  height: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }
@@ -167,8 +177,12 @@
 }
 
 @keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .dql-builder .modal {
@@ -261,7 +275,8 @@
   color: var(--ink-soft);
 }
 
-.dql-builder .modal-divider::before, .dql-builder .modal-divider::after {
+.dql-builder .modal-divider::before,
+.dql-builder .modal-divider::after {
   content: "";
   flex: 1;
   height: 1px;
@@ -327,7 +342,8 @@
   animation: fade-up 0.55s 0.08s ease both;
 }
 
-.dql-builder .query-panel, .dql-builder .canvas-wrap {
+.dql-builder .query-panel,
+.dql-builder .canvas-wrap {
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -447,10 +463,8 @@
   position: relative;
   flex: 1;
   min-height: 0;
-  background:
-    linear-gradient(rgba(60, 64, 67, 0.45) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(60, 64, 67, 0.45) 1px, transparent 1px),
-    #1a1b1e;
+  background: linear-gradient(rgba(60, 64, 67, 0.45) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(60, 64, 67, 0.45) 1px, transparent 1px), #1a1b1e;
   background-size: 28px 28px;
   overflow: auto;
   overscroll-behavior: contain;
@@ -561,7 +575,8 @@
   border-color: rgba(61, 214, 140, 0.35);
 }
 
-.dql-builder .entity-menu-item:active, .dql-builder .entity-menu-item.dragging {
+.dql-builder .entity-menu-item:active,
+.dql-builder .entity-menu-item.dragging {
   cursor: grabbing;
   opacity: 0.6;
 }
@@ -892,9 +907,7 @@
 
 .dql-builder .entity-node.selected {
   border-color: var(--accent);
-  box-shadow:
-    0 0 0 2px rgba(61, 214, 140, 0.25),
-    0 12px 30px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0 0 2px rgba(61, 214, 140, 0.25), 0 12px 30px rgba(0, 0, 0, 0.4);
 }
 
 .dql-builder .entity-node:focus-within {
@@ -960,7 +973,8 @@
   flex-shrink: 0;
 }
 
-.dql-builder .entity-node-header:active, .dql-builder .entity-node.dragging .entity-node-header {
+.dql-builder .entity-node-header:active,
+.dql-builder .entity-node.dragging .entity-node-header {
   cursor: grabbing;
 }
 
@@ -1162,7 +1176,8 @@
   min-width: 0;
 }
 
-.dql-builder .param-card input, .dql-builder .param-card select {
+.dql-builder .param-card input,
+.dql-builder .param-card select {
   width: 100%;
   min-width: 0;
   border: 1px solid var(--line);
@@ -1175,7 +1190,8 @@
   outline: none;
 }
 
-.dql-builder .param-card input:focus, .dql-builder .param-card select:focus {
+.dql-builder .param-card input:focus,
+.dql-builder .param-card select:focus {
   border-color: var(--accent);
 }
 
@@ -1193,7 +1209,8 @@
   color: var(--danger);
 }
 
-.dql-builder .param-empty, .dql-builder .filter-empty {
+.dql-builder .param-empty,
+.dql-builder .filter-empty {
   margin: 0;
   font-size: 0.72rem;
   color: var(--ink-soft);
@@ -1271,7 +1288,8 @@
   margin-top: 0.35rem;
 }
 
-.dql-builder .filter-row select, .dql-builder .filter-row input {
+.dql-builder .filter-row select,
+.dql-builder .filter-row input {
   width: auto;
   min-width: 0;
   max-width: 100%;
@@ -1301,12 +1319,14 @@
   min-width: 4rem;
 }
 
-.dql-builder .filter-row .filter-literal, .dql-builder .filter-row .filter-param {
+.dql-builder .filter-row .filter-literal,
+.dql-builder .filter-row .filter-param {
   flex: 1 1 5.5rem;
   min-width: 4rem;
 }
 
-.dql-builder .filter-row select:focus, .dql-builder .filter-row input:focus {
+.dql-builder .filter-row select:focus,
+.dql-builder .filter-row input:focus {
   border-color: var(--accent);
 }
 
@@ -1334,7 +1354,8 @@
 }
 
 /* Field tree — contained rows; types/aliases stay inside the card */
-.dql-builder .entity-fields, .dql-builder .nested-fields {
+.dql-builder .entity-fields,
+.dql-builder .nested-fields {
   list-style: none;
   margin: 0;
   padding: 0.4rem 0.65rem 0.9rem 0.5rem;
@@ -1356,7 +1377,8 @@
   box-sizing: border-box;
 }
 
-.dql-builder .entity-fields li, .dql-builder .nested-fields li {
+.dql-builder .entity-fields li,
+.dql-builder .nested-fields li {
   margin: 0;
   min-width: 0;
 }
@@ -1455,18 +1477,36 @@
 }
 
 @keyframes fade-down {
-  from { opacity: 0; transform: translateY(-8px); }
-  to { opacity: 1; transform: none; }
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
 @keyframes fade-up {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: none; }
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
 @keyframes pop-in {
-  from { opacity: 0; transform: scale(0.92); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 @media (max-width: 960px) {

--- a/client/src/components/QueryBuilder/lib/styles.css
+++ b/client/src/components/QueryBuilder/lib/styles.css
@@ -1,0 +1,1501 @@
+.dql-builder {
+  --ink: #e8eaed;
+  --ink-soft: #9aa0a6;
+  --paper: #202124;
+  --paper-2: #3c4043;
+  --line: #3c4043;
+  --accent: #3dd68c;
+  --accent-dim: #1e8e53;
+  --accent-hot: #fdd663;
+  --node: #292a2d;
+  --node-header: #303134;
+  --input-bg: #1a1b1e;
+  --danger: #f28b82;
+  --shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+  --focus-ring: rgba(61, 214, 140, 0.22);
+  --mono: "IBM Plex Mono", ui-monospace, monospace;
+  --sans: "Outfit", system-ui, sans-serif;
+}
+
+.dql-builder *, .dql-builder *::before, .dql-builder *::after {
+  box-sizing: border-box;
+}
+
+.dql-builder {
+  margin: 0;
+  height: 100%;
+}
+
+.dql-builder {
+  position: relative;
+  min-height: 0;
+  font-family: var(--sans);
+  color: var(--ink);
+  background:
+    radial-gradient(ellipse 80% 50% at 10% -10%, rgba(61, 214, 140, 0.1), transparent 55%),
+    radial-gradient(ellipse 60% 40% at 100% 0%, rgba(253, 214, 99, 0.06), transparent 50%),
+    linear-gradient(160deg, #17181b 0%, var(--paper) 45%, #1a1b1e 100%);
+  overflow: hidden;
+  color-scheme: dark;
+}
+
+.dql-builder .grain {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  opacity: 0.14;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  mix-blend-mode: soft-light;
+}
+
+.dql-builder.app, .dql-builder .app {
+  position: relative;
+  z-index: 1;
+  height: 100%; min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.dql-builder .topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1.5rem;
+  border-bottom: 1px solid var(--line);
+  flex-shrink: 0;
+  animation: fade-down 0.5s ease both;
+}
+
+.dql-builder .brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.dql-builder .brand-mark {
+  width: 1.15rem;
+  height: 1.15rem;
+  background: var(--accent);
+  clip-path: polygon(50% 0%, 100% 38%, 82% 100%, 18% 100%, 0% 38%);
+  box-shadow: 0 0 0 4px rgba(61, 214, 140, 0.18);
+}
+
+.dql-builder .brand h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.dql-builder .tagline {
+  margin: 0;
+  text-align: right;
+  color: var(--ink-soft);
+  font-size: 0.88rem;
+  font-weight: 500;
+}
+
+.dql-builder .btn-ghost {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.35rem 0.65rem;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.dql-builder .btn-ghost:hover:not(:disabled) {
+  color: var(--ink);
+  border-color: #5f6368;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.dql-builder .btn-ghost:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.dql-builder .btn-solid {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #0f1411;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  padding: 0.42rem 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.dql-builder .btn-solid:hover:not(:disabled) {
+  background: #63e0a4;
+  border-color: #63e0a4;
+}
+
+.dql-builder .btn-solid:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+
+/* Schema modal */
+.dql-builder .modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(3px);
+  animation: fade-in 0.15s ease both;
+}
+
+.dql-builder .modal-overlay[hidden] {
+  display: none;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.dql-builder .modal {
+  width: min(560px, 100%);
+  background: var(--node);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
+  padding: 1.1rem 1.25rem 1.25rem;
+  animation: pop-in 0.22s cubic-bezier(0.2, 0.9, 0.3, 1.15) both;
+}
+
+.dql-builder .modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.dql-builder .modal-head h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.dql-builder .modal-close {
+  border: none;
+  background: transparent;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--ink-soft);
+  cursor: pointer;
+  padding: 0.2rem 0.4rem;
+  border-radius: 6px;
+}
+
+.dql-builder .modal-close:hover {
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.dql-builder .modal-hint {
+  margin: 0 0 0.85rem;
+  font-size: 0.8rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+}
+
+.dql-builder .modal-hint code {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  padding: 0.05rem 0.3rem;
+}
+
+.dql-builder .modal-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.dql-builder .modal-row input {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--input-bg);
+  padding: 0.45rem 0.65rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--ink);
+  outline: none;
+}
+
+.dql-builder .modal-row input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.dql-builder .modal-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.85rem 0 0.6rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.dql-builder .modal-divider::before, .dql-builder .modal-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+}
+
+.dql-builder .modal textarea {
+  width: 100%;
+  height: 160px;
+  resize: vertical;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--input-bg);
+  padding: 0.55rem 0.65rem;
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  line-height: 1.5;
+  color: var(--ink);
+  outline: none;
+}
+
+.dql-builder .modal textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.dql-builder .modal-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.85rem;
+}
+
+.dql-builder .modal-status {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.74rem;
+  line-height: 1.4;
+  color: var(--ink-soft);
+}
+
+.dql-builder .modal-status.is-ok {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.dql-builder .modal-status.is-error {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.dql-builder .import-textarea {
+  height: 260px !important;
+}
+
+.dql-builder .workspace {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(340px, 38%) 1fr;
+  gap: 1rem;
+  padding: 1rem 1.25rem 1.25rem;
+  animation: fade-up 0.55s 0.08s ease both;
+}
+
+.dql-builder .query-panel, .dql-builder .canvas-wrap {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: rgba(41, 42, 45, 0.92);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  backdrop-filter: blur(8px);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.dql-builder .canvas-wrap {
+  overflow: visible;
+}
+
+.dql-builder .panel-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid var(--line);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  flex-shrink: 0;
+  position: relative;
+  z-index: 20;
+  overflow: visible;
+}
+
+.dql-builder .panel-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.dql-builder .panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.dql-builder .dirty-badge {
+  display: inline-block;
+  padding: 0.1rem 0.35rem;
+  border-radius: 999px;
+  background: rgba(217, 119, 6, 0.18);
+  color: var(--accent-hot);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dql-builder .btn-apply {
+  color: var(--accent) !important;
+  border-color: rgba(61, 214, 140, 0.45) !important;
+}
+
+.dql-builder .btn-apply:hover:not(:disabled) {
+  background: rgba(61, 214, 140, 0.12) !important;
+  border-color: var(--accent) !important;
+}
+
+.dql-builder .editor-hint {
+  margin: 0;
+  padding: 0.35rem 1rem 0.5rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(253, 214, 99, 0.1);
+  color: var(--accent-hot);
+  font-size: 0.72rem;
+  font-family: var(--sans);
+  flex-shrink: 0;
+}
+
+.dql-builder .editor-hint kbd {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  padding: 0.05rem 0.28rem;
+  border: 1px solid rgba(253, 214, 99, 0.35);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.dql-builder .query-panel .editor-host {
+  /* Leave room for the dirty hint without squeezing Variables too hard */
+  min-height: 0;
+}
+
+.dql-builder .editor-host.is-dirty {
+  box-shadow: inset 3px 0 0 var(--accent-hot);
+}
+
+.dql-builder .vars-label {
+  border-top: 1px solid var(--line);
+}
+
+.dql-builder .editor-host {
+  flex: 1;
+  min-height: 0;
+  background: var(--paper);
+}
+
+.dql-builder .editor-host.vars-host {
+  flex: 0 0 160px;
+}
+
+/* Canvas */
+.dql-builder .canvas-wrap {
+  min-height: 0;
+}
+
+.dql-builder .canvas {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  background:
+    linear-gradient(rgba(60, 64, 67, 0.45) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(60, 64, 67, 0.45) 1px, transparent 1px),
+    #1a1b1e;
+  background-size: 28px 28px;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.dql-builder .canvas-surface {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 3200px;
+  height: 2400px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.dql-builder .canvas.drag-over {
+  outline: 2px dashed var(--accent);
+  outline-offset: -8px;
+  background-color: #1c2a22;
+}
+
+.dql-builder .canvas-empty {
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  min-height: 12rem;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  text-align: center;
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+  pointer-events: none;
+}
+
+.dql-builder .canvas-empty.hidden {
+  display: none;
+}
+
+/* Entity picker in canvas header */
+.dql-builder .panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.dql-builder .entity-menu {
+  position: relative;
+}
+
+.dql-builder .btn-add-entity {
+  font-weight: 650;
+  color: var(--accent) !important;
+}
+
+.dql-builder .entity-menu-panel {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  z-index: 40;
+  width: min(280px, 70vw);
+  max-height: min(420px, 60vh);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: #292a2d;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.45);
+}
+
+.dql-builder .entity-menu-panel[hidden] {
+  display: none !important;
+}
+
+.dql-builder .entity-menu-list {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.dql-builder .entity-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  padding: 0.4rem 0.5rem;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: grab;
+  user-select: none;
+}
+
+.dql-builder .entity-menu-item:hover {
+  background: rgba(61, 214, 140, 0.1);
+  border-color: rgba(61, 214, 140, 0.35);
+}
+
+.dql-builder .entity-menu-item:active, .dql-builder .entity-menu-item.dragging {
+  cursor: grabbing;
+  opacity: 0.6;
+}
+
+.dql-builder .entity-menu-item .palette-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dql-builder .entity-menu-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dql-builder .entity-menu-hint {
+  color: var(--accent);
+  font-weight: 700;
+  opacity: 0.7;
+}
+
+/* ---------- Builder console (Chrome DevTools–inspired) ---------- */
+
+.dql-builder .builder-console {
+  --console-bg: #202124;
+  --console-bg-2: #292a2d;
+  --console-line: #3c4043;
+  --console-text: #e8eaed;
+  --console-muted: #9aa0a6;
+  --console-error: #f28b82;
+  --console-error-bg: #4c2220;
+  --console-warn: #fdd663;
+  --console-warn-bg: #4a3c16;
+  --console-info: #8ab4f8;
+  --console-link: #8ab4f8;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  height: 168px;
+  background: var(--console-bg);
+  border-top: 1px solid var(--console-line);
+  color: var(--console-text);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+}
+
+.dql-builder .console-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.3rem 0.5rem;
+  background: var(--console-bg-2);
+  border-bottom: 1px solid var(--console-line);
+  flex-shrink: 0;
+}
+
+.dql-builder .console-tool-btn {
+  display: grid;
+  place-items: center;
+  width: 1.55rem;
+  height: 1.55rem;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--console-muted);
+  cursor: pointer;
+  padding: 0;
+}
+
+.dql-builder .console-tool-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--console-text);
+}
+
+.dql-builder .console-clear-icon {
+  width: 0.85rem;
+  height: 0.85rem;
+  border: 1.5px solid currentColor;
+  border-radius: 50%;
+  position: relative;
+}
+
+.dql-builder .console-clear-icon::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: -1px;
+  bottom: -1px;
+  width: 1.5px;
+  background: currentColor;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.dql-builder .console-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex: 1;
+  min-width: 0;
+  height: 1.55rem;
+  padding: 0 0.45rem;
+  border: 1px solid var(--console-line);
+  border-radius: 4px;
+  background: #1a1b1e;
+}
+
+.dql-builder .console-filter-icon {
+  width: 0.7rem;
+  height: 0.7rem;
+  border: 1.5px solid var(--console-muted);
+  border-radius: 50%;
+  position: relative;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+.dql-builder .console-filter-icon::after {
+  content: "";
+  position: absolute;
+  width: 0.35rem;
+  height: 1.5px;
+  background: var(--console-muted);
+  right: -0.28rem;
+  bottom: -0.12rem;
+  transform: rotate(45deg);
+}
+
+.dql-builder .console-filter input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--console-text);
+  font-family: inherit;
+  font-size: inherit;
+  outline: none;
+}
+
+.dql-builder .console-filter input::placeholder {
+  color: var(--console-muted);
+}
+
+.dql-builder .console-level {
+  height: 1.55rem;
+  border: 1px solid var(--console-line);
+  border-radius: 4px;
+  background: #1a1b1e;
+  color: var(--console-text);
+  font-family: inherit;
+  font-size: inherit;
+  padding: 0 0.35rem;
+  outline: none;
+  cursor: pointer;
+}
+
+.dql-builder .console-counts {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-left: 0.25rem;
+  padding-left: 0.55rem;
+  border-left: 1px solid var(--console-line);
+}
+
+.dql-builder .console-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  color: var(--console-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.dql-builder .console-count.is-error .console-count-icon {
+  background: #e33;
+  color: #fff;
+}
+
+.dql-builder .console-count.is-warn .console-count-icon {
+  background: #f5c518;
+  color: #202124;
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  border-radius: 0;
+  font-size: 0.55rem;
+  line-height: 0.85rem;
+}
+
+.dql-builder .console-count-icon {
+  display: grid;
+  place-items: center;
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  font-size: 0.58rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.dql-builder .console-count.is-error .console-count-icon::before {
+  content: "×";
+}
+
+.dql-builder .console-count.is-warn .console-count-icon::before {
+  content: "!";
+}
+
+.dql-builder .console-output {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.dql-builder .console-empty {
+  padding: 0.65rem 0.75rem;
+  color: var(--console-muted);
+}
+
+.dql-builder .console-row {
+  display: grid;
+  grid-template-columns: 1.1rem 1fr auto;
+  gap: 0.45rem;
+  align-items: start;
+  padding: 0.28rem 0.65rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.dql-builder .console-row:hover {
+  filter: brightness(1.08);
+}
+
+.dql-builder .console-row.is-error {
+  background: var(--console-error-bg);
+  color: var(--console-error);
+}
+
+.dql-builder .console-row.is-warn {
+  background: var(--console-warn-bg);
+  color: var(--console-warn);
+}
+
+.dql-builder .console-row.is-info {
+  color: var(--console-text);
+}
+
+.dql-builder .console-row.is-info .console-row-icon {
+  color: var(--console-info);
+}
+
+.dql-builder .console-row-icon {
+  display: grid;
+  place-items: center;
+  width: 0.9rem;
+  height: 0.9rem;
+  margin-top: 0.12rem;
+  border-radius: 50%;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.dql-builder .console-row.is-error .console-row-icon {
+  background: #e33;
+  color: #fff;
+}
+
+.dql-builder .console-row.is-error .console-row-icon::before {
+  content: "×";
+}
+
+.dql-builder .console-row.is-warn .console-row-icon {
+  background: #f5c518;
+  color: #202124;
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  border-radius: 0;
+  font-size: 0.55rem;
+}
+
+.dql-builder .console-row.is-warn .console-row-icon::before {
+  content: "!";
+}
+
+.dql-builder .console-row.is-info .console-row-icon::before {
+  content: "i";
+  font-style: italic;
+  font-family: Georgia, serif;
+}
+
+.dql-builder .console-row-msg {
+  min-width: 0;
+}
+
+.dql-builder .console-row-source {
+  color: var(--console-link);
+  white-space: nowrap;
+  font-size: 0.68rem;
+  opacity: 0.9;
+}
+
+.dql-builder .console-row.is-hidden {
+  display: none;
+}
+
+/* Query blocks — fixed/resizable boxes; content scrolls inside */
+.dql-builder .entity-node {
+  position: absolute;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 420px;
+  min-width: 300px;
+  min-height: 240px;
+  max-width: 900px;
+  background: var(--node);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  z-index: 2;
+  animation: pop-in 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.2) both;
+}
+
+.dql-builder .entity-node.selected {
+  border-color: var(--accent);
+  box-shadow:
+    0 0 0 2px rgba(61, 214, 140, 0.25),
+    0 12px 30px rgba(0, 0, 0, 0.4);
+}
+
+.dql-builder .entity-node:focus-within {
+  z-index: 30;
+}
+
+.dql-builder .entity-node.resizing {
+  user-select: none;
+}
+
+.dql-builder body.is-resizing-node {
+  cursor: nwse-resize;
+  user-select: none;
+}
+
+.dql-builder .entity-node-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  padding-bottom: 0.35rem;
+}
+
+.dql-builder .entity-resize {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  height: 16px;
+  cursor: nwse-resize;
+  z-index: 6;
+  touch-action: none;
+}
+
+.dql-builder .entity-resize::before {
+  content: "";
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid rgba(154, 160, 166, 0.85);
+  border-bottom: 2px solid rgba(154, 160, 166, 0.85);
+  border-radius: 1px;
+}
+
+.dql-builder .entity-node.selected .entity-resize::before {
+  border-color: var(--accent);
+}
+
+.dql-builder .entity-node-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  padding: 0.65rem 0.65rem 0.55rem;
+  background: linear-gradient(180deg, #303134, #292a2d);
+  border-bottom: 1px solid var(--line);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+  flex-shrink: 0;
+}
+
+.dql-builder .entity-node-header:active, .dql-builder .entity-node.dragging .entity-node-header {
+  cursor: grabbing;
+}
+
+.dql-builder .entity-node.dragging {
+  opacity: 0.92;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.5);
+}
+
+.dql-builder body.is-dragging-node {
+  cursor: grabbing;
+  user-select: none;
+}
+
+.dql-builder .entity-node-header .dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-top: 0.45rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dql-builder .entity-node-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.dql-builder .entity-type-label {
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.dql-builder .query-name-input {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 0.2rem 0.35rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--ink);
+  outline: none;
+  cursor: text;
+}
+
+.dql-builder .query-name-input:hover {
+  border-color: var(--line);
+}
+
+.dql-builder .query-name-input:focus {
+  border-color: var(--accent);
+  background: var(--input-bg);
+  box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.dql-builder .result-name-input {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  padding: 0.12rem 0.35rem;
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  color: var(--ink-soft);
+  outline: none;
+  cursor: text;
+}
+
+.dql-builder .result-name-input::placeholder {
+  color: #5f6368;
+}
+
+.dql-builder .result-name-input:hover {
+  border-color: var(--line);
+}
+
+.dql-builder .result-name-input:focus {
+  border-color: var(--accent);
+  background: var(--input-bg);
+  color: var(--ink);
+  box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.dql-builder .entity-node-remove {
+  width: 1.5rem;
+  height: 1.5rem;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink-soft);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.dql-builder .entity-node-remove:hover {
+  background: rgba(242, 139, 130, 0.15);
+  color: var(--danger);
+}
+
+/* Parameters section */
+.dql-builder .block-section {
+  padding: 0.55rem 0.65rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(0, 0, 0, 0.18);
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.dql-builder .block-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.45rem;
+}
+
+.dql-builder .block-section-title {
+  font-size: 0.62rem;
+  font-weight: 650;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.dql-builder .block-section-head.no-margin {
+  margin-bottom: 0;
+}
+
+.dql-builder .directive-toggles {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.dql-builder .directive-toggle {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  font-weight: 500;
+  color: var(--ink-soft);
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.dql-builder .directive-toggle:hover {
+  border-color: var(--accent);
+  color: var(--ink);
+}
+
+.dql-builder .directive-toggle.active {
+  color: #0f1411;
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.dql-builder .btn-mini {
+  font-family: var(--sans);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--accent);
+  background: rgba(61, 214, 140, 0.1);
+  border: 1px solid rgba(61, 214, 140, 0.3);
+  border-radius: 5px;
+  padding: 0.18rem 0.45rem;
+  cursor: pointer;
+}
+
+.dql-builder .btn-mini:hover {
+  background: rgba(61, 214, 140, 0.2);
+}
+
+.dql-builder .param-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 0.4rem;
+  margin-bottom: 0.4rem;
+}
+
+.dql-builder .param-card:last-child {
+  margin-bottom: 0;
+}
+
+.dql-builder .param-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(3.5rem, 4.75rem) minmax(0, 1fr) auto 1.3rem;
+  gap: 0.3rem;
+  align-items: center;
+  min-width: 0;
+}
+
+.dql-builder .param-card input, .dql-builder .param-card select {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--input-bg);
+  padding: 0.25rem 0.3rem;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  color: var(--ink);
+  outline: none;
+}
+
+.dql-builder .param-card input:focus, .dql-builder .param-card select:focus {
+  border-color: var(--accent);
+}
+
+.dql-builder .param-remove {
+  border: none;
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-size: 0.95rem;
+  line-height: 1;
+  padding: 0;
+}
+
+.dql-builder .param-remove:hover {
+  color: var(--danger);
+}
+
+.dql-builder .param-empty, .dql-builder .filter-empty {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--ink-soft);
+}
+
+.dql-builder .filters-section {
+  border-top: 1px solid var(--line);
+}
+
+.dql-builder .filter-panel {
+  margin: 0.35rem 0.55rem 0.45rem;
+  padding: 0.4rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.18);
+  width: auto;
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.dql-builder .filter-panel.is-edge {
+  margin: 0.15rem 0.55rem 0.35rem 1.1rem;
+  border-color: rgba(61, 214, 140, 0.25);
+  background: rgba(61, 214, 140, 0.06);
+}
+
+.dql-builder .filter-panel-head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.35rem;
+}
+
+.dql-builder .filter-panel-label {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--accent-hot);
+}
+
+.dql-builder .filter-op-toggle {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  overflow: hidden;
+  margin-left: 0.15rem;
+}
+
+.dql-builder .filter-op-btn {
+  border: none;
+  background: transparent;
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+  padding: 0.12rem 0.45rem;
+  cursor: pointer;
+}
+
+.dql-builder .filter-op-btn.active {
+  background: rgba(61, 214, 140, 0.25);
+  color: var(--accent);
+}
+
+.dql-builder .filter-panel-head .add-filter {
+  margin-left: auto;
+}
+
+.dql-builder .filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+  margin-top: 0.35rem;
+}
+
+.dql-builder .filter-row select, .dql-builder .filter-row input {
+  width: auto;
+  min-width: 0;
+  max-width: 100%;
+  flex: 1 1 5rem;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--input-bg);
+  padding: 0.22rem 0.35rem;
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  color: var(--ink);
+  outline: none;
+}
+
+.dql-builder .filter-row .filter-func {
+  flex: 0 1 5.5rem;
+  min-width: 4.5rem;
+}
+
+.dql-builder .filter-row .filter-predicate {
+  flex: 1 1 8rem;
+  min-width: 5rem;
+}
+
+.dql-builder .filter-row .filter-value-mode {
+  flex: 0 1 5rem;
+  min-width: 4rem;
+}
+
+.dql-builder .filter-row .filter-literal, .dql-builder .filter-row .filter-param {
+  flex: 1 1 5.5rem;
+  min-width: 4rem;
+}
+
+.dql-builder .filter-row select:focus, .dql-builder .filter-row input:focus {
+  border-color: var(--accent);
+}
+
+.dql-builder .filter-value-blank {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  color: var(--ink-soft);
+  padding: 0 0.25rem;
+}
+
+.dql-builder .filter-remove {
+  border: none;
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-size: 0.95rem;
+  line-height: 1;
+  padding: 0.1rem 0.2rem;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.dql-builder .filter-remove:hover {
+  color: var(--danger);
+}
+
+/* Field tree — contained rows; types/aliases stay inside the card */
+.dql-builder .entity-fields, .dql-builder .nested-fields {
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem 0.65rem 0.9rem 0.5rem;
+}
+
+.dql-builder .entity-fields {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.dql-builder .nested-fields {
+  margin: 0.1rem 0 0.3rem 0.35rem;
+  padding: 0.15rem 0 0.05rem 0.35rem;
+  border-left: 1px solid rgba(61, 214, 140, 0.28);
+  background: transparent;
+  border-radius: 0;
+  width: auto;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.dql-builder .entity-fields li, .dql-builder .nested-fields li {
+  margin: 0;
+  min-width: 0;
+}
+
+.dql-builder .field-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(3.5rem, 5.25rem);
+  align-items: center;
+  column-gap: 0.5rem;
+  padding: 0.28rem 0.45rem;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  transition: background 0.12s ease;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  min-width: 0;
+}
+
+.dql-builder .field-row:hover {
+  background: rgba(61, 214, 140, 0.1);
+}
+
+.dql-builder .field-check {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+  cursor: pointer;
+  padding: 0.1rem 0;
+}
+
+.dql-builder .field-check input {
+  accent-color: var(--accent);
+  width: 0.95rem;
+  height: 0.95rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.dql-builder .alias-input {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 0.15rem 0.3rem;
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  color: var(--accent-hot);
+  outline: none;
+}
+
+.dql-builder .alias-input::placeholder {
+  color: #5f6368;
+}
+
+.dql-builder .alias-input:hover {
+  border-color: var(--line);
+}
+
+.dql-builder .alias-input:focus {
+  border-color: var(--accent);
+  background: var(--input-bg);
+  box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.dql-builder .field-name {
+  font-family: var(--mono);
+  font-size: 0.76rem;
+  font-weight: 500;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dql-builder .field-type {
+  justify-self: end;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+  font-size: 0.66rem;
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  padding-right: 0.15rem;
+}
+
+.dql-builder .field-row.is-object .field-type {
+  color: var(--accent-hot);
+}
+
+@keyframes fade-down {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: none; }
+}
+
+@keyframes fade-up {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: none; }
+}
+
+@keyframes pop-in {
+  from { opacity: 0; transform: scale(0.92); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@media (max-width: 960px) {
+  .dql-builder {
+    overflow: auto;
+  }
+
+  .dql-builder .app {
+    height: auto;
+  }
+
+  .dql-builder .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dql-builder .tagline {
+    text-align: left;
+  }
+
+  .dql-builder .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .dql-builder .editor-host {
+    min-height: 240px;
+  }
+
+  .dql-builder .canvas {
+    min-height: 480px;
+  }
+}

--- a/client/src/components/QueryVarsEditor/index.js
+++ b/client/src/components/QueryVarsEditor/index.js
@@ -112,13 +112,12 @@ export default function QueryVarsEditor() {
         onClick={() => {
           if (newVars.length) {
             smartSpawnVars()
+          } else if (!query.trim() && !haveQueryVarsInHistory(frameItems)) {
+            // First-time empty console only — never overwrite an existing query.
+            spawnVar(DEMO_VAR)
+            dispatch(updateQuery(DEMO_QUERY))
           } else {
-            if (!haveQueryVarsInHistory(frameItems)) {
-              spawnVar(DEMO_VAR)
-              dispatch(updateQuery(DEMO_QUERY))
-            } else {
-              spawnVar(`var: ${queryVars.length + 1}`)
-            }
+            spawnVar(`var: ${queryVars.length + 1}`)
           }
         }}
       >

--- a/client/src/components/QueryView/QueryView.scss
+++ b/client/src/components/QueryView/QueryView.scss
@@ -37,6 +37,18 @@
           height: calc(100vh - 170px);
         }
 
+        .editor-panel.editor-panel-builder {
+          height: calc(100vh - 120px);
+          min-height: 560px;
+          display: flex;
+          flex-direction: column;
+
+          .builder-console-layout {
+            flex: 1;
+            min-height: 0;
+          }
+        }
+
         .frame-list-outer {
           text-align: center;
           padding: 0 2px;


### PR DESCRIPTION
**Description**

Adds a **Builder** mode to the Console (alongside Query / Mutate) for visually constructing DQL from the connected Alpha’s types.

- Schema loads automatically from the live database via `schema { }` (no separate “Load schema” UI).
- Canvas builds DQL into Ratel’s existing CodeMirror editor and Variables panel; hand-edits debounce back onto the canvas.
- **Run** / **Clear** use the normal Console chrome; results show in the existing right-hand pane.
- Builder UI is styled to match Ratel’s light theme.
- Fixes Webpack 5 `process/browser` resolution so newer `react-draggable` builds compile.
- Stops the Variables button from replacing a non-empty query with the demo Star Wars template.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/ratel/pr/428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788107888&installation_model_id=8575&pr_number=428&repository=dgraph-io%2Fratel&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fratel%2Fpull%2F428&signature=f42f9f5603d892c1a2e6e650127695f5ef2d07510bfdfb46671887c1961fc2e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->